### PR TITLE
Add Stonesplit Might support

### DIFF
--- a/src/data/baseStats/classSkillBoosts.json
+++ b/src/data/baseStats/classSkillBoosts.json
@@ -56,5 +56,63 @@
       "scalesWith": "bellstrike.max",
       "scaleMax": 655
     }
+  ],
+  "stonesplitPower": [
+    {
+      "skill": "Affinity Rate UP",
+      "stat": "affinityRate",
+      "maxBonus": 0.043,
+      "scalesWith": "power",
+      "scaleMax": 280
+    },
+    {
+      "skill": "Physical Attack UP",
+      "stat": "maxPhys",
+      "maxBonus": 73.9,
+      "scalesWith": "power",
+      "scaleMax": 280
+    },
+    {
+      "skill": "Mo Blade Stonesplit Attack Min",
+      "stat": "minStonesplit",
+      "maxBonus": 98,
+      "scalesWith": "power",
+      "scaleMax": 0
+    },
+    {
+      "skill": "Mo Blade Stonesplit Attack Max",
+      "stat": "maxStonesplit",
+      "maxBonus": 196,
+      "scalesWith": "power",
+      "scaleMax": 0
+    },
+    {
+      "skill": "Spear Stonesplit Attack Min",
+      "stat": "minStonesplit",
+      "maxBonus": 98,
+      "scalesWith": "power",
+      "scaleMax": 0
+    },
+    {
+      "skill": "Spear Stonesplit Attack Max",
+      "stat": "maxStonesplit",
+      "maxBonus": 196,
+      "scalesWith": "power",
+      "scaleMax": 0
+    },
+    {
+      "skill": "Stonesplit Penetration Scale",
+      "stat": "stonesplitPenetration",
+      "maxBonus": 0.22,
+      "scalesWith": "stonesplit.max",
+      "scaleMax": 655
+    },
+    {
+      "skill": "Attribute Damage Scale",
+      "stat": "attributeDamage",
+      "maxBonus": 0.11,
+      "scalesWith": "stonesplit.max",
+      "scaleMax": 655
+    }
   ]
 }

--- a/src/data/baseStats/mindMethodPanelStats.json
+++ b/src/data/baseStats/mindMethodPanelStats.json
@@ -8,7 +8,7 @@
     "critDamageBoost": 0.044
   },
   "Echoing Mountains": {
-    "critRate": 0.073,
+    "critRate": 0.086,
     "critDamageBoost": 0.044
   },
   "Forgotten River Echo": {
@@ -24,7 +24,7 @@
     "directCritRate": 0.046
   },
   "Mighty Song": {
-    "affinityRate": 0.033,
+    "affinityRate": 0.039,
     "affinityDamageBoost": 0.052
   },
   "Thousand Mountain Law": {
@@ -67,8 +67,8 @@
     "directCritRate": 0.046
   },
   "Endurance Doctrine": {
-    "primaryAttr.max": 21.7,
-    "primaryAttr.min": 10.9,
+    "primaryAttr.max": 25.3,
+    "primaryAttr.min": 12.7,
     "primaryAttr.penetration": 0.06
   },
   "Insightful Strike": {

--- a/src/data/classes/retunementPools.ts
+++ b/src/data/classes/retunementPools.ts
@@ -14,9 +14,14 @@ const BAMBOOCUT_POOL: RetunementPool = {
   stats: ["Momentum", "Agility", "Max Bamboocut", "Min Phys", "Max Phys", "Crit"],
 }
 
+const STONESPLIT_POOL: RetunementPool = {
+  stats: ["Max Phys", "Power", "Momentum", "Max Stonesplit", "Min Stonesplit", "Crit"],
+}
+
 export const RETUNEMENT_POOLS: Record<string, RetunementPool> = {
   bellstrikeRainbow: BELLSTRIKE_POOL,
   bellstrikeUmbra: BELLSTRIKE_POOL,
+  stonesplitPower: STONESPLIT_POOL,
   bamboocutWindTwinblade: BAMBOOCUT_POOL,
   bamboocutDust: BAMBOOCUT_POOL,
 }

--- a/src/data/classes/schools.json
+++ b/src/data/classes/schools.json
@@ -59,9 +59,9 @@
   },
   {
     "id": "stonesplitPower",
-    "cn": "Stonesplit Power",
-    "en": "Stonesplit Power",
-    "displayName": "Stonesplit Power",
+    "cn": "Stonesplit Might",
+    "en": "Stonesplit Might",
+    "displayName": "Stonesplit Might",
     "primaryAttribute": "Stonesplit",
     "attributeMultiplier": 51.5,
     "permanentBuffs": ["Modao Charge Boost"],
@@ -76,7 +76,7 @@
       "Bitter Season"
     ],
     "classBuffs": [],
