### PR TITLE
feat: data-driven All Martial + mystic-type boost coverage for DoTs

### DIFF
--- a/docs/CALCULATION.md
+++ b/docs/CALCULATION.md
@@ -186,7 +186,7 @@ that — treat them as opaque names, not as a claim about any live data source.
 | **BU + 4 per-attribute blocks** | Bellstrike / Stonesplit / Silkbind / Bamboocut tracks | each: `small = block.min + (BU=attr ∧ weapon ? attributePrimaryBonus : 0)` ; `mult = (BU=attr ∧ ¬dotRules) ? O : N` ; `dmgBoost = (BU=attr ? attributeDmgBoostPanel : 0) + (set=Swallowcall ∧ lowQi ? 0.1 : 0)` ; `setMul = 1 + (lowQi ? setBonus.col8 : 0)` |
 | **DZ / EB / ED / EF** | graze / crit / affinity / normal totals | sum of phys + phys-fixed + attr-fixed + the 4 attribute blocks |
 | **EH** | weighted total | `DZ×AL + EB×AN + ED×AP + EF×AR` |
-| **T** | weapon + mystic-type boost | `(weaponBoosts[art.weaponOrAttribute] + allMartialBoost)` when the weapon resolves, `+ mysticTypeBoosts[art.mysticCategory]`. A DoT tick inherits its category from its debuff's `dot.mysticCategory`, so mystic DoTs are boosted too — the in-game stat text explicitly covers "damage over time". Boss damage lives in `generalDamageBoost`, not here. |
+| **T** | weapon + mystic-type boost | `(weaponBoosts[art.weaponOrAttribute] + allMartialBoost)` when the weapon resolves, `+ mysticTypeBoosts[art.mysticCategory]`. A DoT tick resolves both typings like any skill: from its display stand-in's `weaponOrAttribute` / `mystic:*` tag when one exists, else from the debuff's `dot.weaponOrAttribute` / `dot.mysticCategory` — so Sword-typed DoTs (bleed) take weapon + all-martial, and mystic DoTs take their category stat; the in-game stat text explicitly covers "damage over time". Boss damage lives in `generalDamageBoost`, not here. |
 | **H** | total boost | `generalDamageBoost + allDamageBoost + T + yiShui×0.01 + qiExhausted × fatigueDamageTaken + Σslot.col2 + (usesChargeBoost ? chargeBonus : 0) + art.extraDamageBoost + (sustain ? sustainDmgBoostPanel + dotDamageBoost : 0)` |
 | **I** | correction multiplier | `art.correction || 1` |
 | **F** | final per-hit damage | `(guaranteedNormal ? EF : guaranteedCrit ? EB : EH) × (1 + H) × count × I × (1 + E) × dotMult` — `guaranteedNormal` is the fixed-damage flag (no crit/affinity/abrasion, e.g. Dragon Head) |
@@ -337,11 +337,11 @@ divergences (Implemented), and known gaps, which contribute 0 unless noted
   stack-doubling depends on the same window. `dragonsBreath` has no confirmed
   teammate-facing value — the extracted `dragonBreath` def is the caster's own
   Combustion mechanic, not a teammate buff — so it is stored but contributes 0.
-- **Bellstrike Umbra bleed vs all-martial** — column `T` unconditionally folds
-  `allMartialBoost` into any weapon match, but all-martial must never reach a
-  bleed *effect*, so `timeline.ts` neutralizes just that portion for Bleed
-  Detonation via an offsetting stat-effect, leaving the sword contribution
-  intact.
+- **Bellstrike Umbra bleed is Sword-typed** — bleed ticks and Bleed Detonation
+  carry `weaponOrAttribute: "Sword"` (on the stand-in skill / detonation skill
+  and as `dot.weaponOrAttribute` fallback on the debuff), so column `T` gives
+  them sword boost *and* all-martial like any Sword skill, per the lvl-110
+  workbook's skill-type column.
 
 ### Gaps
 

--- a/src/data/skills/debuffsLibrary.json
+++ b/src/data/skills/debuffsLibrary.json
@@ -87,6 +87,7 @@
         "attributeFixed": 0,
         "attributeAttack": "Bellstrike",
         "skillType": "sustain",
