### PR TITLE
feat: add Bitter Season inner way with probabilistic poison DoT

### DIFF
--- a/docs/BUFFS.md
+++ b/docs/BUFFS.md
@@ -77,6 +77,9 @@ buff-def schema, **extend the schema** rather than working around it.
 A handful of mechanics genuinely don't fit the buff-def vocabulary and are
 realized at the `timeline.ts` boundary on purpose — Crosswind Spirit's charge
 counter, the Hawkwing and Concentration probability schedules, Morale Chant's
-stack curve. Each is documented in CALCULATION.md § "Mechanic coverage" with the
-reason. Adding to that list needs the same justification: not "it was easier
-here", but "the def schema cannot express this".
+stack curve, and the Bitter Season inner way's poison (`buffs/bitterSeason.ts`):
+a stochastic per-hit proc plus a percentage target-defense reduction that
+stacks and decays is not expressible as a static `Buff`/`Debuff`. Each is
+documented in CALCULATION.md § "Mechanic coverage" with the reason. Adding to
+that list needs the same justification: not "it was easier here", but "the def
+schema cannot express this".

--- a/docs/CALCULATION.md
+++ b/docs/CALCULATION.md
@@ -138,6 +138,8 @@ The interesting derivations:
   * `+8%` for the `stonesplitBalancePureTang` class
 * **`effectiveDefense`** = `target.defense × (henZhiActive ? 0.94 : 1)`, where
   `henZhiActive = shareDebuff5HenZhi || (Year-Long Lament at tier 6)`
+  (`panel.ts henZhiActiveForInputs` — shared with the Bitter Season suppression
+  check below)
 * **`chargeBonus`** = `0.15` if Mighty Song is selected
 * **`weaponBoosts`** — the per-weapon boost map keyed by weapon name
   (`Sword`/`Spear`/`Fan`/`Umbrella`/`Modao`/`Twin Blades`/`Rope Dart`/`Hengdao`)
@@ -279,7 +281,11 @@ new effect before implementing it, and keep the buckets disjoint — the same
 effect must never land in two.
 
 1. **Flat tier stats** — `mindMethodPanelStats.json`, folded in by
-   `withDerivedStats`. Always-on stat adds; invisible to the Skill Editor.
+   `withDerivedStats`. Always-on stat adds; invisible to the Skill Editor. The
+   one exception is Bitter Season: unlike every other inner way (two
+   selectable tiers), all six of its tiers are selectable, so its two keys are
+   gated to a minimum tier each rather than applying unconditionally
+   (`getMindMethodContributions`).
 2. **`buildContext` scalars** — `panel.ts`. The handful of inner ways that move
    a context-level term rather than a stat: Soldier's Return / Star-Picker /
    Endurance Doctrine (`generalDamageBoost`), Year-Long Lament
@@ -342,6 +348,24 @@ divergences (Implemented), and known gaps, which contribute 0 unless noted
   and as `dot.weaponOrAttribute` fallback on the debuff), so column `T` gives
   them sword boost *and* all-martial like any Sword skill, per the lvl-110
   workbook's skill-type column.
+- **Bitter Season** (`buffs/bitterSeason.ts`) — a global inner way (every
+  class's `allowedMindMethods`, one universal stand-in skill instantiated per
+  class, one debuff entry per class bucket). Its proc chance and stack decay
+  are stochastic, so its stacking debuff and its poison's uptime are each a
+  seeded whole-rotation Monte-Carlo schedule, joining Hawkwing / Concentration /
+  Morale Chant — the def schema cannot express a per-hit roll. Its tier-6 node
+  (−10 target physical resistance) is modelled as +10 player
+  physical-penetration points, because target pen resistance is zero for every
+  target and there is no target-resistance stat key — the two are numerically
+  identical. The party-applied shared debuff (`shareDebuff5HenZhi` / Year-Long
+  Lament tier 6) already represents this same fully-stacked debuff, so the
+  inner way's own stat contribution is suppressed while it is active — the DoT
+  damage is not. A Sword Horizon Zenith detonation extends the poison the same
+  way it already extended Smolder — one shared, capped rule
+  (`ZENITH_MAX_EXTENDED_DURATION_FRAMES`, `builtinBuffs.ts`), not specific to
+  either debuff. Only hits laid by the rotation roll
+  the proc — DoT ticks and trigger-enqueued hits do not — the same structural
+  limitation Hawkwing and Concentration have.
 
 ### Gaps
 

--- a/docs/TIMELINE.md
+++ b/docs/TIMELINE.md
@@ -236,7 +236,11 @@ version:
      `applyBuff`/`applyDebuff` (resolve `statusById`, apply `extendFrames` logic, `recordStack`
      + open window/permanent), or `castSkill` (enqueue the target's hits).
 3. **DoT ticks:** every active `Debuff` with a `dot` emits a tick every `tickIntervalFrames`
-   via `dotTickDamage` / `dotTickDamageForShape` — each a normal `computeSkillDamage` call.
+   via `dotTickDamage` / `dotTickDamageForShape` — each a normal `computeSkillDamage` call. A
+   tick may carry a probability weight (`0..1`, multiplied onto its damage) when its debuff is
+   driven by a stochastic proc schedule (`buffs/bitterSeason.ts`) rather than an `applyDot`
+   trigger — the schedule's per-frame active-probability stands in for the tick actually having
+   fired that pass.
 
 ## 7. Worked example — Bellstrike Umbra (`bellstrikeUmbra`) bleed loop
 

--- a/src/data/baseStats/index.ts
+++ b/src/data/baseStats/index.ts
@@ -1,6 +1,8 @@
 import { ARSENAL_BONUS, getSchool } from "../../engine/panel"
 import { gearAttributeTotals } from "../../engine/gearStats"
 import { APP_PLAYER_LEVEL } from "../../engine/buffs/levelAttributeBonus"
+import { zhongToTier } from "../../engine/buffs/paramMap"
+import { BITTER_SEASON_INNER_WAY } from "../../engine/buffs/bitterSeason"
 import type {
   AttributeKey,
   GearPiece,
@@ -365,6 +367,16 @@ function primaryAttackKey(classId: string): string {
 
 const MIND_PANEL_STATS = mindMethodPanelStats as Record<string, Readonly<Record<string, number>>>
 
+// Unlike every other inner way's flat, always-on panel-stat entry
+// (CALCULATION.md § "Mind-method layers"), Bitter Season's own tier ladder
+// unlocks precision at tier 2 and physBoost at tier 5 — all six of its tiers
+// are selectable (MindMethodsPanel.tsx), so these two keys need a minimum
+// tier instead of applying unconditionally whenever the name is selected.
+const BITTER_SEASON_PANEL_STAT_MIN_TIER: Readonly<Record<string, number>> = {
+  precision: 2,
+  physBoost: 5,
+}
+
 export function getMindMethodContributions(inputs: Inputs): Record<string, number> {
   const out: Record<string, number> = {}
   const school = getSchool(inputs.classId)
@@ -374,7 +386,10 @@ export function getMindMethodContributions(inputs: Inputs): Record<string, numbe
     if (!name) return
     const stats = MIND_PANEL_STATS[name]
     if (!stats) return
+    const isBitterSeason = name === BITTER_SEASON_INNER_WAY
+    const tier = isBitterSeason ? zhongToTier(slot.stacks) : 0
     for (const [rawPath, amount] of Object.entries(stats)) {
+      if (isBitterSeason && tier < (BITTER_SEASON_PANEL_STAT_MIN_TIER[rawPath] ?? 0)) continue
       const path = rawPath.startsWith("primaryAttr.")
         ? `${primaryKey}.${rawPath.slice("primaryAttr.".length)}`
         : rawPath

--- a/src/data/baseStats/mindMethodPanelStats.json
+++ b/src/data/baseStats/mindMethodPanelStats.json
@@ -92,5 +92,9 @@
   "Lone Loyalty": {
     "critRate": 0.063,
     "critDamageBoost": 0.04
+  },
+  "Bitter Season": {
+    "precision": 0.069,
+    "physBoost": 0.025
   }
 }

--- a/src/data/baseStats/mindMethodPanelStats.json
+++ b/src/data/baseStats/mindMethodPanelStats.json
@@ -1,10 +1,6 @@
 {
-  "Unnamed Mind Method": {
-    "phys.max": 63.8,
-    "directAffinityRate": 0.023
-  },
   "Sword Horizon": {
-    "phys.max": 70.9,
+    "phys.max": 74.4,
     "directAffinityRate": 0.023
   },
   "Moon Above Flowers": {
@@ -37,7 +33,7 @@
     "primaryAttr.penetration": 0.06
   },
   "Wolfchaser's Art": {
-    "affinityRate": 0.037,
+    "affinityRate": 0.039,
     "affinityDamageBoost": 0.052
   },
   "Star-Picker": {
@@ -66,8 +62,8 @@
     "critDamageBoost": 0.035
   },
   "Morale Chant": {
-    "phys.max": 47.2,
-    "phys.min": 23.6,
+    "phys.max": 49.6,
+    "phys.min": 24.8,
     "directCritRate": 0.046
   },
   "Endurance Doctrine": {
@@ -76,8 +72,8 @@
     "primaryAttr.penetration": 0.06
   },
   "Insightful Strike": {
-    "phys.min": 21.3,
-    "phys.max": 42.5,
+    "phys.min": 22.3,
+    "phys.max": 44.7,
     "phys.penetration": 0.051
   },
   "Boat on Wood": {

--- a/src/data/classes/schools.json
+++ b/src/data/classes/schools.json
@@ -8,7 +8,14 @@
     "attributeMultiplier": 51.5,
     "permanentBuffs": ["Sword Charge Boost"],
     "classMindGroup": "Unnamed Mind Method",
-    "allowedMindMethods": ["Morale Chant", "Mighty Song", "Thousand Mountain Law", "Stone-Cutter", "Soldier's Return"],
+    "allowedMindMethods": [
+      "Morale Chant",
+      "Mighty Song",
+      "Thousand Mountain Law",
+      "Stone-Cutter",
+      "Soldier's Return",
+      "Bitter Season"
+    ],
     "classBuffs": [],
     "weapons": ["Sword", "Spear"],
     "rotations": ["Qi-Surge"]
@@ -22,7 +29,7 @@
     "attributeMultiplier": 51.5,
     "permanentBuffs": ["Bleed Boost"],
     "classMindGroup": "Sword Horizon",
-    "allowedMindMethods": ["Wolfchaser's Art", "Insightful Strike", "Morale Chant"],
+    "allowedMindMethods": ["Wolfchaser's Art", "Insightful Strike", "Morale Chant", "Bitter Season"],
     "classBuffs": [],
     "weapons": ["Sword", "Spear"],
     "rotations": ["6× Blood Burst + Dragon Whirl"]
@@ -43,7 +50,8 @@
       "Stone-Cutter",
       "Soldier's Return",
       "Year-Long Lament",
-      "Bliss Bleeding"
+      "Bliss Bleeding",
+      "Bitter Season"
     ],
     "classBuffs": [],
     "weapons": ["Umbrella", "Fan"],
@@ -64,7 +72,8 @@
       "Sutra Shift",
       "Stone-Cutter",
       "Soldier's Return",
-      "Endurance Doctrine"
+      "Endurance Doctrine",
+      "Bitter Season"
     ],
     "classBuffs": [],
     "weapons": ["Modao", "Spear"],
@@ -87,7 +96,8 @@
       "Year-Long Lament",
       "Stone-Cutter",
       "Sutra Shift",
-      "Bliss Bleeding"
+      "Bliss Bleeding",
+      "Bitter Season"
     ],
     "classBuffs": [],
     "weapons": ["Hengdao", "Modao"],
@@ -108,7 +118,8 @@
       "Bliss Bleeding",
       "Stone-Cutter",
       "Soldier's Return",
-      "Year-Long Lament"
+      "Year-Long Lament",
+      "Bitter Season"
     ],
     "classBuffs": [],
     "weapons": ["Twin Blades", "Rope Dart"],
@@ -129,7 +140,8 @@
       "Tang Anthem",
       "Stone-Cutter",
       "Year-Long Lament",
-      "Soldier's Return"
+      "Soldier's Return",
+      "Bitter Season"
     ],
     "classBuffs": [],
     "weapons": ["Umbrella", "Rope Dart"],
@@ -144,7 +156,7 @@
     "attributeMultiplier": 51.5,
     "permanentBuffs": [],
     "classMindGroup": "Soaring Ascent",
-    "allowedMindMethods": ["Morale Chant", "Heaven-Seizing Stance", "Threefold Insight"],
+    "allowedMindMethods": ["Morale Chant", "Heaven-Seizing Stance", "Threefold Insight", "Bitter Season"],
     "classBuffs": [],
     "weapons": ["Knuckles", "Rope Dart"],
     "rotations": []

--- a/src/data/skills/debuffsLibrary.json
+++ b/src/data/skills/debuffsLibrary.json
@@ -95,6 +95,32 @@
       "stackScaling": "perStack",
       "createdAt": "2026-07-19T00:00:00.000Z",
       "updatedAt": "2026-07-19T00:00:00.000Z"
+    },
+    {
+      "id": "debuff-bellstrikeRainbow-bitter-season-tick",
+      "classId": "bellstrikeRainbow",
+      "name": "Bitter Season Tick",
+      "activation": "triggered",
+      "durationFrames": 300,
+      "effects": [],
+      "dot": {
+        "tickIntervalFrames": 60,
+        "physMultiplier": 0.15,
+        "physFixed": 0,
+        "attributeMultiplier": 0.225,
+        "attributeFixed": 0,
+        "attributeAttack": "Bellstrike",
+        "skillType": "sustain",
+        "weaponOrAttribute": null,
+        "mysticCategory": null,
+        "count": 1,
+        "perStackShapes": null,
+        "perStackMultipliers": null
+      },
+      "maxStacks": 1,
+      "stackScaling": "flat",
+      "createdAt": "2026-08-06T00:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
     }
   ],
   "bellstrikeUmbra": [
@@ -226,6 +252,32 @@
       },
       "createdAt": "2026-07-19T00:00:00.000Z",
       "updatedAt": "2026-07-19T00:00:00.000Z"