-    "weapons": ["Modao", "Spear"],
+    "weapons": ["Mo Blade", "Stormbreaker Spear"],
     "rotations": ["6× Mountain-River Speed"]
   },
   {

--- a/src/data/skills/stonesplit-power/mobladeheavycharge-1bw-cancel.json
+++ b/src/data/skills/stonesplit-power/mobladeheavycharge-1bw-cancel.json
@@ -11,20 +11,20 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 2.8945,
-      "attributeMultiplier": 4.3417,
-      "physFixed": 668.5,
-      "attributeFixed": 373.5,
+      "physMultiplier": 2.89475,
+      "attributeMultiplier": 4.3421,
+      "physFixed": 800.5,
+      "attributeFixed": 436,
       "extraCritDamage": 0,
       "triggers": []
     },
     {
       "id": "hit-1",
       "frame": 88,
-      "physMultiplier": 2.8945,
-      "attributeMultiplier": 4.3417,
-      "physFixed": 668.5,
-      "attributeFixed": 373.5,
+      "physMultiplier": 2.89475,
+      "attributeMultiplier": 4.3421,
+      "physFixed": 800.5,
+      "attributeFixed": 436,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/mobladeheavycharge-1bw-perception-cancel.json
+++ b/src/data/skills/stonesplit-power/mobladeheavycharge-1bw-perception-cancel.json
@@ -11,20 +11,20 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 2.8945,
-      "attributeMultiplier": 4.3417,
-      "physFixed": 668.5,
-      "attributeFixed": 373.5,
+      "physMultiplier": 2.89475,
+      "attributeMultiplier": 4.3421,
+      "physFixed": 800.5,
+      "attributeFixed": 436,
       "extraCritDamage": 0,
       "triggers": []
     },
     {
       "id": "hit-1",
       "frame": 33,
-      "physMultiplier": 2.8945,
-      "attributeMultiplier": 4.3417,
-      "physFixed": 668.5,
-      "attributeFixed": 373.5,
+      "physMultiplier": 2.89475,
+      "attributeMultiplier": 4.3421,
+      "physFixed": 800.5,
+      "attributeFixed": 436,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/mobladeheavycharge-1bw-perception.json
+++ b/src/data/skills/stonesplit-power/mobladeheavycharge-1bw-perception.json
@@ -11,20 +11,20 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 2.8945,
-      "attributeMultiplier": 4.3417,
-      "physFixed": 668.5,
-      "attributeFixed": 373.5,
+      "physMultiplier": 2.89475,
+      "attributeMultiplier": 4.3421,
+      "physFixed": 800.5,
+      "attributeFixed": 436,
       "extraCritDamage": 0,
       "triggers": []
     },
     {
       "id": "hit-1",
       "frame": 52,
-      "physMultiplier": 2.8945,
-      "attributeMultiplier": 4.3417,
-      "physFixed": 668.5,
-      "attributeFixed": 373.5,
+      "physMultiplier": 2.89475,
+      "attributeMultiplier": 4.3421,
+      "physFixed": 800.5,
+      "attributeFixed": 436,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/mobladeheavycharge-1bw.json
+++ b/src/data/skills/stonesplit-power/mobladeheavycharge-1bw.json
@@ -11,20 +11,20 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 2.8945,
-      "attributeMultiplier": 4.3417,
-      "physFixed": 668.5,
-      "attributeFixed": 373.5,
+      "physMultiplier": 2.89475,
+      "attributeMultiplier": 4.3421,
+      "physFixed": 800.5,
+      "attributeFixed": 436,
       "extraCritDamage": 0,
       "triggers": []
     },
     {
       "id": "hit-1",
       "frame": 113,
-      "physMultiplier": 2.8945,
-      "attributeMultiplier": 4.3417,
-      "physFixed": 668.5,
-      "attributeFixed": 373.5,
+      "physMultiplier": 2.89475,
+      "attributeMultiplier": 4.3421,
+      "physFixed": 800.5,
+      "attributeFixed": 436,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/mobladeheavycharge-2bw-cancel.json
+++ b/src/data/skills/stonesplit-power/mobladeheavycharge-2bw-cancel.json
@@ -11,20 +11,20 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 3.6181,
-      "attributeMultiplier": 5.42715,
-      "physFixed": 835.5,
-      "attributeFixed": 467,
+      "physMultiplier": 3.6184,
+      "attributeMultiplier": 5.42765,
+      "physFixed": 1001,
+      "attributeFixed": 545,
       "extraCritDamage": 0,
       "triggers": []
     },
     {
       "id": "hit-1",
       "frame": 88,
-      "physMultiplier": 3.6181,
-      "attributeMultiplier": 5.42715,
-      "physFixed": 835.5,
-      "attributeFixed": 467,
+      "physMultiplier": 3.6184,
+      "attributeMultiplier": 5.42765,
+      "physFixed": 1001,
+      "attributeFixed": 545,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/mobladeheavycharge-2bw-perception-cancel.json
+++ b/src/data/skills/stonesplit-power/mobladeheavycharge-2bw-perception-cancel.json
@@ -11,20 +11,20 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 3.6181,
-      "attributeMultiplier": 5.42715,
-      "physFixed": 835.5,
-      "attributeFixed": 467,
+      "physMultiplier": 3.6184,
+      "attributeMultiplier": 5.42765,
+      "physFixed": 1001,
+      "attributeFixed": 545,
       "extraCritDamage": 0,
       "triggers": []
     },
     {
       "id": "hit-1",
       "frame": 33,
-      "physMultiplier": 3.6181,
-      "attributeMultiplier": 5.42715,
-      "physFixed": 835.5,
-      "attributeFixed": 467,
+      "physMultiplier": 3.6184,
+      "attributeMultiplier": 5.42765,
+      "physFixed": 1001,
+      "attributeFixed": 545,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/mobladeheavycharge-2bw-perception.json
+++ b/src/data/skills/stonesplit-power/mobladeheavycharge-2bw-perception.json
@@ -11,20 +11,20 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 3.6181,
-      "attributeMultiplier": 5.42715,
-      "physFixed": 835.5,
-      "attributeFixed": 467,
+      "physMultiplier": 3.6184,
+      "attributeMultiplier": 5.42765,
+      "physFixed": 1001,
+      "attributeFixed": 545,
       "extraCritDamage": 0,
       "triggers": []
     },
     {
       "id": "hit-1",
       "frame": 52,
-      "physMultiplier": 3.6181,
-      "attributeMultiplier": 5.42715,
-      "physFixed": 835.5,
-      "attributeFixed": 467,
+      "physMultiplier": 3.6184,
+      "attributeMultiplier": 5.42765,
+      "physFixed": 1001,
+      "attributeFixed": 545,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/mobladeheavycharge-2bw.json
+++ b/src/data/skills/stonesplit-power/mobladeheavycharge-2bw.json
@@ -11,20 +11,20 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 3.6181,
-      "attributeMultiplier": 5.42715,
-      "physFixed": 835.5,
-      "attributeFixed": 467,
+      "physMultiplier": 3.6184,
+      "attributeMultiplier": 5.42765,
+      "physFixed": 1001,
+      "attributeFixed": 545,
       "extraCritDamage": 0,
       "triggers": []
     },
     {
       "id": "hit-1",
       "frame": 113,
-      "physMultiplier": 3.6181,
-      "attributeMultiplier": 5.42715,
-      "physFixed": 835.5,
-      "attributeFixed": 467,
+      "physMultiplier": 3.6184,
+      "attributeMultiplier": 5.42765,
+      "physFixed": 1001,
+      "attributeFixed": 545,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/mobladevariedcombo-2bw-cancel.json
+++ b/src/data/skills/stonesplit-power/mobladevariedcombo-2bw-cancel.json
@@ -11,10 +11,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 2.6338,
-      "attributeMultiplier": 3.9507,
-      "physFixed": 609,
-      "attributeFixed": 340,
+      "physMultiplier": 2.6343,
+      "attributeMultiplier": 3.9514,
+      "physFixed": 729,
+      "attributeFixed": 397,
       "extraCritDamage": 0,
       "triggers": [
         {

--- a/src/data/skills/stonesplit-power/mobladevariedcombo-2bw.json
+++ b/src/data/skills/stonesplit-power/mobladevariedcombo-2bw.json
@@ -11,10 +11,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 2.6338,
-      "attributeMultiplier": 3.9507,
-      "physFixed": 609,
-      "attributeFixed": 340,
+      "physMultiplier": 2.6343,
+      "attributeMultiplier": 3.9514,
+      "physFixed": 729,
+      "attributeFixed": 397,
       "extraCritDamage": 0,
       "triggers": [
         {

--- a/src/data/skills/stonesplit-power/mobladevariedcombogroundslam-2bw.json
+++ b/src/data/skills/stonesplit-power/mobladevariedcombogroundslam-2bw.json
@@ -11,10 +11,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 1.6461,
-      "attributeMultiplier": 2.4692,
-      "physFixed": 380,
-      "attributeFixed": 212,
+      "physMultiplier": 1.6464,
+      "attributeMultiplier": 2.4696,
+      "physFixed": 455,
+      "attributeFixed": 248,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/spearq.json
+++ b/src/data/skills/stonesplit-power/spearq.json
@@ -11,10 +11,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 0.3146,
-      "attributeMultiplier": 0.4719,
-      "physFixed": 74,
-      "attributeFixed": 41,
+      "physMultiplier": 0.3151,
+      "attributeMultiplier": 0.4726,
+      "physFixed": 88,
+      "attributeFixed": 48,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/spearspecial-cancel-prepull.json
+++ b/src/data/skills/stonesplit-power/spearspecial-cancel-prepull.json
@@ -11,10 +11,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 0.32271,
-      "attributeMultiplier": 0.48405,
-      "physFixed": 74.7,
-      "attributeFixed": 41.7,
+      "physMultiplier": 0.339,
+      "attributeMultiplier": 0.5085,
+      "physFixed": 93.9,
+      "attributeFixed": 51.3,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/spearspecial-cancel.json
+++ b/src/data/skills/stonesplit-power/spearspecial-cancel.json
@@ -11,10 +11,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 0.32271,
-      "attributeMultiplier": 0.48405,
-      "physFixed": 74.7,
-      "attributeFixed": 41.7,
+      "physMultiplier": 0.339,
+      "attributeMultiplier": 0.5085,
+      "physFixed": 93.9,
+      "attributeFixed": 51.3,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/spearspecial-prepull.json
+++ b/src/data/skills/stonesplit-power/spearspecial-prepull.json
@@ -11,10 +11,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 1.0757,
-      "attributeMultiplier": 1.6135,
-      "physFixed": 249,
-      "attributeFixed": 139,
+      "physMultiplier": 1.13,
+      "attributeMultiplier": 1.695,
+      "physFixed": 313,
+      "attributeFixed": 171,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/data/skills/stonesplit-power/spearspecial.json
+++ b/src/data/skills/stonesplit-power/spearspecial.json
@@ -11,10 +11,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 1.0757,
-      "attributeMultiplier": 1.6135,
-      "physFixed": 249,
-      "attributeFixed": 139,
+      "physMultiplier": 1.13,
+      "attributeMultiplier": 1.695,
+      "physFixed": 313,
+      "attributeFixed": 171,
       "extraCritDamage": 0,
       "triggers": []
     }

--- a/src/engine/attunements.ts
+++ b/src/engine/attunements.ts
@@ -53,6 +53,15 @@ export const ATTUNEMENT_OPTIONS: readonly AttunementOption[] = [
     classIds: ["bellstrikeUmbra"],
     enginePath: "dingYinByTag.Bleed Boost",
   },
+  {
+    id: "moBladeCharge",
+    label: "Mo Blade Charged Boost",
+    min: 0.036,
+    max: 0.06,
+    slots: ARMOR_SLOTS,
+    classIds: ["stonesplitPower"],
+    enginePath: "dingYinByTag.attune:moBladeCharge",
+  },
 ]
 
 export function attunementsFor(slot: GearSlot, classId: string): AttunementOption[] {

--- a/src/engine/panel.ts
+++ b/src/engine/panel.ts
@@ -278,6 +278,11 @@ export function buildContext(
   const targetGeneralDamageTaken = inputs.dummyMode ? 0 : target.generalDamageTaken
   const targetFatigueDamageTaken = inputs.dummyMode ? 0 : target.fatigueDamageTaken
   const effectiveBossBoost = inputs.bossBoost
+  const artOfResistanceBoost = has("Endurance Doctrine")
+    ? stackOf("Endurance Doctrine") === "tier 6"
+      ? 0.15
+      : 0.05
+    : 0
 
   const generalDamageBoost =
     targetGeneralDamageTaken +
@@ -288,7 +293,7 @@ export function buildContext(
     (inputs.tianGongElement === "fire" ? 0.015 : 0) +
     (inputs.tianGongElement === "poison" ? 0.01 : 0) +
     effectiveBossBoost +
-    (has("Endurance Doctrine") ? 0.02 : 0) +
+    artOfResistanceBoost +
     (school.id === "stonesplitBalancePureTang" ? 0.08 : 0)
 
   const dingYinByTag: Record<string, number> = {}

--- a/src/engine/timeline.ts
+++ b/src/engine/timeline.ts
@@ -104,6 +104,11 @@ function bleedAttunementValue(inputs: Inputs): number {
   return inputs.classId === "bellstrikeUmbra" ? (inputs.dingYinByTag["Bleed Boost"] ?? 0) : 0
 }
 
+function taggedSkillAttunementValue(inputs: Inputs, tags: readonly string[] | undefined): number {
+  const attunementTag = tags?.find((tag) => tag.startsWith("attune:"))
+  return attunementTag ? (inputs.dingYinByTag[attunementTag] ?? 0) : 0
+}
+
 const CONCENTRATION_DOT_MULT_SKILLS = new Set(["Bleed Detonation", "Bleed Tick", "Combustion"])
 
 const CONCENTRATION_DISPLAY_THRESHOLD = 0.5
@@ -684,6 +689,8 @@ export function simulateTimeline(inputs: Inputs): Result {
       const bleedAttune = bleedAttunementValue(inputs)
       if (bleedAttune) art.correction = (art.correction ?? 1) * (1 + bleedAttune)
     }
+    const skillAttunement = taggedSkillAttunementValue(inputs, tags)
+    if (skillAttunement) art.correction = (art.correction ?? 1) * (1 + skillAttunement)
     if (skill.id.startsWith("") && hit.extraCritDamage === MIN_PHYS_CRIT_BONUS_SENTINEL) {
       const weaponType = tags?.find((t) => t.startsWith(WEAPON_TAG))?.slice(WEAPON_TAG.length)
       art.extraCritDamage = classGrantsMinPhysCritBoost(inputs.classId, weaponType)

--- a/src/ui/features/overview/class-select/ClassSelect.tsx
+++ b/src/ui/features/overview/class-select/ClassSelect.tsx
@@ -3,7 +3,7 @@ import { useI18n } from "../../../../i18n/i18nContext"
 
 const SCHOOLS = schools as { id: string; cn: string; en: string }[]
 
-const SUPPORTED_CLASS_IDS: ReadonlySet<string> = new Set(["bellstrikeUmbra"])
+const SUPPORTED_CLASS_IDS: ReadonlySet<string> = new Set(["bellstrikeUmbra", "stonesplitPower"])
 
 interface Props {
   value: string

--- a/tests/engine/stonesplitMight.test.ts
+++ b/tests/engine/stonesplitMight.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { getDefaultTalentsForClass } from "../../src/data/baseStats"
+import { poolForClass } from "../../src/data/classes/retunementPools"
+import { attunementsFor } from "../../src/engine/attunements"
+import {
+  builtinRotationsForClass,
+  builtinSkillsForClass,
+  defaultRotationForClass,
+} from "../../src/engine/builtinLibrary"
+import { defaultInputs } from "../../src/engine/defaults"
+import { runEngine } from "../../src/engine/dps"
+import { resolveRotation } from "../../src/engine/rotation"
+
+const CLASS = "stonesplitPower"
+
+function skillNamed(name: string) {
+  const skill = builtinSkillsForClass(CLASS).find((candidate) => candidate.name === name)
+  expect(skill, `${CLASS} has no built-in skill named ${name}`).toBeTruthy()
+  return skill!
+}
+
+function totals(name: string) {
+  return skillNamed(name).hits.reduce(
+    (sum, hit) => ({
+      physMultiplier: sum.physMultiplier + hit.physMultiplier,
+      physFixed: sum.physFixed + hit.physFixed,
+      attributeMultiplier: sum.attributeMultiplier + hit.attributeMultiplier,
+      attributeFixed: sum.attributeFixed + hit.attributeFixed,
+    }),
+    { physMultiplier: 0, physFixed: 0, attributeMultiplier: 0, attributeFixed: 0 },
+  )
+}
+
+describe("Stonesplit Might built-in data", () => {
+  it.each([
+    ["MoBladeHeavyCharge-1BW", 5.7895, 1601, 8.6842, 872],
+    ["MoBladeHeavyCharge-2BW", 7.2368, 2002, 10.8553, 1090],
+    ["MoBladeVariedCombo-2BW", 2.6343, 729, 3.9514, 397],
+    ["MoBladeVariedComboGroundSlam-2BW", 1.6464, 455, 2.4696, 248],
+    ["SpearSpecial", 1.13, 313, 1.695, 171],
+    ["SpearSpecial[Cancel]", 0.339, 93.9, 0.5085, 51.3],
+    ["SpearQ", 0.3151, 88, 0.4726, 48],
+  ])(
+    "%s carries the confirmed level-100 totals",
+    (name, physMultiplier, physFixed, attributeMultiplier, attributeFixed) => {
+      expect(totals(name)).toEqual({
+        physMultiplier,
+        physFixed,
+        attributeMultiplier,
+        attributeFixed,
+      })
+    },
+  )
+
+  it("keeps the confirmed charge timings and two-hit structure", () => {
+    const full = skillNamed("MoBladeHeavyCharge-1BW")
+    const cancel = skillNamed("MoBladeHeavyCharge-1BW[Cancel]")
+    const perception = skillNamed("MoBladeHeavyCharge-1BW[Perception]")
+    const perceptionCancel = skillNamed("MoBladeHeavyCharge-1BW[Perception][Cancel]")
+    expect([
+      full.castFrames,
+      cancel.castFrames,
+      perception.castFrames,
+      perceptionCancel.castFrames,
+    ]).toEqual([226, 176, 105, 67])
+    expect(full.hits).toHaveLength(2)
+  })
+
+  it("resolves every shipped rotation and produces damage", () => {
+    const skills = builtinSkillsForClass(CLASS)
+    const rotations = builtinRotationsForClass(CLASS)
+    expect(rotations).toHaveLength(3)
+    for (const rotation of rotations) {
+      const { warnings } = resolveRotation(rotation, skills, [])
+      expect(warnings.filter((warning) => warning.includes("missing skill"))).toEqual([])
+    }
+    expect(defaultRotationForClass(CLASS)).not.toBeNull()
+    expect(runEngine({ ...defaultInputs, classId: CLASS }).dps).toBeGreaterThan(0)
+  })
+
+  it("reuses shared progression while targeting Stonesplit stats", () => {
+    const talents = getDefaultTalentsForClass(CLASS)
+    expect(talents).toHaveLength(8)
+    expect(talents.some((talent) => talent.stat === "minStonesplit")).toBe(true)
+    expect(talents.some((talent) => talent.stat === "maxStonesplit")).toBe(true)
+    expect(talents.some((talent) => talent.stat === "stonesplitPenetration")).toBe(true)
+  })
+
+  it("exposes Stonesplit retunement and the 3.6-6% Mo Blade charged attunement", () => {
+    expect(poolForClass(CLASS)?.stats).toContain("Max Stonesplit")
+    const option = attunementsFor("helm", CLASS).find((entry) => entry.id === "moBladeCharge")
+    expect(option).toMatchObject({ min: 0.036, max: 0.06 })
+  })
+})


### PR DESCRIPTION
## What changed

- enables Stonesplit Might in the class selector and uses the Mo Blade / Stormbreaker Spear naming
- updates the existing Stonesplit skill scaffold with confirmed level-100 coefficients, flat damage, hit splits, and cast timings
- wires the existing Xia, dummy, and team-dummy Stonesplit rotations into the supported class
- reuses the shared martial-arts talent and Oddity systems while mapping path-dependent values to Stonesplit
- adds the Stonesplit retunement pool and the 3.6-6% Mo Blade Charged attunement
- updates the Stonesplit inner-way panel values and Art of Resistance T4/T6 damage handling
- adds focused regression coverage for coefficients, timings, rotations, talents, retunement, attunement, and a non-zero engine result

## Validation

- `eslint . --max-warnings 0`
- `vitest run` — 70 files, 645 tests passed
- `tsc -b --noEmit`
- `vite build`
- `prettier --check "**/*.{ts,tsx,mjs,json,css,scss}"`

## Manual testing requested

Please verify the Stonesplit class-switch flow, default build state, rotations, and displayed DPS in the browser. The source values came from in-game level-100 tooltips and the contributor's existing Stonesplit calculator dataset.