+        "weaponOrAttribute": "Sword",
         "count": 1,
         "perStackShapes": null
       },
@@ -209,6 +210,7 @@
         "attributeFixed": 0,
         "attributeAttack": "Bellstrike",
         "skillType": "sustain",
+        "weaponOrAttribute": "Sword",
         "count": 1,
         "perStackShapes": null,
         "perStackMultipliers": [2, 2.5, 3, 4, 5]

--- a/src/data/skills/universal/drunkenpoet-prepull.json
+++ b/src/data/skills/universal/drunkenpoet-prepull.json
@@ -2,8 +2,8 @@
   "id": "universal-drunkenpoet-prepull",
   "classId": "universal",
   "name": "DrunkenPoet Prepull",
-  "tags": [],
-  "skillType": "weapon",
+  "tags": ["mystic:burst"],
+  "skillType": "mystic",
   "weaponOrAttribute": "",
   "attributeAttack": "",
   "hits": [

--- a/src/engine/buffs/catalog.ts
+++ b/src/engine/buffs/catalog.ts
@@ -1,5 +1,18 @@
 import { catalogBuffDefs, dedupedMechanicBuffDefs, dedupedMechanicBuffDefsForClass } from "./data"
-import { anyTagStartsWith, castTagOf, hasAnyWeapon, hasProp, skillTagsOf } from "./tags"
+import {
+  anyTagStartsWith,
+  castTagOf,
+  hasAnyWeapon,
+  hasProp,
+  mysticCategoryOf,
+  skillTagsOf,
+} from "./tags"
+import {
+  MYSTIC_TYPE_BOOST_STAT_KEY,
+  STAT_DEF_BY_KEY,
+  WEAPON_BOOST_STAT_KEY,
+  type StatKey,
+} from "../statRegistry"
 import type { BuffDef, BuffBonus, BuffStatMods } from "./buffDef"
 import type { Skill } from "../skill"
 import type { Debuff } from "../debuff"
@@ -148,6 +161,20 @@ export interface ReceivesRow {
   triggeredBy: string | null
 }
 
+function gearStatRow(key: StatKey, affects: string, inputs?: Inputs): ReceivesRow {
+  const label = STAT_DEF_BY_KEY[key]?.label ?? key
+  const value = inputs ? ((inputs as unknown as Record<string, number>)[key] ?? 0) : null
+  return {
+    id: `stat:${key}`,
+    name: `${label} (${affects})`,
+    effect: value !== null ? `+${(value * 100).toFixed(1)}% damage` : "panel stat",
+    requires: null,
+    isSpecMechanic: false,
+    active: true,
+    triggeredBy: null,
+  }
+}
+
 export function receivesForSkill(skill: Skill, classId?: string, inputs?: Inputs): ReceivesRow[] {
   const tagSet = skillTagsOf(skill)
   const specIds = specMechanicDefIds(classId)
@@ -197,6 +224,17 @@ export function receivesForSkill(skill: Skill, classId?: string, inputs?: Inputs
             : true,
       triggeredBy: triggeredByNote(def, defsById),
     })
+  }
+
+  const weaponBoostKey = WEAPON_BOOST_STAT_KEY[skill.weaponOrAttribute ?? ""]
+  if (weaponBoostKey) {
+    rows.push(gearStatRow(weaponBoostKey, `${skill.weaponOrAttribute} skills`, inputs))
+    rows.push(gearStatRow("allMartialBoost", "all weapon-typed skills", inputs))
+  }
+  const mysticCategory = mysticCategoryOf(skill)
+  const mysticBoostKey = MYSTIC_TYPE_BOOST_STAT_KEY[mysticCategory]
+  if (mysticBoostKey) {
+    rows.push(gearStatRow(mysticBoostKey, `mystic: ${mysticCategory}`, inputs))
   }
 
   if (classId) {

--- a/src/engine/debuff.ts
+++ b/src/engine/debuff.ts
@@ -16,6 +16,7 @@ export interface DebuffDotSpec {
   attributeFixed: number
   attributeAttack: AttributeKey | ""
   skillType: string
+  weaponOrAttribute?: string | null
   mysticCategory?: string | null
   count: number
   perStackShapes?: DotStackShape[] | null

--- a/src/engine/itemRanking.ts
+++ b/src/engine/itemRanking.ts
@@ -123,7 +123,6 @@ function buildWordSpecs(inputs: Inputs): WordSpec[] {
           x.affinityRate += 0.044
         }),
     },
