### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-winds-meet-dps",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary
- Bump `package.json` version from 0.1.6 to 0.1.7, covering the data-driven All Martial + mystic-type boost coverage for DoTs (#5) merged since the last release bump.

No migration needed: the version number is not read by the app or stored in saved profiles.