+    },
+    {
+      "id": "debuff-bellstrikeUmbra-bitter-season-tick",
+      "classId": "bellstrikeUmbra",
+      "name": "Bitter Season Tick",
+      "activation": "triggered",
+      "durationFrames": 300,
+      "effects": [],
+      "dot": {
+        "tickIntervalFrames": 60,
+        "physMultiplier": 0.15,
+        "physFixed": 0,
+        "attributeMultiplier": 0.225,
+        "attributeFixed": 0,
+        "attributeAttack": "Bellstrike",
+        "skillType": "sustain",
+        "weaponOrAttribute": null,
+        "mysticCategory": null,
+        "count": 1,
+        "perStackShapes": null,
+        "perStackMultipliers": null
+      },
+      "maxStacks": 1,
+      "stackScaling": "flat",
+      "createdAt": "2026-08-06T00:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
     }
   ],
   "silkbindJade": [
@@ -438,6 +490,32 @@
       "stackScaling": "flat",
       "createdAt": "2026-07-19T00:00:00.000Z",
       "updatedAt": "2026-07-19T00:00:00.000Z"
+    },
+    {
+      "id": "debuff-silkbindJade-bitter-season-tick",
+      "classId": "silkbindJade",
+      "name": "Bitter Season Tick",
+      "activation": "triggered",
+      "durationFrames": 300,
+      "effects": [],
+      "dot": {
+        "tickIntervalFrames": 60,
+        "physMultiplier": 0.15,
+        "physFixed": 0,
+        "attributeMultiplier": 0.225,
+        "attributeFixed": 0,
+        "attributeAttack": "Silkbind",
+        "skillType": "sustain",
+        "weaponOrAttribute": null,
+        "mysticCategory": null,
+        "count": 1,
+        "perStackShapes": null,
+        "perStackMultipliers": null
+      },
+      "maxStacks": 1,
+      "stackScaling": "flat",
+      "createdAt": "2026-08-06T00:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
     }
   ],
   "stonesplitPower": [
@@ -512,6 +590,32 @@
       "stackScaling": "flat",
       "createdAt": "2026-07-19T00:00:00.000Z",
       "updatedAt": "2026-07-19T00:00:00.000Z"
+    },
+    {
+      "id": "debuff-stonesplitPower-bitter-season-tick",
+      "classId": "stonesplitPower",
+      "name": "Bitter Season Tick",
+      "activation": "triggered",
+      "durationFrames": 300,
+      "effects": [],
+      "dot": {
+        "tickIntervalFrames": 60,
+        "physMultiplier": 0.15,
+        "physFixed": 0,
+        "attributeMultiplier": 0.225,
+        "attributeFixed": 0,
+        "attributeAttack": "Stonesplit",
+        "skillType": "sustain",
+        "weaponOrAttribute": null,
+        "mysticCategory": null,
+        "count": 1,
+        "perStackShapes": null,
+        "perStackMultipliers": null
+      },
+      "maxStacks": 1,
+      "stackScaling": "flat",
+      "createdAt": "2026-08-06T00:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
     }
   ],
   "stonesplitBalancePureTang": [
@@ -586,6 +690,32 @@
       "stackScaling": "flat",
       "createdAt": "2026-07-19T00:00:00.000Z",
       "updatedAt": "2026-07-19T00:00:00.000Z"
+    },
+    {
+      "id": "debuff-stonesplitBalancePureTang-bitter-season-tick",
+      "classId": "stonesplitBalancePureTang",
+      "name": "Bitter Season Tick",
+      "activation": "triggered",
+      "durationFrames": 300,
+      "effects": [],
+      "dot": {
+        "tickIntervalFrames": 60,
+        "physMultiplier": 0.15,
+        "physFixed": 0,
+        "attributeMultiplier": 0.225,
+        "attributeFixed": 0,
+        "attributeAttack": "Stonesplit",
+        "skillType": "sustain",
+        "weaponOrAttribute": null,
+        "mysticCategory": null,
+        "count": 1,
+        "perStackShapes": null,
+        "perStackMultipliers": null
+      },
+      "maxStacks": 1,
+      "stackScaling": "flat",
+      "createdAt": "2026-08-06T00:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
     }
   ],
   "bamboocutWindTwinblade": [
@@ -660,6 +790,32 @@
       "stackScaling": "flat",
       "createdAt": "2026-07-19T00:00:00.000Z",
       "updatedAt": "2026-07-19T00:00:00.000Z"
+    },
+    {
+      "id": "debuff-bamboocutWindTwinblade-bitter-season-tick",
+      "classId": "bamboocutWindTwinblade",
+      "name": "Bitter Season Tick",
+      "activation": "triggered",
+      "durationFrames": 300,
+      "effects": [],
+      "dot": {
+        "tickIntervalFrames": 60,
+        "physMultiplier": 0.15,
+        "physFixed": 0,
+        "attributeMultiplier": 0.225,
+        "attributeFixed": 0,
+        "attributeAttack": "Bamboocut",
+        "skillType": "sustain",
+        "weaponOrAttribute": null,
+        "mysticCategory": null,
+        "count": 1,
+        "perStackShapes": null,
+        "perStackMultipliers": null
+      },
+      "maxStacks": 1,
+      "stackScaling": "flat",
+      "createdAt": "2026-08-06T00:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
     }
   ],
   "bamboocutDust": [
@@ -734,6 +890,32 @@
       "stackScaling": "flat",
       "createdAt": "2026-07-19T00:00:00.000Z",
       "updatedAt": "2026-07-19T00:00:00.000Z"
+    },
+    {
+      "id": "debuff-bamboocutDust-bitter-season-tick",
+      "classId": "bamboocutDust",
+      "name": "Bitter Season Tick",
+      "activation": "triggered",
+      "durationFrames": 300,
+      "effects": [],
+      "dot": {
+        "tickIntervalFrames": 60,
+        "physMultiplier": 0.15,
+        "physFixed": 0,
+        "attributeMultiplier": 0.225,
+        "attributeFixed": 0,
+        "attributeAttack": "Bamboocut",
+        "skillType": "sustain",
+        "weaponOrAttribute": null,
+        "mysticCategory": null,
+        "count": 1,
+        "perStackShapes": null,
+        "perStackMultipliers": null
+      },
+      "maxStacks": 1,
+      "stackScaling": "flat",
+      "createdAt": "2026-08-06T00:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
     }
   ],
   "stonesplitBalanceDualCut": [
@@ -808,6 +990,32 @@
       "stackScaling": "flat",
       "createdAt": "2026-07-19T00:00:00.000Z",
       "updatedAt": "2026-07-19T00:00:00.000Z"
+    },
+    {
+      "id": "debuff-stonesplitBalanceDualCut-bitter-season-tick",
+      "classId": "stonesplitBalanceDualCut",
+      "name": "Bitter Season Tick",
+      "activation": "triggered",
+      "durationFrames": 300,
+      "effects": [],
+      "dot": {
+        "tickIntervalFrames": 60,
+        "physMultiplier": 0.15,
+        "physFixed": 0,
+        "attributeMultiplier": 0.225,
+        "attributeFixed": 0,
+        "attributeAttack": "Bamboocut",
+        "skillType": "sustain",
+        "weaponOrAttribute": null,
+        "mysticCategory": null,
+        "count": 1,
+        "perStackShapes": null,
+        "perStackMultipliers": null
+      },
+      "maxStacks": 1,
+      "stackScaling": "flat",
+      "createdAt": "2026-08-06T00:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
     }
   ]
 }

--- a/src/data/skills/universal/bitter-season-tick.json
+++ b/src/data/skills/universal/bitter-season-tick.json
@@ -1,0 +1,66 @@
+{
+  "id": "universal-bitter-season-tick",
+  "classId": "universal",
+  "name": "Bitter Season Tick",
+  "tags": ["source:innerWayDot"],
+  "skillType": "sustain",
+  "elevatedAttributeMultiplier": false,
+  "weaponOrAttribute": "",
+  "attributeAttack": "",
+  "hits": [
+    {
+      "id": "hit-0",
+      "frame": 0,
+      "physMultiplier": 0.15,
+      "attributeMultiplier": 0.225,
+      "physFixed": 0,
+      "attributeFixed": 0,
+      "extraCritDamage": 0,
+      "triggers": []
+    },
+    {
+      "id": "hit-1",
+      "frame": 60,
+      "physMultiplier": 0.15,
+      "attributeMultiplier": 0.225,
+      "physFixed": 0,
+      "attributeFixed": 0,
+      "extraCritDamage": 0,
+      "triggers": []
+    },
+    {
+      "id": "hit-2",
+      "frame": 120,
+      "physMultiplier": 0.15,
+      "attributeMultiplier": 0.225,
+      "physFixed": 0,
+      "attributeFixed": 0,
+      "extraCritDamage": 0,
+      "triggers": []
+    },
+    {
+      "id": "hit-3",
+      "frame": 180,
+      "physMultiplier": 0.15,
+      "attributeMultiplier": 0.225,
+      "physFixed": 0,
+      "attributeFixed": 0,
+      "extraCritDamage": 0,
+      "triggers": []
+    },
+    {
+      "id": "hit-4",
+      "frame": 240,
+      "physMultiplier": 0.15,
+      "attributeMultiplier": 0.225,
+      "physFixed": 0,
+      "attributeFixed": 0,
+      "extraCritDamage": 0,
+      "triggers": []
+    }
+  ],
+  "castFrames": 0,
+  "triggerable": true,
+  "createdAt": "2026-08-06T00:00:00.000Z",
+  "updatedAt": "2026-08-06T00:00:00.000Z"
+}

--- a/src/data/skills/universal/bitter-season-tick.md
+++ b/src/data/skills/universal/bitter-season-tick.md
@@ -1,0 +1,32 @@
+# Bitter Season Tick
+
+The per-tick coefficient (`physMultiplier: 0.15`) is an **unverified
+placeholder** — no workbook row or reference-site def exists for this inner
+way. It was chosen to sit between the bleed tick's per-stack base and
+Smolder's per-tick coefficient. Editable in the Skill Editor; changing it
+changes the poison DoT's damage directly, since `timeline.ts` reads this
+skill's `hits[0]` in preference to the sibling debuff's own `dot` shape.
+
+`attributeMultiplier` follows the data-set's `1.5×` pairing convention but is
+inert here: every DoT tick uses `physMultiplier`, never `attributeMultiplier`,
+on the matching-attribute path (`elevatedAttributeMultiplier: false`). Flat
+damage is `0` for the same reason — DoT rows lose flat damage.
+
+Five hits (one per tick of the 5 s poison window) rather than a single
+representative hit, matching the Bleed Tick convention. `weaponOrAttribute` is
+empty: an inner-way proc is not a martial art, so it takes no weapon boost, no
+All-Martial, and no mystic-type boost.
+
+The ticks are not driven by an `applyDot` trigger — there is no skill whose
+hit could carry one, since the poison is a probabilistic proc off *any*
+damaging hit. Instead `timeline.ts` opens the sibling debuff's window over
+`buffs/bitterSeason.ts`'s deterministic guaranteed-proc envelope
+(`bitterSeasonEnvelopeWindows` — every hit refreshes it, exactly as if it had
+procced) and weights each tick's damage by the modelled poison uptime from the
+seeded schedule, which is provably 0 outside that envelope.
+
+The window (and therefore these ticks) can be extended by a Sword Horizon
+Zenith detonation, because the extension events fed to the schedule are the
+Zenith detonation markers, which only exist on a Sword Horizon build — the
+same shared cap rule Smolder's own Zenith extension uses
+(`ZENITH_MAX_EXTENDED_DURATION_FRAMES`, `builtinBuffs.ts`).

--- a/src/data/skills/universal/index.ts
+++ b/src/data/skills/universal/index.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "../../../engine/skill"
+import bitterSeasonTick from "./bitter-season-tick.json"
 import deflectCancelPrepull from "./deflect-cancel-prepull.json"
 import deflectCancel from "./deflect-cancel.json"
 import delay from "./delay.json"