-    // All Martial max roll: 3.2 % (in-game, 2026-08-06).
     {
       word: "All Martial Boost",
       amount: 0.032,

--- a/src/engine/itemRanking.ts
+++ b/src/engine/itemRanking.ts
@@ -2,6 +2,7 @@ import type { Inputs, ItemRankingRow } from "./types"
 import type { Skill } from "./skill"
 import { runEngine } from "./dps"
 import { getSchool } from "./panel"
+import { WEAPON_BOOST_STAT_KEY } from "./statRegistry"
 import { getAttunement } from "./attunements"
 import { builtinSkillsForClass, defaultRotationForClass } from "./builtinLibrary"
 import { resolveRotation } from "./rotation"
@@ -122,13 +123,14 @@ function buildWordSpecs(inputs: Inputs): WordSpec[] {
           x.affinityRate += 0.044
         }),
     },
+    // All Martial max roll: 3.2 % (in-game, 2026-08-06).
     {
       word: "All Martial Boost",
-      amount: 0.036,
+      amount: 0.032,
       unit: "percent",
       apply: (i) =>
         clone(i, (x) => {
-          x.allMartialBoost += 0.036
+          x.allMartialBoost += 0.032
         }),
     },
   ]
@@ -303,20 +305,10 @@ function buildWordSpecs(inputs: Inputs): WordSpec[] {
 
 function applyWeaponBoost(weapon: string, amt: number) {
   return (i: Inputs) => {
-    const map: Record<string, keyof Inputs> = {
-      Sword: "swordBoost",
-      Spear: "spearBoost",
-      Fan: "fanBoost",
-      Umbrella: "umbrellaBoost",
-      Modao: "modaoBoost",
-      "Twin Blades": "dualKnivesBoost",
-      "Rope Dart": "ropeDartBoost",
-      Hengdao: "hengDaoBoost",
-    }
-    const key = map[weapon]
+    const key = WEAPON_BOOST_STAT_KEY[weapon]
     if (!key) return
     const target = i as unknown as Record<string, number>
-    target[key as string] = (target[key as string] ?? 0) + amt
+    target[key] = (target[key] ?? 0) + amt
   }
 }
 

--- a/src/engine/statRegistry.ts
+++ b/src/engine/statRegistry.ts
@@ -353,6 +353,24 @@ export const STAT_DEF_BY_KEY: Readonly<Record<string, StatDef>> = Object.fromEnt
 export const PLAYER_STAT_DEFS: readonly StatDef[] = STAT_DEFS.filter((d) => d.scope === "player")
 export const TARGET_STAT_DEFS: readonly StatDef[] = STAT_DEFS.filter((d) => d.scope === "target")
 
+export const WEAPON_BOOST_STAT_KEY: Readonly<Record<string, StatKey>> = {
+  Sword: "swordBoost",
+  Spear: "spearBoost",
+  Fan: "fanBoost",
+  Umbrella: "umbrellaBoost",
+  Modao: "modaoBoost",
+  "Twin Blades": "dualKnivesBoost",
+  "Rope Dart": "ropeDartBoost",
+  Hengdao: "hengDaoBoost",
+}
+
+export const MYSTIC_TYPE_BOOST_STAT_KEY: Readonly<Record<string, StatKey>> = {
+  control: "singleMysticBoost",
+  burst: "singleMysticBoost",
+  "area-debuff": "groupAnomalyBoost",
+  "area-damage": "groupDamageBoost",
+}
+
 const ATTACK_BLOCKS = new Set(["phys", "bellstrike", "stonesplit", "silkbind", "bamboocut"])
 
 const TARGET_DELTA_FIELD: Record<string, keyof TargetOverride> = {

--- a/src/engine/timeline.ts
+++ b/src/engine/timeline.ts
@@ -27,7 +27,7 @@ import { builtinBuffsForClass, ZENITH_BAR_BUFF_ID, ZENITH_DETONATION_BUFF_ID } f
 import { BuffEngine } from "./buffs/buffEngine"
 import { buffDefsForClass, groupBuffDefs, mechanicBuffDefsForClass } from "./buffs/data"
 import { paramsFromInputs } from "./buffs/params"
-import { castTagOf, WEAPON_TAG } from "./buffs/tags"
+import { castTagOf, mysticCategoryOf, WEAPON_TAG } from "./buffs/tags"
 import { CrosswindTracker } from "./buffs/crosswind"
 import { classGrantsMinPhysCritBoost } from "./buffs/critBoostWeapons"
 import {
@@ -458,10 +458,6 @@ export function simulateTimeline(inputs: Inputs): Result {
     }
     if (buffEngine && inputs.classId === "bellstrikeUmbra") {
       if (skill) {
-        if (skill.name === "Bleed Detonation" && inputs.allMartialBoost) {
-          effects.push({ statKey: "allMartialBoost", amount: -inputs.allMartialBoost })
-          sig += "~noMartialOnDetonation"
-        }
         if (BLEED_ATTUNEMENT_SKILLS.has(skill.name)) {
           const levelBonus = playerLevelAttributeAttackBonus(APP_PLAYER_LEVEL)
           if (levelBonus !== 0) {
@@ -862,6 +858,8 @@ export function simulateTimeline(inputs: Inputs): Result {
           attributeFixed: srcHit.attributeFixed,
           attributeAttack: (tickSkill!.attributeAttack ||
             baseDot.attributeAttack) as DebuffDotSpec["attributeAttack"],
+          weaponOrAttribute: tickSkill!.weaponOrAttribute || null,
+          mysticCategory: mysticCategoryOf(tickSkill!) || null,
         }
       : baseDot
     const debuffForTick: Debuff = srcHit ? { ...debuffDef, dot } : debuffDef
@@ -1043,6 +1041,7 @@ function dotTickDamage(debuff: Debuff, ctx: Ctx, forceCrit = false, correction =
     elevatedAttributeMultiplier: false,
     guaranteedCrit: forceCrit ? 1 : undefined,
     correction,
+    weaponOrAttribute: dot.weaponOrAttribute || undefined,
     mysticCategory: dot.mysticCategory || undefined,
   } as Parameters<typeof computeSkillDamage>[0]
   return computeSkillDamage(art, padSlots([]), ctx, Math.max(1, dot.count)).expectedDamage
@@ -1069,6 +1068,7 @@ function dotTickDamageForShape(
     elevatedAttributeMultiplier: false,
     guaranteedCrit: forceCrit ? 1 : undefined,
     correction,
+    weaponOrAttribute: dot.weaponOrAttribute || undefined,
     mysticCategory: dot.mysticCategory || undefined,
   } as Parameters<typeof computeSkillDamage>[0]
   return computeSkillDamage(art, padSlots([]), ctx, Math.max(1, dot.count)).expectedDamage

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -895,6 +895,10 @@ function migrateStatusStoresIfNeeded(): void {
               attributeFixed: typeof rawDot.attributeFixed === "number" ? rawDot.attributeFixed : 0,
               attributeAttack: (rawDot.attributeAttack ?? "") as DebuffDotSpec["attributeAttack"],
               skillType: typeof rawDot.skillType === "string" ? rawDot.skillType : "sustain",
+              weaponOrAttribute:
+                typeof rawDot.weaponOrAttribute === "string" ? rawDot.weaponOrAttribute : null,
+              mysticCategory:
+                typeof rawDot.mysticCategory === "string" ? rawDot.mysticCategory : null,
               count: typeof rawDot.count === "number" ? rawDot.count : 1,
               perStackShapes: sanitizePerStackShapes(rawDot.perStackShapes),
               perStackMultipliers: sanitizePerStackMultipliers(rawDot.perStackMultipliers),
@@ -1122,6 +1126,8 @@ export function importCustomDebuff(text: string, targetClassId: string): Debuff 
         attributeFixed: typeof rawDot.attributeFixed === "number" ? rawDot.attributeFixed : 0,
         attributeAttack: (rawDot.attributeAttack ?? "") as DebuffDotSpec["attributeAttack"],
         skillType: typeof rawDot.skillType === "string" ? rawDot.skillType : "sustain",
+        weaponOrAttribute:
+          typeof rawDot.weaponOrAttribute === "string" ? rawDot.weaponOrAttribute : null,
         mysticCategory: typeof rawDot.mysticCategory === "string" ? rawDot.mysticCategory : null,
         count: typeof rawDot.count === "number" ? rawDot.count : 1,
         perStackShapes: sanitizePerStackShapes(rawDot.perStackShapes),

--- a/tests/engine/bellstrikeUmbraParity.test.ts
+++ b/tests/engine/bellstrikeUmbraParity.test.ts
@@ -137,17 +137,20 @@ describe("Bellstrike Umbra (bellstrikeUmbra) — T6-Bili parity vs the reference
     // Intentionally loose, re-centered bands (see the file header) — not the
     // site's cached target. Re-center as further mechanics land; do not
     // widen a band to paper over a regression.
-    expect(result.dps).toBeGreaterThan(47760)
-    expect(result.dps).toBeLessThan(47930)
-    expect(result.totalDamage).toBeGreaterThan(2898000)
-    expect(result.totalDamage).toBeLessThan(2911000)
-    expect(detonation?.expectedDamage).toBeGreaterThan(1560000)
-    expect(detonation?.expectedDamage).toBeLessThan(1572000)
+    expect(result.dps).toBeGreaterThan(48490)
+    expect(result.dps).toBeLessThan(48660)
+    expect(result.totalDamage).toBeGreaterThan(2942000)
+    expect(result.totalDamage).toBeLessThan(2956000)
+    expect(detonation?.expectedDamage).toBeGreaterThan(1592000)
+    expect(detonation?.expectedDamage).toBeLessThan(1606000)
 
-    expect(result.dps / SITE_TARGET_DPS).toBeGreaterThan(0.985)
-    expect(result.dps / SITE_TARGET_DPS).toBeLessThan(1.005)
-    expect(result.totalDamage / SITE_TARGET_TOTAL).toBeGreaterThan(0.985)
-    expect(result.totalDamage / SITE_TARGET_TOTAL).toBeLessThan(1.005)
-    expect(detonation?.expectedDamage ?? 0).toBeLessThan(SITE_TARGET_DETONATION)
+    // The engine sits ~0.4 % ABOVE the cached target: bleed ticks and Bleed
+    // Detonation take all-martial (and ticks sword boost) per the lvl-110
+    // workbook's Sword typing, which the cached run predates.
+    expect(result.dps / SITE_TARGET_DPS).toBeGreaterThan(0.999)
+    expect(result.dps / SITE_TARGET_DPS).toBeLessThan(1.009)
+    expect(result.totalDamage / SITE_TARGET_TOTAL).toBeGreaterThan(0.999)
+    expect(result.totalDamage / SITE_TARGET_TOTAL).toBeLessThan(1.009)
+    expect((detonation?.expectedDamage ?? 0) / SITE_TARGET_DETONATION).toBeLessThan(1.018)
   })
 })

--- a/tests/engine/bleedTickSkillSource.test.ts
+++ b/tests/engine/bleedTickSkillSource.test.ts
@@ -53,6 +53,8 @@ describe("Bleed Tick sources its per-tick damage from the skill", () => {
     expect(hit.attributeFixed).toBe(debuff.dot!.attributeFixed)
     expect(skill.attributeAttack).toBe(debuff.dot!.attributeAttack)
     expect(skill.attributeAttack).toBe("Bellstrike")
+    expect(skill.weaponOrAttribute).toBe(debuff.dot!.weaponOrAttribute)
+    expect(skill.weaponOrAttribute).toBe("Sword")
     expect(hit.physMultiplier).toBe(0.06864)
     expect(hit.attributeMultiplier).toBe(0.10296)
   })

--- a/tests/engine/catalogReceives.test.ts
+++ b/tests/engine/catalogReceives.test.ts
@@ -90,3 +90,31 @@ describe("catalog receives — Mirage Bonus surfaces its cast condition", () => 
     expect(row!.triggeredBy).toMatch(/Mirage/)
   })
 })
+
+describe("catalog receives — gear-stat boost rows follow the skill's typing", () => {
+  const inputs: Inputs = {
+    ...defaultInputs,
+    classId: CLASS,
+    swordBoost: 0.05,
+    allMartialBoost: 0.03,
+  }
+
+  it("Bleed Tick and Bleed Detonation list Sword Martial Boost and All Martial Boost", () => {
+    for (const name of ["Bleed Tick", "Bleed Detonation"]) {
+      const rows = receivesForSkill(findSkill(name), CLASS, inputs)
+      const sword = rows.find((r) => r.id === "stat:swordBoost")
+      const allMartial = rows.find((r) => r.id === "stat:allMartialBoost")
+      expect(sword, `${name} should list swordBoost`).toBeTruthy()
+      expect(sword!.effect).toBe("+5.0% damage")
+      expect(allMartial, `${name} should list allMartialBoost`).toBeTruthy()
+      expect(allMartial!.effect).toBe("+3.0% damage")
+    }
+  })
+
+  it("a burst-mystic cast lists the single-target mystic stat and no weapon stats", () => {
+    const rows = receivesForSkill(findSkill("Dragon's Breath 1 Hit"), CLASS, inputs)
+    expect(rows.some((r) => r.id === "stat:singleMysticBoost")).toBe(true)
+    expect(rows.some((r) => r.id === "stat:allMartialBoost")).toBe(false)
+    expect(rows.some((r) => r.id === "stat:swordBoost")).toBe(false)
+  })
+})

--- a/tests/engine/itemRanking.test.ts
+++ b/tests/engine/itemRanking.test.ts
@@ -63,7 +63,10 @@ describe("computeRanking — top-rank consistency", () => {
   it("Physical Penetration ranks in the top 10", () =>
     expect(top10.has("Physical Penetration")).toBe(true))
   it("Max Phys ranks in the top 10", () => expect(top10.has("Max Phys")).toBe(true))
-  it("Power ranks in the top 10", () => expect(top10.has("Power")).toBe(true))
+  it("Sword Martial Boost ranks in the top 10", () =>
+    expect(top10.has("Sword Martial Boost")).toBe(true))
+  it("All Martial Boost ranks in the top 10", () =>
+    expect(top10.has("All Martial Boost")).toBe(true))
 })
 
 // `WordSpec.amount` and the `apply` delta must stay in lockstep, since

--- a/tests/engine/martialBoostCoverage.test.ts
+++ b/tests/engine/martialBoostCoverage.test.ts
@@ -1,0 +1,87 @@
+// Bleed ticks and Bleed Detonation are Sword-typed (lvl-110 workbook
+// skill-type column), so they take swordBoost AND allMartialBoost like any
+// Sword skill; mystic skills and their DoTs take neither. Guards the
+// data-driven typing against a reintroduced per-skill exclusion.
+import { describe, expect, it } from "vitest"
+import { simulateTimeline } from "../../src/engine/timeline"
+import { defaultInputs } from "../../src/engine/defaults"
+import { builtinSkillsForClass } from "../../src/engine/builtinLibrary"
+import { makeRotation, makeStep } from "../../src/engine/rotation"
+import type { Inputs } from "../../src/engine/types"
+
+function rotationOf(skillNames: string[]) {
+  const skills = builtinSkillsForClass("bellstrikeUmbra")
+  const steps = skillNames.map((name) => {
+    const skill = skills.find((s) => s.name === name)
+    if (!skill) throw new Error(`no built-in skill "${name}" for bellstrikeUmbra`)
+    return makeStep({ skillId: skill.id, hitCount: skill.hits.length })
+  })
+  return makeRotation("bellstrikeUmbra", { name: `test-${skillNames.join("+")}`, steps })
+}
+
+function simulate(skillNames: string[], overrides: Partial<Inputs> = {}) {
+  return simulateTimeline({
+    ...defaultInputs,
+    classId: "bellstrikeUmbra",
+    activeCustomRotation: rotationOf(skillNames),
+    ...overrides,
+  })
+}
+
+function damageOf(result: ReturnType<typeof simulateTimeline>, name: string): number {
+  return result.perSkill
+    .filter((p) => p.name === name)
+    .reduce((sum, p) => sum + p.expectedDamage, 0)
+}
+
+// 6 hits of the canDetonate 3-hit skill ⇒ bleed ticks plus exactly one
+// detonation (see bleedDetonation.test.ts).
+const BLEED_ROTATION = ["SwordSpecial 3-Hit", "SwordSpecial 3-Hit"]
+const BURST_ROTATION = ["Dragon's Breath 1 Hit", "Poet1", "Poet2"]
+
+describe("all-martial and sword boost reach every Sword-typed row", () => {
+  const base = simulate(BLEED_ROTATION)
+
+  it("allMartialBoost raises Bleed Tick ticks and Bleed Detonation", () => {
+    const boosted = simulate(BLEED_ROTATION, { allMartialBoost: 0.1 })
+    expect(damageOf(base, "Bleed Tick (DoT)")).toBeGreaterThan(0)
+    expect(damageOf(boosted, "Bleed Tick (DoT)")).toBeGreaterThan(
+      damageOf(base, "Bleed Tick (DoT)"),
+    )
+    expect(damageOf(base, "Bleed Detonation")).toBeGreaterThan(0)
+    expect(damageOf(boosted, "Bleed Detonation")).toBeGreaterThan(
+      damageOf(base, "Bleed Detonation"),
+    )
+  })
+
+  it("swordBoost raises Bleed Tick ticks and Bleed Detonation", () => {
+    const boosted = simulate(BLEED_ROTATION, { swordBoost: 0.1 })
+    expect(damageOf(boosted, "Bleed Tick (DoT)")).toBeGreaterThan(
+      damageOf(base, "Bleed Tick (DoT)"),
+    )
+    expect(damageOf(boosted, "Bleed Detonation")).toBeGreaterThan(
+      damageOf(base, "Bleed Detonation"),
+    )
+  })
+
+  it("per point, allMartialBoost and swordBoost are identical on an all-Sword rotation", () => {
+    const viaAllMartial = simulate(BLEED_ROTATION, { allMartialBoost: 0.05 })
+    const viaSword = simulate(BLEED_ROTATION, { swordBoost: 0.05 })
+    expect(viaAllMartial.totalDamage).toBeCloseTo(viaSword.totalDamage, 6)
+  })
+})
+
+describe("mystic skills and their DoTs take neither weapon boost", () => {
+  it("allMartialBoost and swordBoost leave a burst-mystic rotation (incl. Combustion DoT) untouched", () => {
+    const base = simulate(BURST_ROTATION)
+    const boosted = simulate(BURST_ROTATION, { allMartialBoost: 0.1, swordBoost: 0.1 })
+    expect(damageOf(base, "Combustion (DoT)")).toBeGreaterThan(0)
+    expect(boosted.totalDamage).toBe(base.totalDamage)
+  })
+
+  it("singleMysticBoost leaves the bleed rotation untouched", () => {
+    const base = simulate(BLEED_ROTATION)
+    const boosted = simulate(BLEED_ROTATION, { singleMysticBoost: 0.1 })
+    expect(boosted.totalDamage).toBe(base.totalDamage)
+  })
+})

--- a/tests/migrations/profileV5.test.ts
+++ b/tests/migrations/profileV5.test.ts
@@ -177,7 +177,7 @@ describe("v5 profile → v6 dropped-stats scheme", () => {
     const withStats = pipelineDps(rawInputs)
     const zeroed = pipelineDps(withZeroedDerivedStats(rawInputs))
     expect(findDivergences(zeroed, withStats)).toEqual([])
-    expect(zeroed.dps).toBe(withStats.dps)
+    expect(zeroed.dps).toBeCloseTo(withStats.dps, 6)
   })
 
   it("the loaded profile still computes positive DPS", () => {


### PR DESCRIPTION
Bleed ticks and Bleed Detonation are Sword-typed per the lvl-110 workbook, so they take sword boost and All Martial like any Sword skill. DoT ticks resolve their boost typing from the display stand-in skill (weaponOrAttribute / mystic tag) with dot.weaponOrAttribute as the debuff-level fallback; the hardcoded all-martial neutralization on Bleed Detonation is removed.

Also: Receives panel lists the gear-stat boosts a skill responds to, All Martial max roll corrected to 3.2%, DrunkenPoet Prepull tagged mystic:burst, parity bands re-centered (~0.4% above the cached target).

No migration needed: profiles never embed skills/debuffs, saved stand-in copies already carry the Sword typing, and the new dot field is additive.