@@ -26,6 +27,7 @@ import soaring from "./soaring.json"
 import toadCancel from "./toad-cancel.json"
 
 export const UNIVERSAL_SKILLS = [
+  bitterSeasonTick,
   deflectCancelPrepull,
   deflectCancel,
   delay,

--- a/src/engine/buffs/bitterSeason.ts
+++ b/src/engine/buffs/bitterSeason.ts
@@ -1,0 +1,241 @@
+import { mulberry32 } from "./hawkwing"
+import { ZENITH_MAX_EXTENDED_DURATION_FRAMES } from "../builtinBuffs"
+
+const STEP_SEC = 0.05
+const SIM_RUNS = 500
+const STACK_SEED_OFFSET = 40217
+const POISON_SEED_OFFSET = 58601
+const ZENITH_MAX_EXTENDED_DURATION_SEC = ZENITH_MAX_EXTENDED_DURATION_FRAMES / 60
+
+export const BITTER_SEASON_INNER_WAY = "Bitter Season"
+export const BITTER_SEASON_TICK_SLUG = "bitter-season-tick"
+export const BITTER_SEASON_MAX_STACKS = 5
+export const BITTER_SEASON_STACK_DURATION_SEC = 10
+export const BITTER_SEASON_ZENITH_EXTENSION_SEC = 10
+
+export function bitterSeasonDebuffId(classId: string): string {
+  return `debuff-${classId}-${BITTER_SEASON_TICK_SLUG}`
+}
+
+export interface BitterSeasonTuning {
+  procChance: number
+  defenseReductionPerStack: number
+  physPenetrationAtMaxStacks: number
+}
+
+export function resolveBitterSeasonTuning(tier: number): BitterSeasonTuning {
+  return {
+    procChance: tier >= 4 ? 0.15 : 0.1,
+    defenseReductionPerStack: tier >= 1 ? 0.012 : 0.006,
+    // Tier 6: −10 target physical resistance, modelled as +10 player physical
+    // penetration points (0.1 in the panel's fraction-of-100 unit) — target pen
+    // resistance is zero for every target, so the two are numerically
+    // equivalent (CLAUDE.md § "Calculation rules").
+    physPenetrationAtMaxStacks: tier >= 6 ? 0.1 : 0,
+  }
+}
+
+export interface BitterSeasonStackSchedule {
+  expectedStacksAtTime(tSec: number): number
+  maxStackProbAtTime(tSec: number): number
+}
+
+const ZERO_STACK_SCHEDULE: BitterSeasonStackSchedule = {
+  expectedStacksAtTime: () => 0,
+  maxStackProbAtTime: () => 0,
+}
+
+export function bitterSeasonStackSchedule(
+  hitTimesSec: readonly number[],
+  procChance: number,
+  rotationDurationSec: number,
+): BitterSeasonStackSchedule {
+  if (hitTimesSec.length === 0 || rotationDurationSec <= 0 || procChance <= 0) {
+    return ZERO_STACK_SCHEDULE
+  }
+
+  const steps = Math.ceil(rotationDurationSec / STEP_SEC) + 1
+  const stackAccum = new Float64Array(steps)
+  const maxStackAccum = new Float64Array(steps)
+
+  for (let sim = 0; sim < SIM_RUNS; sim++) {
+    const rng = mulberry32(STACK_SEED_OFFSET + sim)
+    let stacks = 0
+    let windowEnd = -Infinity
+    let hitIdx = 0
+    for (let step = 0; step < steps; step++) {
+      const now = step * STEP_SEC
+      while (hitIdx < hitTimesSec.length && hitTimesSec[hitIdx] <= now) {
+        const hitTime = hitTimesSec[hitIdx]
+        if (stacks > 0 && hitTime >= windowEnd) stacks = 0
+        if (rng() < procChance) {
+          stacks = Math.min(stacks + 1, BITTER_SEASON_MAX_STACKS)
+          windowEnd = hitTime + BITTER_SEASON_STACK_DURATION_SEC
+        }
+        hitIdx++
+      }
+      if (stacks > 0 && now >= windowEnd) stacks = 0
+      stackAccum[step] += stacks
+      if (stacks === BITTER_SEASON_MAX_STACKS) maxStackAccum[step] += 1
+    }
+  }
+
+  const expectedStacks = new Float64Array(steps)
+  const maxStackProb = new Float64Array(steps)
+  for (let step = 0; step < steps; step++) {
+    expectedStacks[step] = stackAccum[step] / SIM_RUNS
+    maxStackProb[step] = maxStackAccum[step] / SIM_RUNS
+  }
+
+  return {
+    expectedStacksAtTime(tSec: number): number {
+      if (tSec <= 0) return expectedStacks[0]
+      const idx = Math.min(Math.floor(tSec / STEP_SEC), steps - 1)
+      return expectedStacks[idx]
+    },
+    maxStackProbAtTime(tSec: number): number {
+      if (tSec <= 0) return maxStackProb[0]
+      const idx = Math.min(Math.floor(tSec / STEP_SEC), steps - 1)
+      return maxStackProb[idx]
+    },
+  }
+}
+
+export interface BitterSeasonPoisonSchedule {
+  activeProbAtTime(tSec: number): number
+  remainingActiveSecAtTime(tSec: number): number
+}
+
+const ZERO_POISON_SCHEDULE: BitterSeasonPoisonSchedule = {
+  activeProbAtTime: () => 0,
+  remainingActiveSecAtTime: () => 0,
+}
+
+export function bitterSeasonPoisonSchedule(
+  hitTimesSec: readonly number[],
+  procChance: number,
+  poisonDurationSec: number,
+  rotationDurationSec: number,
+  extensionTimesSec: readonly number[],
+): BitterSeasonPoisonSchedule {
+  if (
+    hitTimesSec.length === 0 ||
+    rotationDurationSec <= 0 ||
+    procChance <= 0 ||
+    poisonDurationSec <= 0
+  ) {
+    return ZERO_POISON_SCHEDULE
+  }
+
+  const steps = Math.ceil(rotationDurationSec / STEP_SEC) + 1
+  const accum = new Float64Array(steps)
+  // Expected remaining active time ASSUMING NO FURTHER HITS from that step
+  // on — i.e. `max(0, poisonEnd - now)` per sim, averaged. Unlike
+  // `activeProbAtTime` (which keeps counting future hits and so stays high
+  // through a dense rotation), this decays to 0 the moment hits actually
+  // stop landing — the number the "Remaining" display wants.
+  const remainingAccum = new Float64Array(steps)
+
+  for (let sim = 0; sim < SIM_RUNS; sim++) {
+    const rng = mulberry32(POISON_SEED_OFFSET + sim)
+    let poisonEnd = -Infinity
+    let hitIdx = 0
+    let extIdx = 0
+    for (let step = 0; step < steps; step++) {
+      const now = step * STEP_SEC
+      for (;;) {
+        const nextHitTime = hitIdx < hitTimesSec.length ? hitTimesSec[hitIdx] : Infinity
+        const nextExtTime = extIdx < extensionTimesSec.length ? extensionTimesSec[extIdx] : Infinity
+        if (nextHitTime > now && nextExtTime > now) break
+        if (nextHitTime <= nextExtTime) {
+          if (rng() < procChance) poisonEnd = Math.max(poisonEnd, nextHitTime + poisonDurationSec)
+          hitIdx++
+        } else {
+          // See `ZENITH_MAX_EXTENDED_DURATION_FRAMES` (builtinBuffs.ts).
+          if (poisonEnd > nextExtTime) {
+            poisonEnd = Math.max(
+              poisonEnd,
+              Math.min(
+                poisonEnd + BITTER_SEASON_ZENITH_EXTENSION_SEC,
+                nextExtTime + ZENITH_MAX_EXTENDED_DURATION_SEC,
+              ),
+            )
+          }
+          extIdx++
+        }
+      }
+      accum[step] += now < poisonEnd ? 1 : 0
+      remainingAccum[step] += Math.max(0, poisonEnd - now)
+    }
+  }
+
+  const activeProb = new Float64Array(steps)
+  const expectedRemaining = new Float64Array(steps)
+  for (let step = 0; step < steps; step++) {
+    activeProb[step] = accum[step] / SIM_RUNS
+    expectedRemaining[step] = remainingAccum[step] / SIM_RUNS
+  }
+
+  const indexAt = (tSec: number): number =>
+    tSec <= 0 ? 0 : Math.min(Math.floor(tSec / STEP_SEC), steps - 1)
+
+  return {
+    activeProbAtTime(tSec: number): number {
+      return activeProb[indexAt(tSec)]
+    },
+    remainingActiveSecAtTime(tSec: number): number {
+      return expectedRemaining[indexAt(tSec)]
+    },
+  }
+}
+
+export interface BitterSeasonEnvelopeWindow {
+  startSec: number
+  endSec: number
+}
+
+// The guaranteed-proc (procChance = 1) envelope of `bitterSeasonPoisonSchedule`,
+// deterministically. Because a real proc chance can only end a run earlier
+// than this, `activeProbAtTime` is provably 0 outside these windows — so they
+// bound tick emission without dropping any expected damage.
+export function bitterSeasonEnvelopeWindows(
+  hitTimesSec: readonly number[],
+  poisonDurationSec: number,
+  extensionTimesSec: readonly number[],
+): BitterSeasonEnvelopeWindow[] {
+  if (hitTimesSec.length === 0 || poisonDurationSec <= 0) return []
+
+  const windows: BitterSeasonEnvelopeWindow[] = []
+  let currentStart: number | null = null
+  let currentEnd = -Infinity
+  let hitIdx = 0
+  let extIdx = 0
+  while (hitIdx < hitTimesSec.length || extIdx < extensionTimesSec.length) {
+    const nextHitTime = hitIdx < hitTimesSec.length ? hitTimesSec[hitIdx] : Infinity
+    const nextExtTime = extIdx < extensionTimesSec.length ? extensionTimesSec[extIdx] : Infinity
+    if (nextHitTime <= nextExtTime) {
+      if (currentStart === null || nextHitTime > currentEnd) {
+        if (currentStart !== null) windows.push({ startSec: currentStart, endSec: currentEnd })
+        currentStart = nextHitTime
+        currentEnd = nextHitTime + poisonDurationSec
+      } else {
+        currentEnd = Math.max(currentEnd, nextHitTime + poisonDurationSec)
+      }
+      hitIdx++
+    } else {
+      // See `ZENITH_MAX_EXTENDED_DURATION_FRAMES` (builtinBuffs.ts).
+      if (currentStart !== null && currentEnd > nextExtTime) {
+        currentEnd = Math.max(
+          currentEnd,
+          Math.min(
+            currentEnd + BITTER_SEASON_ZENITH_EXTENSION_SEC,
+            nextExtTime + ZENITH_MAX_EXTENDED_DURATION_SEC,
+          ),
+        )
+      }
+      extIdx++
+    }
+  }
+  if (currentStart !== null) windows.push({ startSec: currentStart, endSec: currentEnd })
+  return windows
+}

--- a/src/engine/builtinBuffs.ts
+++ b/src/engine/builtinBuffs.ts
@@ -9,6 +9,15 @@ export const SPEAR_SPECIAL_COOLDOWN_FRAMES = 690
 
 export const ZENITH_SMOLDER_EXTEND_FRAMES = 600
 
+// User-verified 2026-08-07: a Zenith detonation always adds its full extend
+// amount, but the resulting REMAINING duration (from that detonation's own
+// frame, re-evaluated per detonation — not a lifetime cap on the window)
+// never exceeds 16 s. If the window is already longer than that, the
+// detonation must leave it alone — never truncate it down to the cap.
+// Sword Horizon logic, not specific to any one debuff it extends (Smolder,
+// Bitter Season's poison, …).
+export const ZENITH_MAX_EXTENDED_DURATION_FRAMES = 960
+
 export const RIVER_FLOW_BUFF_ID = "buff-bellstrikeUmbra-river-flow"
 export const SPEAR_SPECIAL_COOLDOWN_BUFF_ID = "buff-bellstrikeUmbra-spear-special-cooldown"
 export const ZENITH_BAR_BUFF_ID = "buff-bellstrikeUmbra-zenith-bar"

--- a/src/engine/panel.ts
+++ b/src/engine/panel.ts
@@ -75,6 +75,16 @@ export function resistanceForInputs(inputs: Inputs): number {
   return resistanceForBreakthrough(inputs.breakthrough)
 }
 
+export function henZhiActiveForInputs(inputs: Inputs): boolean {
+  const stackOf = (name: string) =>
+    inputs.mindMethods.find((slot) => slot.name === name)?.stacks ?? ""
+  return (
+    inputs.shareDebuff5HenZhi ||
+    (inputs.mindMethods.some((slot) => slot.name === "Year-Long Lament") &&
+      stackOf("Year-Long Lament") === "tier 6")
+  )
+}
+
 // Pen resistance is zero for every target per the 2026-07 decision; the
 // level parameter is kept as plumbing for a future target that has one.
 export function penResistanceForLevel(_level: number): { physical: number; attribute: number } {
@@ -251,9 +261,7 @@ export function buildContext(
   const has = (name: string) => mindMethodNames.includes(name)
   const stackOf = (name: string) => inputs.mindMethods.find((m) => m.name === name)?.stacks ?? ""
 
-  const henZhiActive =
-    inputs.shareDebuff5HenZhi ||
-    (has("Year-Long Lament") && stackOf("Year-Long Lament") === "tier 6")
+  const henZhiActive = henZhiActiveForInputs(inputs)
   const effectiveDefense = target.defense * (henZhiActive ? 0.94 : 1)
 
   const chargeBonus = has("Mighty Song") ? 0.15 : 0

--- a/src/engine/timeline.ts
+++ b/src/engine/timeline.ts
@@ -18,12 +18,23 @@ import {
   selectHitVariant,
 } from "./skill"
 import { resolveRotation, type ResolvedStep } from "./rotation"
-import { deriveStats, buildContext, effectiveRates } from "./panel"
+import {
+  deriveStats,
+  buildContext,
+  effectiveRates,
+  getBreakthrough,
+  henZhiActiveForInputs,
+} from "./panel"
 import { computeSkillDamage } from "./formula"
 import { padSlots } from "./perSkillDamage"
 import { applyBuffEffects } from "./statRegistry"
 import { builtinSkillsForClass, builtinDebuffsForClass } from "./builtinLibrary"
-import { builtinBuffsForClass, ZENITH_BAR_BUFF_ID, ZENITH_DETONATION_BUFF_ID } from "./builtinBuffs"
+import {
+  builtinBuffsForClass,
+  ZENITH_BAR_BUFF_ID,
+  ZENITH_DETONATION_BUFF_ID,
+  ZENITH_MAX_EXTENDED_DURATION_FRAMES,
+} from "./builtinBuffs"
 import { BuffEngine } from "./buffs/buffEngine"
 import { buffDefsForClass, groupBuffDefs, mechanicBuffDefsForClass } from "./buffs/data"
 import { paramsFromInputs } from "./buffs/params"
@@ -47,6 +58,18 @@ import {
 } from "./buffs/hawkwing"
 import { concentrationActiveProbSchedule } from "./buffs/concentration"
 import { APP_PLAYER_LEVEL, playerLevelAttributeAttackBonus } from "./buffs/levelAttributeBonus"
+import { zhongToTier } from "./buffs/paramMap"
+import {
+  bitterSeasonDebuffId,
+  bitterSeasonEnvelopeWindows,
+  bitterSeasonPoisonSchedule,
+  bitterSeasonStackSchedule,
+  resolveBitterSeasonTuning,
+  BITTER_SEASON_INNER_WAY,
+  BITTER_SEASON_MAX_STACKS,
+  type BitterSeasonPoisonSchedule,
+  type BitterSeasonStackSchedule,
+} from "./buffs/bitterSeason"
 
 export const FPS = 60
 
@@ -84,6 +107,8 @@ function bleedAttunementValue(inputs: Inputs): number {
 const CONCENTRATION_DOT_MULT_SKILLS = new Set(["Bleed Detonation", "Bleed Tick", "Combustion"])
 
 const CONCENTRATION_DISPLAY_THRESHOLD = 0.5
+
+const BITTER_SEASON_REMAINING_DISPLAY_THRESHOLD = 0.5
 
 type Ctx = ReturnType<typeof buildContext>
 type Derived = ReturnType<typeof deriveStats>
@@ -259,6 +284,57 @@ export function simulateTimeline(inputs: Inputs): Result {
       : null
   const concentrationTier6 =
     inputs.mindMethods.find((m) => m.name === "Insightful Strike")?.stacks === "tier 6"
+
+  const bitterSeasonId = bitterSeasonDebuffId(inputs.classId)
+  const bitterSeasonSlot =
+    inputs.mindMethods.find((slot) => slot.name === BITTER_SEASON_INNER_WAY) ?? null
+  const bitterSeasonTuning = bitterSeasonSlot
+    ? resolveBitterSeasonTuning(zhongToTier(bitterSeasonSlot.stacks))
+    : null
+  const bitterSeasonHitTimesSec: number[] = []
+  if (bitterSeasonTuning) {
+    for (const ls of laidSteps) {
+      for (const hit of ls.performedHits) {
+        if (!hitDealsDamage(hit)) continue
+        bitterSeasonHitTimesSec.push((ls.startFrame + hit.frame) / FPS)
+      }
+    }
+    bitterSeasonHitTimesSec.sort((a, b) => a - b)
+  }
+  const bitterSeasonStacks: BitterSeasonStackSchedule | null = bitterSeasonTuning
+    ? bitterSeasonStackSchedule(
+        bitterSeasonHitTimesSec,
+        bitterSeasonTuning.procChance,
+        rotationDurationSec,
+      )
+    : null
+  // The party-applied shared debuff (`shareDebuff5HenZhi`/Year-Long Lament T6)
+  // already supplies the fully-stacked reduction.
+  const bitterSeasonSuppressed = henZhiActiveForInputs(inputs)
+  const bitterSeasonBaseTargetDefense = getBreakthrough(inputs.breakthrough).defense
+
+  function bitterSeasonEffectsAt(tSec: number): BuffStatEffect[] {
+    if (!bitterSeasonStacks || !bitterSeasonTuning) return []
+    const out: BuffStatEffect[] = []
+    const stacks = bitterSeasonStacks.expectedStacksAtTime(tSec)
+    if (stacks > 0) {
+      out.push({
+        statKey: "target.defense",
+        amount:
+          -stacks * bitterSeasonTuning.defenseReductionPerStack * bitterSeasonBaseTargetDefense,
+      })
+    }
+    if (bitterSeasonTuning.physPenetrationAtMaxStacks > 0) {
+      const maxStackProb = bitterSeasonStacks.maxStackProbAtTime(tSec)
+      if (maxStackProb > 0) {
+        out.push({
+          statKey: "phys.penetration",
+          amount: bitterSeasonTuning.physPenetrationAtMaxStacks * maxStackProb,
+        })
+      }
+    }
+    return out
+  }
 
   const prePullHitsCount = rotation.prePullHitsCount ?? false
   const inWindow = (frame: number): boolean =>
@@ -487,6 +563,17 @@ export function simulateTimeline(inputs: Inputs): Result {
       hawkwingPhysBonus = stacks * HAWKWING_BONUS_PER_STACK
       sig += `~hawkwing:${stacks}`
     }
+    if (bitterSeasonTuning && !bitterSeasonSuppressed) {
+      const bitterSeasonEffects = bitterSeasonEffectsAt(frame / FPS)
+      if (bitterSeasonEffects.length > 0) {
+        effects.push(...bitterSeasonEffects)
+        sig +=
+          "~bitterSeason:" +
+          bitterSeasonEffects
+            .map((effect) => `${effect.statKey}:${effect.amount.toFixed(6)}`)
+            .join(",")
+      }
+    }
     const combat = inputs.combatSettings
     if (combat?.revelryScript) {
       effects.push({ statKey: "allDamageBoost", amount: 0.3 })
@@ -671,8 +758,15 @@ export function simulateTimeline(inputs: Inputs): Result {
               if (frame >= cand.start && frame < cand.end && (!w || cand.end > w.end)) w = cand
             }
           if (w) {
-            w.end += trigger.extendFrames
-            ;(w.extensions ??= []).push({ frame, amount: trigger.extendFrames })
+            // See `ZENITH_MAX_EXTENDED_DURATION_FRAMES` (builtinBuffs.ts).
+            const isZenithExtension = trigger.condition?.buffId === ZENITH_DETONATION_BUFF_ID
+            const rawEnd = w.end + trigger.extendFrames
+            const nextEnd = isZenithExtension
+              ? Math.max(w.end, Math.min(rawEnd, frame + ZENITH_MAX_EXTENDED_DURATION_FRAMES))
+              : rawEnd
+            const appliedAmount = nextEnd - w.end
+            w.end = nextEnd
+            if (appliedAmount > 0) (w.extensions ??= []).push({ frame, amount: appliedAmount })
           } else if (!trigger.extendOnly) {
             const next = clamp(
               stacksAt(status.id, frame) + trigger.stacks,
@@ -697,6 +791,46 @@ export function simulateTimeline(inputs: Inputs): Result {
           queue.push({ frame: frame + subHit.frame, seq: seq++, skill: sub, hit: subHit })
         }
       }
+    }
+  }
+
+  // Zenith extension events only exist for a Sword Horizon build (the only
+  // build whose crosswind tracker pushes ZENITH_DETONATION_BUFF_ID windows),
+  // so this list is empty for every other build without a class check.
+  let bitterSeasonPoison: BitterSeasonPoisonSchedule | null = null
+  if (bitterSeasonTuning && durationFrames > 0 && bitterSeasonHitTimesSec.length > 0) {
+    const bitterSeasonDebuff = statusById.get(bitterSeasonId)
+    if (bitterSeasonDebuff && isDebuffStatus(bitterSeasonDebuff) && bitterSeasonDebuff.dot) {
+      const zenithExtensionTimesSec = (windowsByBuff.get(ZENITH_DETONATION_BUFF_ID) ?? [])
+        .map((zenithWindow) => zenithWindow.start / FPS)
+        .sort((a, b) => a - b)
+      const poisonDurationSec = bitterSeasonDebuff.durationFrames / FPS
+      bitterSeasonPoison = bitterSeasonPoisonSchedule(
+        bitterSeasonHitTimesSec,
+        bitterSeasonTuning.procChance,
+        poisonDurationSec,
+        rotationDurationSec,
+        zenithExtensionTimesSec,
+      )
+      // Bounds tick emission to the guaranteed-proc envelope instead of one
+      // span covering the whole rotation — activeProbAtTime is 0 outside it,
+      // so no expected damage is lost by not ticking there.
+      for (const envelopeWindow of bitterSeasonEnvelopeWindows(
+        bitterSeasonHitTimesSec,
+        poisonDurationSec,
+        zenithExtensionTimesSec,
+      )) {
+        pushWindow(
+          bitterSeasonDebuff.id,
+          Math.round(envelopeWindow.startSec * FPS),
+          Math.round(envelopeWindow.endSec * FPS),
+        )
+      }
+      recordStack(
+        bitterSeasonDebuff.id,
+        Math.max(0, Math.round(bitterSeasonHitTimesSec[0] * FPS)),
+        1,
+      )
     }
   }
 
@@ -737,6 +871,20 @@ export function simulateTimeline(inputs: Inputs): Result {
               end = endHere
           }
         if (end !== undefined) remainingSec = (end - queryFrame) / FPS
+      }
+      // Below the display threshold there's a real chance no poison has
+      // procced yet at all (e.g. right after the very first eligible hits),
+      // so the expected-remaining number alone would understate that and
+      // read as an oddly short "duration" — withhold it until more likely
+      // than not to be up, same convention as Concentration's own gate.
+      if (b.id === bitterSeasonId && bitterSeasonPoison) {
+        const isLikelyActive =
+          bitterSeasonPoison.activeProbAtTime(queryTimeSec) >=
+          BITTER_SEASON_REMAINING_DISPLAY_THRESHOLD
+        const activeSec = isLikelyActive
+          ? bitterSeasonPoison.remainingActiveSecAtTime(queryTimeSec)
+          : 0
+        remainingSec = activeSec > 0 ? activeSec : undefined
       }
       buffs.push({
         id: b.id,
@@ -814,6 +962,42 @@ export function simulateTimeline(inputs: Inputs): Result {
           })
         }
       }
+      if (bitterSeasonTuning && !seenBuffIds.has("bitterSeasonPoison")) {
+        const shown = bitterSeasonSuppressed
+          ? BITTER_SEASON_MAX_STACKS
+          : Math.round(bitterSeasonStacks?.expectedStacksAtTime(queryTimeSec) ?? 0)
+        if (shown >= 1) {
+          seenBuffIds.add("bitterSeasonPoison")
+          const uptimePct = Math.round(
+            (bitterSeasonPoison?.activeProbAtTime(queryTimeSec) ?? 0) * 100,
+          )
+          // The mechanic's own numbers (both worded as a target physical
+          // defense reduction, per the in-game hint, even though the tier-6
+          // node is implemented through `phys.penetration` — see
+          // `bitterSeasonEffectsAt`), stated plainly rather than surfacing
+          // that internal stat-key vehicle, and scaled to the shown stack
+          // count rather than always quoting the 5-stack cap.
+          const currentDefensePct = Math.round(
+            bitterSeasonTuning.defenseReductionPerStack * shown * 100,
+          )
+          const tier6DefenseFlatAmount = bitterSeasonTuning.physPenetrationAtMaxStacks * 100
+          const mechanicText =
+            `at ${shown}/${BITTER_SEASON_MAX_STACKS} stacks: -${currentDefensePct}% target physical defense` +
+            (tier6DefenseFlatAmount > 0
+              ? ` · -${tier6DefenseFlatAmount} target physical defense at ${BITTER_SEASON_MAX_STACKS}/${BITTER_SEASON_MAX_STACKS} stacks (tier 6)`
+              : "")
+          buffs.push({
+            id: "bitterSeasonPoison",
+            name: "Bitter Season Poison",
+            stacks: shown,
+            maxStacks: BITTER_SEASON_MAX_STACKS,
+            effects: [],
+            description: bitterSeasonSuppressed
+              ? "party-applied Bitter Season debuff already caps the reduction — the inner way adds none"
+              : `expected stacks (avg of 500 sims, rounded) · ${mechanicText} · ≈${uptimePct}% poison uptime`,
+          })
+        }
+      }
     }
     return {
       index: 0,
@@ -884,6 +1068,11 @@ export function simulateTimeline(inputs: Inputs): Result {
     for (const ep of episodes) {
       for (let f = ep.start + interval; f < ep.end; f += interval) {
         if (f < 0 || !inWindow(f)) continue
+        const tickWeight =
+          bitterSeasonPoison && buffId === bitterSeasonId
+            ? bitterSeasonPoison.activeProbAtTime(f / FPS)
+            : 1
+        if (tickWeight <= 0) continue
         let dmg: number
         if (table) {
           const liveStacks = Math.max(1, stacksAt(buffId, f))
@@ -902,6 +1091,7 @@ export function simulateTimeline(inputs: Inputs): Result {
           const st = resolveState(f, dotSkill)
           dmg = dotTickDamage(debuffForTick, st.ctx, st.forceCrit, bleedCorrection) * stackCount
         }
+        dmg *= tickWeight
         totalDamage += dmg
         const dotName = `${debuffDef.name} (DoT)`
         const dotType = dot.skillType || "sustain"

--- a/src/ui/features/overview/encounter-settings-panel/EncounterSettingsPanel.tsx
+++ b/src/ui/features/overview/encounter-settings-panel/EncounterSettingsPanel.tsx
@@ -74,7 +74,7 @@ export function EncounterSettingsPanel({ inputs, onChange }: Props) {
         <div className="section-label">{t("Shared Debuffs")}</div>
         <div className={styles.toggleChips}>
           <ToggleChip
-            label={t("Bitter Season")}
+            label={t("Bitter Season (from a teammate)")}
             on={inputs.shareDebuff5HenZhi}
             onToggle={() => set("shareDebuff5HenZhi", !inputs.shareDebuff5HenZhi)}
           />

--- a/src/ui/features/overview/mind-methods-panel/MindMethodsPanel.tsx
+++ b/src/ui/features/overview/mind-methods-panel/MindMethodsPanel.tsx
@@ -1,9 +1,23 @@
 import type { Inputs, MindMethodSlot } from "../../../../engine/types"
 import { allowedInnerWaysForClass } from "../../../../engine/panel"
+import { BITTER_SEASON_INNER_WAY } from "../../../../engine/buffs/bitterSeason"
 import { useI18n } from "../../../../i18n/i18nContext"
 import styles from "./MindMethodsPanel.module.scss"
 
 const TIER_OPTIONS = ["tier 6", "tier 5"] as const
+// Bitter Season's ladder has a distinct node at every tier (`buffs/bitterSeason.ts`).
+const BITTER_SEASON_TIER_OPTIONS = [
+  "tier 6",
+  "tier 5",
+  "tier 4",
+  "tier 3",
+  "tier 2",
+  "tier 1",
+] as const
+
+function tierOptionsFor(name: string): readonly string[] {
+  return name === BITTER_SEASON_INNER_WAY ? BITTER_SEASON_TIER_OPTIONS : TIER_OPTIONS
+}
 
 interface Props {
   inputs: Inputs
@@ -40,6 +54,8 @@ export function MindMethodsPanel({ inputs, onChange }: Props) {
         )
         const isTaken = (name: string) =>
           name !== "" && name !== currentName && takenElsewhere.has(name)
+        const tierOptions = tierOptionsFor(currentName)
+        const fallbackTier = slot.stacks && !tierOptions.includes(slot.stacks) ? [slot.stacks] : []
         return (
           <div key={idx} className={styles.mindSlot}>
             <label>{label}</label>
@@ -48,8 +64,11 @@ export function MindMethodsPanel({ inputs, onChange }: Props) {
               onChange={(e) => {
                 const name = e.target.value
                 const patch: Partial<MindMethodSlot> = { name }
-                if (name && !slot.stacks) patch.stacks = "tier 6"
-                if (!name) patch.stacks = ""
+                if (!name) {
+                  patch.stacks = ""
+                } else if (!slot.stacks || !tierOptionsFor(name).includes(slot.stacks)) {
+                  patch.stacks = "tier 6"
+                }
                 updateSlot(idx, patch)
               }}
             >
@@ -73,11 +92,16 @@ export function MindMethodsPanel({ inputs, onChange }: Props) {
               disabled={!currentName}
               onChange={(e) => updateSlot(idx, { stacks: e.target.value })}
             >
-              {TIER_OPTIONS.map((tier) => (
+              {tierOptions.map((tier) => (
                 <option key={tier} value={tier}>
                   {t(tier)}
                 </option>
               ))}
+              {fallbackTier.length > 0 && (
+                <option key={fallbackTier[0]} value={fallbackTier[0]} disabled>
+                  {t(fallbackTier[0])}
+                </option>
+              )}
             </select>
           </div>
         )

--- a/src/ui/features/rotation/buffChips.ts
+++ b/src/ui/features/rotation/buffChips.ts
@@ -4,6 +4,8 @@ export const PINNED_BUFF_HUES: Record<string, number> = {
   "Bleed Tick": 0,
   Smolder: 30,
   "Zenith Bar": 200,
+  "Bitter Season Tick": 100,
+  "Bitter Season Poison": 130,
 }
 
 export const FALLBACK_BUFF_HUES: readonly number[] = [

--- a/src/ui/features/skills/skills-tab/SkillsTab.tsx
+++ b/src/ui/features/skills/skills-tab/SkillsTab.tsx
@@ -158,7 +158,10 @@ const INNER_WAY_DISPLAY_NAMES: Record<string, string> = {
   swordHorizon: "Sword Horizon",
 }
 
+const INNER_WAY_DOT_TAG = "source:innerWayDot"
+
 function typeBadge(skill: Skill, t: (text: string) => string): string {
+  if (skill.tags?.includes(INNER_WAY_DOT_TAG)) return t("Inner Way - DoT")
   if (skill.skillType === "mystic") return t("Mystic Skill")
   if (skill.attributeAttack) return t(skill.attributeAttack)
   if (skill.skillType) return t(skill.skillType)

--- a/tests/engine/bitterSeason.test.ts
+++ b/tests/engine/bitterSeason.test.ts
@@ -1,0 +1,483 @@
+// Scoped to Bellstrike Umbra — see CLASSES.md
+import { describe, expect, it } from "vitest"
+import {
+  bitterSeasonDebuffId,
+  bitterSeasonEnvelopeWindows,
+  bitterSeasonPoisonSchedule,
+  bitterSeasonStackSchedule,
+  resolveBitterSeasonTuning,
+  BITTER_SEASON_MAX_STACKS,
+} from "../../src/engine/buffs/bitterSeason"
+import { allowedInnerWaysForClass, getSchool } from "../../src/engine/panel"
+import { builtinDebuffsForClass, builtinSkillsForClass } from "../../src/engine/builtinLibrary"
+import { runEngine } from "../../src/engine/dps"
+import { simulateTimeline } from "../../src/engine/timeline"
+import { defaultInputs, emptyMindMethod } from "../../src/engine/defaults"
+import { seedSkillFromBuiltin, makeSkill, makeHit } from "../../src/engine/skill"
+import { makeRotation, makeStep } from "../../src/engine/rotation"
+import { getMindMethodContributions } from "../../src/data/baseStats"
+import schools from "../../src/data/classes/schools.json"
+import type { Inputs } from "../../src/engine/types"
+
+const ALL_CLASSES = (schools as { id: string }[]).map((school) => school.id)
+
+describe("bitterSeasonPoisonSchedule", () => {
+  it("stays active for the poison duration after a single guaranteed proc", () => {
+    const schedule = bitterSeasonPoisonSchedule([0], 1, 5, 20, [])
+    expect(schedule.activeProbAtTime(1)).toBe(1)
+    expect(schedule.activeProbAtTime(4.9)).toBe(1)
+    expect(schedule.activeProbAtTime(6)).toBe(0)
+  })
+
+  it("a Zenith extension on an active poison pushes its end back 10 s", () => {
+    const schedule = bitterSeasonPoisonSchedule([0], 1, 5, 20, [3])
+    expect(schedule.activeProbAtTime(14.9)).toBe(1)
+    expect(schedule.activeProbAtTime(15.1)).toBe(0)
+  })
+
+  it("a Zenith extension after the poison has already expired does not reopen it", () => {
+    const schedule = bitterSeasonPoisonSchedule([0], 1, 5, 20, [6])
+    expect(schedule.activeProbAtTime(7)).toBe(0)
+  })
+
+  it("caps each Zenith extension's resulting remaining duration at 16 s, re-evaluated per extension", () => {
+    const schedule = bitterSeasonPoisonSchedule([0], 1, 5, 40, [4, 9, 14])
+    expect(schedule.activeProbAtTime(29.9)).toBe(1)
+    expect(schedule.activeProbAtTime(30.1)).toBe(0)
+  })
+
+  it("an empty extension list (no Zenith bar) gives the same curve as the unextended case", () => {
+    const schedule = bitterSeasonPoisonSchedule([0], 1, 5, 20, [])
+    expect(schedule.activeProbAtTime(1)).toBe(1)
+    expect(schedule.activeProbAtTime(4.9)).toBe(1)
+    expect(schedule.activeProbAtTime(6)).toBe(0)
+  })
+
+  it("returns a zero schedule and does not throw for empty hits / zero proc chance / non-positive duration", () => {
+    expect(bitterSeasonPoisonSchedule([], 1, 5, 20, []).activeProbAtTime(1)).toBe(0)
+    expect(bitterSeasonPoisonSchedule([0], 0, 5, 20, []).activeProbAtTime(1)).toBe(0)
+    expect(bitterSeasonPoisonSchedule([0], 1, 0, 20, []).activeProbAtTime(1)).toBe(0)
+    expect(bitterSeasonPoisonSchedule([0], 1, 5, 0, []).activeProbAtTime(1)).toBe(0)
+  })
+})
+
+describe("bitterSeasonPoisonSchedule.remainingActiveSecAtTime", () => {
+  it("counts down toward 0 as the poison's nominal duration elapses, assuming no further hits", () => {
+    const schedule = bitterSeasonPoisonSchedule([0], 1, 5, 20, [])
+    expect(schedule.remainingActiveSecAtTime(1)).toBe(4)
+    expect(schedule.remainingActiveSecAtTime(6)).toBe(0)
+  })
+
+  it("does not keep counting future hits — it decays even though the schedule as a whole is dense", () => {
+    const hits = [0, 0.5, 1, 1.5, 2]
+    const schedule = bitterSeasonPoisonSchedule(hits, 1, 5, 20, [])
+    // The last hit is at 2s, so from 2s the guaranteed window ends at 7s —
+    // "remaining" should reflect that, not the rest of the rotation.
+    expect(schedule.remainingActiveSecAtTime(2)).toBe(5)
+    expect(schedule.remainingActiveSecAtTime(8)).toBe(0)
+  })
+
+  it("reflects a Zenith extension that landed while the poison was active", () => {
+    const schedule = bitterSeasonPoisonSchedule([0], 1, 5, 20, [3])
+    expect(schedule.remainingActiveSecAtTime(4)).toBe(11)
+  })
+
+  it("is 0 for an empty/zero-guarded schedule", () => {
+    expect(bitterSeasonPoisonSchedule([], 1, 5, 20, []).remainingActiveSecAtTime(1)).toBe(0)
+  })
+})
+
+describe("bitterSeasonEnvelopeWindows", () => {
+  it("refreshes a single window across hits closer together than the poison duration", () => {
+    const windows = bitterSeasonEnvelopeWindows([0, 1, 2], 5, [])
+    expect(windows).toEqual([{ startSec: 0, endSec: 7 }])
+  })
+
+  it("splits into separate windows across a gap wider than the poison duration", () => {
+    const windows = bitterSeasonEnvelopeWindows([0, 20], 5, [])
+    expect(windows).toEqual([
+      { startSec: 0, endSec: 5 },
+      { startSec: 20, endSec: 25 },
+    ])
+  })
+
+  it("extends the window that is active when the extension lands", () => {
+    const windows = bitterSeasonEnvelopeWindows([0], 5, [3])
+    expect(windows).toEqual([{ startSec: 0, endSec: 15 }])
+  })
+
+  it("does not extend a window that has already closed", () => {
+    const windows = bitterSeasonEnvelopeWindows([0], 5, [6])
+    expect(windows).toEqual([{ startSec: 0, endSec: 5 }])
+  })
+
+  it("caps each extension's resulting remaining duration at 16 s, re-evaluated per extension — not a lifetime cap (Sword Horizon logic, not Bitter Season specific)", () => {
+    // 1 s left -> Zenith hit -> 11 s -> 5 s elapse -> 6 s left -> Zenith hit
+    // -> 16 s (capped) -> 5 s elapse -> 11 s left -> Zenith hit -> 16 s
+    // (capped again, since remaining had decayed back under 16 s by the time
+    // this hit landed).
+    const windows = bitterSeasonEnvelopeWindows([0], 5, [4, 9, 14])
+    // Poison starts at t=0 (ends at 5, i.e. "1 s left" at t=4).
+    // t=4: remaining 1 -> min(1+10,16)=11 -> end 15.
+    // t=9: remaining 6 -> min(6+10,16)=16 -> end 25.
+    // t=14: remaining 11 -> min(11+10,16)=16 -> end 30.
+    expect(windows).toEqual([{ startSec: 0, endSec: 30 }])
+  })
+
+  it("a further extension arriving while remaining is already at the 16 s cap is a no-op", () => {
+    const windows = bitterSeasonEnvelopeWindows([0], 5, [3, 8, 8])
+    // t=3: remaining 2 -> min(2+10,16)=12 -> end 15.
+    // t=8 (first): remaining 7 -> min(7+10,16)=16 -> end 24.
+    // t=8 (second, same instant): remaining already 16 -> min(16+10,16)=16 -> no change.
+    expect(windows).toEqual([{ startSec: 0, endSec: 24 }])
+  })
+
+  it("returns no windows for an empty hit list or a non-positive poison duration", () => {
+    expect(bitterSeasonEnvelopeWindows([], 5, [])).toEqual([])
+    expect(bitterSeasonEnvelopeWindows([0], 0, [])).toEqual([])
+  })
+})
+
+describe("bitterSeasonStackSchedule", () => {
+  it("reaches the 5-stack cap under a guaranteed proc and drops to 0 once the shared window lapses", () => {
+    const hits = [0, 0.1, 0.2, 0.3, 0.4]
+    const schedule = bitterSeasonStackSchedule(hits, 1, 20)
+    expect(schedule.expectedStacksAtTime(1)).toBe(5)
+    expect(schedule.maxStackProbAtTime(1)).toBe(1)
+    expect(schedule.expectedStacksAtTime(11)).toBe(0)
+  })
+
+  it("returns a zero schedule and does not throw for empty hits / zero proc chance / non-positive duration", () => {
+    expect(bitterSeasonStackSchedule([], 1, 20).expectedStacksAtTime(1)).toBe(0)
+    expect(bitterSeasonStackSchedule([0], 0, 20).expectedStacksAtTime(1)).toBe(0)
+    expect(bitterSeasonStackSchedule([0], 1, 0).expectedStacksAtTime(1)).toBe(0)
+  })
+})
+
+describe("resolveBitterSeasonTuning", () => {
+  it("is total for tier 0 (base values everywhere)", () => {
+    const tuning = resolveBitterSeasonTuning(0)
+    expect(tuning.procChance).toBe(0.1)
+    expect(tuning.defenseReductionPerStack).toBe(0.006)
+    expect(tuning.physPenetrationAtMaxStacks).toBe(0)
+  })
+
+  it("upgrades defenseReductionPerStack at tier 1, before proc chance or penetration upgrade", () => {
+    const tuning = resolveBitterSeasonTuning(1)
+    expect(tuning.procChance).toBe(0.1)
+    expect(tuning.defenseReductionPerStack).toBe(0.012)
+    expect(tuning.physPenetrationAtMaxStacks).toBe(0)
+  })
+
+  it("upgrades procChance at tier 4", () => {
+    expect(resolveBitterSeasonTuning(3).procChance).toBe(0.1)
+    expect(resolveBitterSeasonTuning(4).procChance).toBe(0.15)
+  })
+
+  it("upgrades physPenetrationAtMaxStacks only at tier 6", () => {
+    expect(resolveBitterSeasonTuning(5).physPenetrationAtMaxStacks).toBe(0)
+    expect(resolveBitterSeasonTuning(6).physPenetrationAtMaxStacks).toBe(0.1)
+  })
+})
+
+describe("Bitter Season panel-stat tier gating (getMindMethodContributions)", () => {
+  const contributionsAt = (stacks: string) =>
+    getMindMethodContributions({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: [
+        { name: "Bitter Season", stacks },
+        emptyMindMethod,
+        emptyMindMethod,
+        emptyMindMethod,
+      ] as Inputs["mindMethods"],
+    })
+
+  it("grants neither precision nor physBoost below tier 2", () => {
+    const below = contributionsAt("tier 1")
+    expect(below.precision ?? 0).toBe(0)
+    expect(below.physBoost ?? 0).toBe(0)
+  })
+
+  it("grants precision from tier 2, but not physBoost yet", () => {
+    const atTier2 = contributionsAt("tier 2")
+    expect(atTier2.precision).toBeCloseTo(0.069, 10)
+    expect(atTier2.physBoost ?? 0).toBe(0)
+  })
+
+  it("grants both precision and physBoost from tier 5 onward", () => {
+    for (const stacks of ["tier 5", "tier 6"]) {
+      const contributions = contributionsAt(stacks)
+      expect(contributions.precision).toBeCloseTo(0.069, 10)
+      expect(contributions.physBoost).toBeCloseTo(0.025, 10)
+    }
+  })
+
+  it("does not gate any other inner way's flat entry (Stone-Cutter's precision stays unconditional)", () => {
+    const contributions = getMindMethodContributions({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: [
+        { name: "Stone-Cutter", stacks: "tier 1" },
+        emptyMindMethod,
+        emptyMindMethod,
+        emptyMindMethod,
+      ] as Inputs["mindMethods"],
+    })
+    expect(contributions.precision).toBeCloseTo(0.059, 10)
+  })
+})
+
+describe("registry coverage — all eight classes (metadata only, no DPS)", () => {
+  it("every class's allowedInnerWaysForClass contains Bitter Season exactly once", () => {
+    for (const classId of ALL_CLASSES) {
+      const list = allowedInnerWaysForClass(classId)
+      expect(list.filter((name) => name === "Bitter Season")).toHaveLength(1)
+    }
+  })
+
+  it("every class resolves the debuff/skill id pair, matching dot shape and primary attribute", () => {
+    for (const classId of ALL_CLASSES) {
+      const debuff = builtinDebuffsForClass(classId).find(
+        (debuff) => debuff.id === bitterSeasonDebuffId(classId),
+      )
+      expect(debuff).toBeTruthy()
+      expect(debuff!.dot).toBeTruthy()
+
+      const skill = builtinSkillsForClass(classId).find(
+        (skill) => skill.id === `${classId}-bitter-season-tick`,
+      )
+      expect(skill).toBeTruthy()
+      expect(skill!.classId).toBe(classId)
+      expect(skill!.attributeAttack).toBe(getSchool(classId).primaryAttribute)
+
+      const hit = skill!.hits[0]
+      const dot = debuff!.dot!
+      expect(hit.physMultiplier).toBe(dot.physMultiplier)
+      expect(hit.attributeMultiplier).toBe(dot.attributeMultiplier)
+      expect(hit.physFixed).toBe(dot.physFixed)
+      expect(hit.attributeFixed).toBe(dot.attributeFixed)
+    }
+  })
+})
+
+const UMBRA_BASE_MIND_METHODS: Inputs["mindMethods"] = [
+  { name: "Sword Horizon", stacks: "tier 6" },
+  { name: "Wolfchaser's Art", stacks: "tier 6" },
+  { name: "Insightful Strike", stacks: "tier 6" },
+  { name: "", stacks: "" },
+]
+
+function withBitterSeasonAt(tier: "tier 5" | "tier 6"): Inputs["mindMethods"] {
+  return [
+    UMBRA_BASE_MIND_METHODS[0],
+    UMBRA_BASE_MIND_METHODS[1],
+    UMBRA_BASE_MIND_METHODS[2],
+    { name: "Bitter Season", stacks: tier },
+  ]
+}
+
+const DOT_ROW_NAME = "Bitter Season Tick (DoT)"
+
+describe("Bitter Season — Bellstrike Umbra engine integration", () => {
+  it("the built-in stand-in skill carries the source:innerWayDot tag, five hits, and elevatedAttributeMultiplier === false", () => {
+    const skill = builtinSkillsForClass("bellstrikeUmbra").find(
+      (skill) => skill.id === "bellstrikeUmbra-bitter-season-tick",
+    )
+    expect(skill).toBeTruthy()
+    expect(skill!.tags).toContain("source:innerWayDot")
+    expect(skill!.hits).toHaveLength(5)
+    expect(skill!.elevatedAttributeMultiplier).toBe(false)
+  })
+
+  it("selecting the inner way at tier 5 raises DPS and adds a Bitter Season Tick (DoT) row", () => {
+    const base = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: UMBRA_BASE_MIND_METHODS,
+    })
+    const withBitterSeason = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 5"),
+    })
+    expect(withBitterSeason.dps).toBeGreaterThan(base.dps)
+    const dotRow = withBitterSeason.perSkill.find((row) => row.name === DOT_ROW_NAME)
+    expect(dotRow).toBeTruthy()
+    expect(dotRow!.expectedDamage).toBeGreaterThan(0)
+  })
+
+  it("withholds Remaining while the poison is unlikely to be up yet (a single low-probability hit)", () => {
+    const soleHit = makeSkill("bellstrikeUmbra", {
+      name: "Solo Hit",
+      hits: [makeHit({ frame: 0, physMultiplier: 1 })],
+      castFrames: 300,
+    })
+    const pad = makeSkill("bellstrikeUmbra", { name: "Pad", castFrames: 300, hits: [makeHit()] })
+    const inputs: Inputs = {
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+      customSkills: [soleHit, pad],
+      activeCustomRotation: makeRotation("bellstrikeUmbra", {
+        name: "single-low-probability-hit",
+        steps: [
+          makeStep({ skillId: soleHit.id, hitCount: 1 }),
+          makeStep({ skillId: pad.id, hitCount: 1 }),
+        ],
+      }),
+    }
+    const result = simulateTimeline(inputs)
+    const chips = (result.casts ?? [])
+      .map((cast) => cast.buffs.find((buff) => buff.name === "Bitter Season Tick"))
+      .filter((chip): chip is NonNullable<typeof chip> => chip != null)
+    expect(chips.length).toBeGreaterThan(0)
+    // procChance at tier 6 is 0.15, well under the 0.5 display threshold, so
+    // the single hit never makes the poison likely enough to show a "Remaining".
+    for (const chip of chips) expect(chip.remainingSec).toBeUndefined()
+  })
+
+  it("the Bitter Season Tick chip's Remaining time never exceeds the 16 s Zenith-extension cap", () => {
+    const result = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+    })
+    const remainingValues = (result.casts ?? [])
+      .map((cast) => cast.buffs.find((buff) => buff.name === "Bitter Season Tick")?.remainingSec)
+      .filter((value): value is number => value != null)
+    expect(remainingValues.length).toBeGreaterThan(0)
+    for (const remaining of remainingValues) {
+      expect(remaining).toBeLessThanOrEqual(16)
+    }
+  })
+
+  it("tier 6 deals more damage than tier 5 (the physical-resistance node)", () => {
+    const tier5 = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 5"),
+    })
+    const tier6 = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+    })
+    expect(tier6.dps).toBeGreaterThan(tier5.dps)
+  })
+
+  it("suppresses the defense/penetration contribution (not the DoT) once the party-applied debuff is active", () => {
+    const withoutBitterSeason = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: UMBRA_BASE_MIND_METHODS,
+      shareDebuff5HenZhi: true,
+    })
+    const withBitterSeason = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+      shareDebuff5HenZhi: true,
+    })
+    for (const row of withoutBitterSeason.perSkill) {
+      const match = withBitterSeason.perSkill.find((candidateRow) => candidateRow.name === row.name)
+      expect(match).toBeTruthy()
+      expect(match!.expectedDamage).toBe(row.expectedDamage)
+    }
+  })
+
+  it("two identical runs produce identical dps (the schedule is seeded)", () => {
+    const inputs: Inputs = {
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+    }
+    const firstRun = runEngine(inputs)
+    const secondRun = runEngine(inputs)
+    expect(firstRun.dps).toBe(secondRun.dps)
+  })
+
+  it("the Rotation Editor casts carry a Bitter Season Poison chip with maxStacks 5 and stacks >= 1", () => {
+    const result = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+    })
+    const chip = result.casts
+      ?.flatMap((cast) => cast.buffs)
+      .find((chip) => chip.name === "Bitter Season Poison")
+    expect(chip).toBeTruthy()
+    expect(chip!.maxStacks).toBe(BITTER_SEASON_MAX_STACKS)
+    expect(chip!.stacks).toBeGreaterThanOrEqual(1)
+  })
+
+  it("the Bitter Season Poison chip carries no raw stat-effect entries, describing the mechanic in its own terms instead", () => {
+    const result = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+    })
+    const chip = result.casts
+      ?.flatMap((cast) => cast.buffs)
+      .find((chip) => chip.name === "Bitter Season Poison")
+    expect(chip).toBeTruthy()
+    expect(chip!.effects).toEqual([])
+    const description = chip!.description ?? ""
+    const defenseMentions = description.match(/target physical defense/g) ?? []
+    expect(defenseMentions.length).toBe(2)
+    expect(description).toContain("-10 target physical defense at 5/5 stacks (tier 6)")
+    expect(description).not.toContain("target physical resistance")
+    expect(description).not.toContain("Physical Penetration")
+    expect(description).not.toContain("phys.penetration")
+  })
+
+  it("scales the shown base defense percentage to the current stack count, not always the 5-stack cap", () => {
+    const result = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 5"),
+    })
+    const chips = (result.casts ?? [])
+      .flatMap((cast) => cast.buffs)
+      .filter((chip) => chip.name === "Bitter Season Poison")
+    expect(chips.length).toBeGreaterThan(0)
+    let sawBelowCap = false
+    for (const chip of chips) {
+      const description = chip.description ?? ""
+      const match = /at (\d)\/5 stacks: -(\d+)% target physical defense/.exec(description)
+      expect(match).toBeTruthy()
+      const [, stacksText, pctText] = match!
+      expect(Number(stacksText)).toBe(chip.stacks)
+      // Tier 5 already unlocks the tier-1 node (0.012/stack).
+      expect(Number(pctText)).toBe(Math.round(0.012 * chip.stacks * 100))
+      if (chip.stacks < BITTER_SEASON_MAX_STACKS) sawBelowCap = true
+    }
+    expect(sawBelowCap).toBe(true)
+  })
+
+  it("editing the stand-in skill's hits in the Skill Editor raises the DoT row's damage", () => {
+    const base = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+    })
+    const skill = builtinSkillsForClass("bellstrikeUmbra").find(
+      (skill) => skill.id === "bellstrikeUmbra-bitter-season-tick",
+    )!
+    const seeded = seedSkillFromBuiltin("bellstrikeUmbra", skill)
+    seeded.hits = seeded.hits.map((hit) => ({
+      ...hit,
+      physMultiplier: hit.physMultiplier * 3,
+      attributeMultiplier: hit.attributeMultiplier * 3,
+    }))
+    const bumped = runEngine({
+      ...defaultInputs,
+      classId: "bellstrikeUmbra",
+      mindMethods: withBitterSeasonAt("tier 6"),
+      customSkills: [seeded],
+    })
+    const baseDot = base.perSkill.find((row) => row.name === DOT_ROW_NAME)!.expectedDamage
+    const bumpedDot = bumped.perSkill.find((row) => row.name === DOT_ROW_NAME)!.expectedDamage
+    expect(bumpedDot).toBeGreaterThan(baseDot)
+  })
+})

--- a/tests/engine/darkFire.test.ts
+++ b/tests/engine/darkFire.test.ts
@@ -215,9 +215,48 @@ describe("Zenith detonation extends Smolder", () => {
         (ev) => ev.kind === "dot" && ev.skillName.includes("Smolder"),
       ).length
     }
+    // See `ZENITH_MAX_EXTENDED_DURATION_FRAMES` (builtinBuffs.ts). No further
+    // Smolder cast follows in this rotation, so once the window closes a
+    // later detonation's extend-only trigger finds nothing active to extend.
     const noZenith = ticksFor(5)
     const oneZenith = ticksFor(6)
-    expect(oneZenith - noZenith).toBe(20)
-    expect(ticksFor(12) - oneZenith).toBe(20)
+    expect(oneZenith - noZenith).toBe(11)
+    expect(ticksFor(12) - oneZenith).toBe(0)
+  })
+
+  it("never shortens an already-longer window — a Zenith detonation can only extend, never truncate", () => {
+    const swordHorizon: Inputs["mindMethods"] = [
+      { name: "Sword Horizon", stacks: "tier 6" },
+      { name: "Wolfchaser's Art", stacks: "tier 6" },
+      { name: "Insightful Strike", stacks: "tier 6" },
+      { name: "Morale Chant", stacks: "tier 6" },
+    ]
+    const detonation = skillNamed("Bleed Detonation")
+    const smolder = skillNamed(TWO_HITS)
+    const filler = skillNamed("Soaring")
+    const ticksFor = (smolderCasts: number, detonations: number) => {
+      const steps: ReturnType<typeof makeStep>[] = []
+      for (let i = 0; i < smolderCasts; i++)
+        steps.push(makeStep({ skillId: smolder.id, hitCount: smolder.hits.length }))
+      for (let i = 0; i < detonations; i++)
+        steps.push(makeStep({ skillId: detonation.id, hitCount: 1 }))
+      for (let i = 0; i < 30; i++)
+        steps.push(makeStep({ skillId: filler.id, hitCount: filler.hits.length }))
+      const inputs: Inputs = {
+        ...defaultInputs,
+        classId: CLASS,
+        mindMethods: swordHorizon,
+        activeCustomRotation: makeRotation(CLASS, {
+          name: `zenith-${smolderCasts}-${detonations}`,
+          steps,
+        }),
+      }
+      return simulateTimeline(inputs).timeline!.filter(
+        (ev) => ev.kind === "dot" && ev.skillName.includes("Smolder"),
+      ).length
+    }
+    for (const smolderCasts of [1, 2, 3, 4]) {
+      expect(ticksFor(smolderCasts, 6)).toBeGreaterThanOrEqual(ticksFor(smolderCasts, 5))
+    }
   })
 })

--- a/tests/engine/insightfulStrike.test.ts
+++ b/tests/engine/insightfulStrike.test.ts
@@ -60,8 +60,8 @@ describe("Insightful Strike — panel stat rework", () => {
       mingInputs([emptyMindMethod, emptyMindMethod, emptyMindMethod, emptyMindMethod]),
     )
     const d = (p: string) => (withNS[p] ?? 0) - (without[p] ?? 0)
-    expect(d("phys.min")).toBeCloseTo(21.3, 6)
-    expect(d("phys.max")).toBeCloseTo(42.5, 6)
+    expect(d("phys.min")).toBeCloseTo(22.3, 6)
+    expect(d("phys.max")).toBeCloseTo(44.7, 6)
     expect(d("phys.penetration")).toBeCloseTo(0.051, 6)
     expect(d("directAffinityRate")).toBeCloseTo(0, 6)
     expect(d("bellstrike.min")).toBeCloseTo(0, 6)

--- a/tests/engine/skillDataFiles.test.ts
+++ b/tests/engine/skillDataFiles.test.ts
@@ -7,7 +7,7 @@ import {
 
 // Scoped to Bellstrike Umbra — see CLAUDE.md § "Implemented classes".
 const EXPECTED_COUNTS: Record<string, number> = {
-  bellstrikeUmbra: 49,
+  bellstrikeUmbra: 50,
 }
 
 describe("per-class skill file coverage", () => {

--- a/tests/migrations/profileV6BitterSeasonTiers.test.ts
+++ b/tests/migrations/profileV6BitterSeasonTiers.test.ts
@@ -1,0 +1,187 @@
+// Additive, no version bump — see MIGRATIONS.md. Widening Bitter Season's
+// tier dropdown to all six tiers (previously only tier 5 / tier 6) never
+// needed a migration: `hydrateInputs` never validated the `stacks` string
+// against an allowlist, so a value the UI could not have produced before
+// (e.g. "tier 3") already round-tripped untouched, and continues to.
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { loadProfiles } from "../../src/storage"
+import { runEngine } from "../../src/engine/dps"
+import { applyArmorSet, applyBowSet } from "../../src/engine/panel"
+import { withDerivedStats } from "../../src/engine/derivedInputs"
+import { defaultInputs } from "../../src/engine/defaults"
+import { LATEST_PROFILES_VERSION } from "../../src/migrations"
+import { kvStore } from "../../src/kvStore"
+import type { Inputs, StoredProfile } from "../../src/engine/types"
+import legacyProfileFile from "./testProfiles/profile-v6.json"
+
+const PROFILES_KEY = "wwm.profiles"
+
+type LegacyFile = { v: number; profile: StoredProfile }
+const LEGACY = legacyProfileFile as unknown as LegacyFile
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function writeProfile(profile: StoredProfile): void {
+  localStorage.setItem(
+    PROFILES_KEY,
+    JSON.stringify({ v: LEGACY.v, profiles: [profile], activeId: profile.id }),
+  )
+}
+
+function loadOne(): StoredProfile {
+  const { profiles } = loadProfiles()
+  expect(profiles).toHaveLength(1)
+  return profiles[0]
+}
+
+function withBitterSeasonAtTier3(profile: StoredProfile): StoredProfile {
+  return {
+    ...profile,
+    inputs: {
+      ...profile.inputs,
+      mindMethods: [
+        { name: "Bitter Season", stacks: "tier 3" },
+        profile.inputs.mindMethods[1],
+        profile.inputs.mindMethods[2],
+        profile.inputs.mindMethods[3],
+      ] as StoredProfile["inputs"]["mindMethods"],
+    },
+  }
+}
+
+describe("profile-v6 fixture is already at the latest version", () => {
+  it("is v6, matching LATEST_PROFILES_VERSION", () => {
+    expect(LEGACY.v).toBe(6)
+    expect(LEGACY.profile.inputs.classId).toBe("bellstrikeUmbra")
+  })
+})
+
+describe("profile-v6 (real fixture, unmodified) survives the widened tier dropdown untouched", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("round-trips its mind methods exactly and still computes positive DPS", () => {
+    writeProfile(clone(LEGACY.profile))
+    const after = loadOne()
+    expect(after.inputs.mindMethods).toEqual(LEGACY.profile.inputs.mindMethods)
+    const result = runEngine(applyBowSet(applyArmorSet(withDerivedStats(after.inputs))))
+    expect(result.dps).toBeGreaterThan(0)
+  })
+})
+
+describe("profile-v6 with a slot at a tier only reachable via the widened Bitter Season dropdown", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("survives hydration unchanged — 'tier 3' is not clamped or cleared", () => {
+    writeProfile(withBitterSeasonAtTier3(clone(LEGACY.profile)))
+    const after = loadOne()
+    expect(after.inputs.mindMethods[0]).toEqual({ name: "Bitter Season", stacks: "tier 3" })
+  })
+
+  it("still computes a valid, positive-DPS run with the rest of the real build intact", () => {
+    writeProfile(withBitterSeasonAtTier3(clone(LEGACY.profile)))
+    const after = loadOne()
+    const result = runEngine(applyBowSet(applyArmorSet(withDerivedStats(after.inputs))))
+    expect(result.dps).toBeGreaterThan(0)
+  })
+
+  it("is idempotent across repeated loads", () => {
+    writeProfile(withBitterSeasonAtTier3(clone(LEGACY.profile)))
+    const once = loadOne()
+    writeProfile(clone(once))
+    expect(loadOne()).toEqual(once)
+  })
+})
+
+// Additive, no version bump — see MIGRATIONS.md. Widening the inner-way NAME
+// allowlist (`allowedMindMethods` in schools.json) to include Bitter Season on
+// every class can only make previously-illegal slot values legal, never the
+// reverse.
+describe("Bitter Season inner way — widened allowlist round-trips (no version bump)", () => {
+  beforeEach(() => {
+    try {
+      kvStore.remove(PROFILES_KEY)
+    } catch {}
+  })
+  afterEach(() => {
+    try {
+      kvStore.remove(PROFILES_KEY)
+    } catch {}
+  })
+
+  function withBitterSeasonSlot(classId: string): Inputs {
+    return {
+      ...defaultInputs,
+      classId,
+      mindMethods: [
+        { name: "Bitter Season", stacks: "tier 6" },
+        { name: "", stacks: "" },
+        { name: "", stacks: "" },
+        { name: "", stacks: "" },
+      ] as Inputs["mindMethods"],
+    }
+  }
+
+  it("a Bellstrike Umbra profile holding Bitter Season survives hydration unchanged", () => {
+    const inputs = withBitterSeasonSlot("bellstrikeUmbra")
+    kvStore.set(
+      PROFILES_KEY,
+      JSON.stringify({
+        v: LATEST_PROFILES_VERSION,
+        profiles: [{ id: "p1", name: "Profile", inputs }],
+        activeId: "p1",
+      }),
+    )
+
+    const { profiles } = loadProfiles()
+    expect(profiles[0].inputs.mindMethods[0]).toEqual({ name: "Bitter Season", stacks: "tier 6" })
+  })
+
+  it("survives hydration unchanged on a non-Umbra class too (inner ways are global)", () => {
+    const inputs = withBitterSeasonSlot("silkbindJade")
+    kvStore.set(
+      PROFILES_KEY,
+      JSON.stringify({
+        v: LATEST_PROFILES_VERSION,
+        profiles: [{ id: "p1", name: "Profile", inputs }],
+        activeId: "p1",
+      }),
+    )
+
+    const { profiles } = loadProfiles()
+    expect(profiles[0].inputs.mindMethods[0]).toEqual({ name: "Bitter Season", stacks: "tier 6" })
+  })
+
+  it("is idempotent across repeated hydration", () => {
+    const inputs = withBitterSeasonSlot("bellstrikeUmbra")
+    kvStore.set(
+      PROFILES_KEY,
+      JSON.stringify({
+        v: LATEST_PROFILES_VERSION,
+        profiles: [{ id: "p1", name: "Profile", inputs }],
+        activeId: "p1",
+      }),
+    )
+
+    const first = loadProfiles()
+    kvStore.set(
+      PROFILES_KEY,
+      JSON.stringify({
+        v: LATEST_PROFILES_VERSION,
+        profiles: first.profiles,
+        activeId: first.activeId,
+      }),
+    )
+    const second = loadProfiles()
+    expect(second.profiles[0].inputs.mindMethods[0]).toEqual({
+      name: "Bitter Season",
+      stacks: "tier 6",
+    })
+  })
+
+  it("leaves the default build's mind-method slots untouched", () => {
+    const { profiles } = loadProfiles()
+    expect(profiles[0].inputs.mindMethods).toEqual(defaultInputs.mindMethods)
+  })
+})

--- a/tests/migrations/testProfiles/profile-v6.json
+++ b/tests/migrations/testProfiles/profile-v6.json
@@ -1,0 +1,776 @@
+{
+  "v": 6,
+  "profile": {
+    "id": "pr-ms9h5obb-umkihk-2",
+    "name": "Mizukee",
+    "inputs": {
+      "classId": "bellstrikeUmbra",
+      "breakthrough": 16,
+      "allDamageBoost": 0,
+      "mindMethods": [
+        {
+          "name": "Sword Horizon",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Wolfchaser's Art",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Insightful Strike",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Morale Chant",
+          "stacks": "tier 6"
+        }
+      ],
+      "food": true,
+      "tianGongElement": "fire",
+      "set": "Hawking",
+      "shareDebuff5HenZhi": false,
+      "shareEasyHurt": false,
+      "bowSet": "affinity",
+      "arsenal": "bellstrike",
+      "dummyMode": true,
+      "rotation": null,
+      "activeCustomRotation": null,
+      "inventory": [
+        {
+          "id": "gp-ms9h9cgs-269r62-1",
+          "slot": "leftWeapon",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 65,
+          "maxPhys": 151,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Void Attack",
+              "value": 37.3,
+              "retuned": false
+            },
+            {
+              "word": "Max Void Attack",
+              "value": 39.2,
+              "retuned": false
+            },
+            {
+              "word": "Sword Martial Boost",
+              "value": 0.058,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 73.1,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 45.6,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.107,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hahfr-5uvjeo-2",
+          "slot": "rightWeapon",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 59,
+          "maxPhys": 136,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 70.4,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 45.9,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.041,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 44.4,
+              "retuned": true
+            },
+            {
+              "word": "Max Phys",
+              "value": 73.1,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hccrh-6y8qcx-3",
+          "slot": "disc",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 86,
+          "maxPhys": 0,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 63.5,
+              "retuned": false
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 34,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 60,
+              "retuned": false
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.024,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hdmcx-30tt7f-4",
+          "slot": "pendant",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 116,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 70.4,
+              "retuned": false
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.02,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 41.8,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 64.5,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 44.8,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.093,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hfcpj-r5uvyj-5",
+          "slot": "helm",
+          "level": 91,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4614,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.035,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.034,
+              "retuned": false
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 34.4,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.069,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 63.8,
+              "retuned": true
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.05,
+          "relayed": false
+        },
+        {
+          "id": "gp-ms9hh82z-aba86x-6",
+          "slot": "armor",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 9227,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 40.4,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 63.8,
+              "retuned": true
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": false
+            },
+            {
+              "word": "Max Bamboocut",
+              "value": 36.2,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.052,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hiw6b-wxbo56-7",
+          "slot": "greaves",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4153,
+          "physDef": 32,
+          "words": [
+            {
+              "word": "Power",
+              "value": 44.6,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 70.5,
+              "retuned": false
+            },
+            {
+              "word": "Damage VS Boss %",
+              "value": 0.03,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": true
+            },
+            {
+              "word": "Power",
+              "value": 44.6,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.058,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hkp0q-4bwvf2-8",
+          "slot": "bracer",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4153,
+          "physDef": 16,
+          "words": [
+            {
+              "word": "Power",
+              "value": 38,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.07,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 60,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 38,
+              "retuned": true
+            },
+            {
+              "word": "Power",
+              "value": 38,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.05,
+          "relayed": true
+        },
+        {
+          "id": "gp-msausuvc-l1u40i-4",
+          "slot": "armor",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 9227,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.043,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.044,
+              "retuned": true
+            },
+            {
+              "word": "Min Silkbind",
+              "value": 44.2,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 68.6,
+              "retuned": false
+            },
+            {
+              "word": "Single-Target Mystic Skill DMG Boost",
+              "value": 0.078,
+              "retuned": false
+            }
+          ],
+          "attunement": "",
+          "attunementValue": 0,
+          "relayed": false
+        },
+        {
+          "id": "gp-mscbnonp-1zyh3n-1",
+          "slot": "helm",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4614,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": true
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 36.2,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 70.8,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 44.8,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.055,
+          "relayed": true
+        },
+        {
+          "id": "gp-mshtzfiu-b8llz0-2",
+          "slot": "disc",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 86,
+          "maxPhys": 0,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 68.2,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 45.5,
+              "retuned": true
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.032,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 76,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.07,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": false
+        }
+      ],
+      "equipped": {
+        "leftWeapon": "gp-ms9h9cgs-269r62-1",
+        "rightWeapon": "gp-ms9hahfr-5uvjeo-2",
+        "disc": "gp-ms9hccrh-6y8qcx-3",
+        "pendant": "gp-ms9hdmcx-30tt7f-4",
+        "helm": "gp-mscbnonp-1zyh3n-1",
+        "armor": "gp-ms9hh82z-aba86x-6",
+        "greaves": "gp-ms9hiw6b-wxbo56-7",
+        "bracer": "gp-ms9hkp0q-4bwvf2-8"
+      },
+      "martialArtsTalents": [
+        {
+          "id": "default-bellstrikeUmbra-0",
+          "name": "Affinity Rate UP",
+          "enabled": true,
+          "stat": "affinityRate",
+          "maxBonus": 0.043,
+          "scalesWith": "power",
+          "scaleMax": 280
+        },
+        {
+          "id": "default-bellstrikeUmbra-1",
+          "name": "Physical Attack UP",
+          "enabled": true,
+          "stat": "maxPhys",
+          "maxBonus": 73.9,
+          "scalesWith": "power",
+          "scaleMax": 280
+        },
+        {
+          "id": "default-bellstrikeUmbra-2",
+          "name": "Sword Bellstrike Attack Min",
+          "enabled": true,
+          "stat": "minBellstrike",
+          "maxBonus": 98,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-3",
+          "name": "Sword Bellstrike Attack Max",
+          "enabled": true,
+          "stat": "maxBellstrike",
+          "maxBonus": 196,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-4",
+          "name": "Spear Bellstrike Attack Min",
+          "enabled": true,
+          "stat": "minBellstrike",
+          "maxBonus": 98,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-5",
+          "name": "Spear Bellstrike Attack Max",
+          "enabled": true,
+          "stat": "maxBellstrike",
+          "maxBonus": 196,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-6",
+          "name": "Bellstrike Penetration Scale",
+          "enabled": true,
+          "stat": "bellstrikePenetration",
+          "maxBonus": 0.22,
+          "scalesWith": "bellstrike.max",
+          "scaleMax": 655
+        },
+        {
+          "id": "default-bellstrikeUmbra-7",
+          "name": "Attribute Damage Scale",
+          "enabled": true,
+          "stat": "attributeDamage",
+          "maxBonus": 0.11,
+          "scalesWith": "bellstrike.max",
+          "scaleMax": 655
+        }
+      ],
+      "oddities": {
+        "Qinghe": [
+          {
+            "id": 1,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Kaifeng": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 7,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 8,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 9,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 10,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Hexi": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Kaifeng Palace": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Hidden Mountain: Suixiang": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ]
+      },
+      "combatSettings": {
+        "qiBreak": {
+          "enabled": true,
+          "startSec": 25,
+          "durationSec": 10
+        },
+        "dragonsBreath": false,
+        "healerBuff": false,
+        "breakExtension": false,
+        "revelryScript": false
+      },
+      "selectedBuiltinRotationId": "builtin-bellstrikeUmbra-36-bbs"
+    }
+  }
+}

--- a/tests/ui/buffChips.test.ts
+++ b/tests/ui/buffChips.test.ts
@@ -26,19 +26,23 @@ function cast(index: number, timeSec: number, buffs: CastBuffTag[]): RotationCas
 }
 
 describe("buffChipHue", () => {
-  it("returns the pinned hues for Bleed Tick / Smolder / Zenith Bar", () => {
+  it("returns the pinned hues for Bleed Tick / Smolder / Zenith Bar / Bitter Season Tick / Bitter Season Poison", () => {
     expect(buffChipHue("Bleed Tick")).toBe(0)
     expect(buffChipHue("Smolder")).toBe(30)
     expect(buffChipHue("Zenith Bar")).toBe(200)
+    expect(buffChipHue("Bitter Season Tick")).toBe(100)
+    expect(buffChipHue("Bitter Season Poison")).toBe(130)
   })
 
-  it("the three pinned hues are distinct", () => {
+  it("the five pinned hues are distinct", () => {
     const hues = new Set([
       buffChipHue("Bleed Tick"),
       buffChipHue("Smolder"),
       buffChipHue("Zenith Bar"),
+      buffChipHue("Bitter Season Tick"),
+      buffChipHue("Bitter Season Poison"),
     ])
-    expect(hues.size).toBe(3)
+    expect(hues.size).toBe(5)
   })
 
   it("is stable for an unpinned name across calls and always lands in FALLBACK_BUFF_HUES", () => {
@@ -61,7 +65,7 @@ describe("buffChipHue", () => {
   })
 
   it("never returns a pinned hue for an unpinned name", () => {
-    const pinned = new Set([0, 30, 200])
+    const pinned = new Set([0, 30, 200, 100, 130])
     const names = [
       "River Flow",
       "Soul Shaken",

--- a/tests/ui/innerWaySlots.test.ts
+++ b/tests/ui/innerWaySlots.test.ts
@@ -5,12 +5,13 @@ import { defaultInputs } from "../../src/engine/defaults"
 import type { Inputs } from "../../src/engine/types"
 
 describe("allowedInnerWaysForClass", () => {
-  it("is exactly the four Bellstrike Umbra inner ways, signature first", () => {
+  it("is exactly the five Bellstrike Umbra inner ways, signature first", () => {
     expect(allowedInnerWaysForClass("bellstrikeUmbra")).toEqual([
       "Sword Horizon",
       "Wolfchaser's Art",
       "Insightful Strike",
       "Morale Chant",
+      "Bitter Season",
     ])
   })
 


### PR DESCRIPTION
Adds a new global inner way, selectable in all four Overview mind-method slots for every class: +6.9% precision at tier 2, +2.5% physical damage boost at tier 5, and a poison proc (10% chance per damaging hit, 15% from tier 4) that reduces the target's physical defense per stack (0.6%, 1.2% from tier 1, stacking to 5, 10s shared duration) — plus, at tier 6 with 5 stacks, an additional -10 target physical resistance (modelled as +10 player physical penetration, since target pen resistance is zero for every target and there's no target-resistance stat key to spend adding one).

Bitter Season Tick is a universal DoT stand-in skill instantiated per class and paired with a debuff entry in every class's debuff bucket, so its per-tick coefficients are editable in the Skill Editor exactly like Bleed Tick; it's badged "Inner Way - DoT" there instead of falling back to the class's attribute. The poison's stacking and uptime are seeded whole-rotation Monte-Carlo schedules (`buffs/bitterSeason.ts`), joining the existing Hawkwing / Concentration / Morale Chant schedules, since a stochastic per-hit proc plus a stacking/decaying target-defense reduction isn't expressible as a static buff/debuff. Ticks are weighted by the modelled uptime on a continuous window bounded to a guaranteed-proc envelope, so no expected damage is lost by not ticking outside it. Bitter Season is the only inner way with all six tiers selectable (every other inner way offers two) since its ladder has a distinct node at every tier, so the panel-stat table gates its two keys to a minimum tier instead of applying them unconditionally.

A Sword Horizon Zenith detonation extends the poison the same way it already extends Smolder, sharing one capped extension rule (`ZENITH_MAX_EXTENDED_DURATION_FRAMES`, `builtinBuffs.ts`): a detonation always attempts its full +10s, but the resulting remaining duration never exceeds 16s, and a detonation can never shorten a window that's already longer than that. When the party-applied "Bitter Season (from a teammate)" shared debuff is already active, the inner way's own defense/penetration contribution is suppressed — both represent the same fully-stacked debuff — while the poison DoT damage is unaffected.

The Rotation Editor's Buffs column shows a "Bitter Season Poison" chip with the probable stack count out of 5, the mechanic's own numbers scaled to that stack count (not always the 5-stack cap), and the modelled poison uptime; "Bitter Season Tick"/"Bitter Season Poison" get pinned chip hues. The Encounter Settings shared-debuff toggle is relabeled "Bitter Season (from a teammate)" to avoid confusion with the new selectable inner way.

Also included: a rebalance of four existing inner ways' panel stats (Sword Horizon, Wolfchaser's Art, Morale Chant, Insightful Strike) and removal of the unused "Unnamed Mind Method" placeholder entry, as a separate commit.

No migration needed: widening `allowedMindMethods` can only make previously-illegal mind-method values legal, never the reverse, and every new/changed panel-stat number is derived at load time (`withDerivedStats`) rather than persisted — a stored profile can't hold a stale copy of any of it. `tests/migrations/profileV6BitterSeasonTiers.test.ts` guards this against a real captured profile, including the widened six-tier dropdown.