### PR TITLE
feat(dragon-head): qi-break doubling, teammate/low-HP toggles, new co…

### DIFF
--- a/src/data/skills/buffs/dragonHeadLowHp.json
+++ b/src/data/skills/buffs/dragonHeadLowHp.json
@@ -1,0 +1,21 @@
+{
+  "id": "dragonHeadLowHp",
+  "scope": "global",
+  "variants": [
+    {
+      "def": {
+        "id": "dragonHeadLowHp",
+        "name": "Low HP Bonus (Dragon Head)",
+        "triggers": [],
+        "duration": 9999,
+        "alwaysActive": true,
+        "affects": ["Dragon Head - Plus"],
+        "bonus": {
+          "type": "buffBonus",
+          "value": 0.45
+        },
+        "enabledParam": "dragonHeadLowHpMaxBonus"
+      }
+    }
+  ]
+}

--- a/src/data/skills/buffs/index.ts
+++ b/src/data/skills/buffs/index.ts
@@ -47,6 +47,7 @@ import mirageBonusFile from "./mirageBonus.json"
 import rainwhisperShieldFile from "./rainwhisperShield.json"
 import resistanceResolveFile from "./resistanceResolve.json"
 import surgingWavesFile from "./surgingWaves.json"
+import dragonHeadLowHpFile from "./dragonHeadLowHp.json"
 import healerBuffFile from "./healerBuff.json"
 import soulShakenFile from "./soulShaken.json"
 import bellstrikeUmbraBleedPenFile from "./bellstrikeUmbraBleedPen.json"
@@ -160,6 +161,7 @@ export const GLOBAL_BUFF_DEFS: BuffDef[] = [
   soleDef(rainwhisperShieldFile),
   soleDef(resistanceResolveFile),
   soleDef(surgingWavesFile),
+  soleDef(dragonHeadLowHpFile),
 ]
 
 export const GROUP_BUFF_DEFS: BuffDef[] = [soleDef(healerBuffFile)]

--- a/src/data/skills/buffs/surgingWaves.json
+++ b/src/data/skills/buffs/surgingWaves.json
@@ -14,6 +14,10 @@
         "bonus": {
           "type": "buffBonus",
           "valuePerStack": 0.0125
+        },
+        "tierConditionalStacks": {
+          "enabledParam": "allySurgingWaves",
+          "stacksPerCast": 40
         }
       }
     }

--- a/src/data/skills/universal/dragon-head-plus.json
+++ b/src/data/skills/universal/dragon-head-plus.json
@@ -2,7 +2,7 @@
   "id": "universal-dragon-head-plus",
   "classId": "universal",
   "name": "Dragon Head - Plus",
-  "tags": ["mystic:burst"],
+  "tags": ["mystic:burst", "prop:hasQiBreakDoubleDamage"],
   "skillType": "mystic",
   "weaponOrAttribute": "",
   "attributeAttack": "",
@@ -11,9 +11,9 @@
     {
       "id": "hit-0",
       "frame": 246,
-      "physMultiplier": 25.200406,
-      "attributeMultiplier": 37.800609,
-      "physFixed": 4695.46,
+      "physMultiplier": 17.3793,
+      "attributeMultiplier": 26.0689,
+      "physFixed": 3237,
       "attributeFixed": 0,
       "extraCritDamage": 0,
       "triggers": []

--- a/src/data/skills/universal/dragon-head.json
+++ b/src/data/skills/universal/dragon-head.json
@@ -11,9 +11,9 @@
     {
       "id": "hit-0",
       "frame": 246,
-      "physMultiplier": 36.00058,
-      "attributeMultiplier": 54.00087,
-      "physFixed": 6707.8,
+      "physMultiplier": 24.827571,
+      "attributeMultiplier": 37.241286,
+      "physFixed": 4624.285714,
       "attributeFixed": 0,
       "extraCritDamage": 0,
       "triggers": []

--- a/src/data/skills/universal/dragon-head.md
+++ b/src/data/skills/universal/dragon-head.md
@@ -13,17 +13,6 @@ source of truth for all numbers — this file carries only what they can't.
 - Cast timing (246-frame cast, hit on the final frame): user-verified
   2026-08-06.
 
-## Coefficient provenance
-
-The lvl-110 workbook tabulates a single Dragon Head row, named
-"(32 stacks +50%HP)" and with its "Guaranteed Precision" column set — that is
-the **Plus** (25.200406 phys / 4695.46 flat / 37.800609 attr). Dividing by 0.7
-(the Plus "reduces base damage by 30 %") recovers the clean base row
-(36.00058 / 6707.8 / 54.00087); the ratio is asserted in
-`tests/engine/dragonHead.test.ts`. The row's 0.57 universal damage boost is
-that scenario's stack/HP state and is deliberately **not** baked into the
-skill — the stack mechanic is modeled live instead (below).
-
 ## How the mechanics map
 
 - Base uses `guaranteedNormal` (fixed damage), Plus uses `guaranteedPrecision`
@@ -32,10 +21,19 @@ skill — the stack mechanic is modeled live instead (below).
   engine applies it at cast start, so the granting cast's own hit — landing at
   the end of the channel — is boosted; that is what matches the in-game
   "increases the damage of the **current** Dragon Head".
-
-## Not modeled
-
-- The Plus's doubled damage against a non-player target without Qi / with
-  depleted Qi — the simulation has no target-Qi state on the hit path.
-- Ally-contributed Surging Waves stacks (up to 10 per ally on top of the
-  self-granted 8) — the simulation is solo.
+- The Plus's doubled damage vs a target with depleted Qi is the
+  `prop:hasQiBreakDoubleDamage` tag, gated on the qi-break window (the sim's
+  only "no Qi" state) and on the Qi Break Window toggle. It multiplies
+  `art.correction`, not `allDamageBoost` — the official wording is a doubling,
+  and the boost lane is additive, so a +1.0 effect there would land well under
+  ×2. Sibling qi-phase tags: `prop:hasLowQiDmgBoost`, `prop:hasQiBreakPhysPen`.
+- The HP-lost damage bonus is the "Max Low-HP Bonus (Dragon Head)" toggle
+  (`CombatSettings.dragonHeadLowHpMaxBonus` → the `dragonHeadLowHpMaxBonus`
+  param → `buffs/dragonHeadLowHp.json`). **It applies the 45 % cap only** —
+  see "Open questions" for why there is no HP-percentage input. Its `affects`
+  names the Plus in full, so the prefix match excludes the base version;
+  Surging Waves deliberately does the opposite with the bare "Dragon Head".
+- Ally-contributed stacks are the "40 Stacks (Dragon Head)" teammate toggle
+  (`CombatSettings.dragonHeadFullStacks` → the `allySurgingWaves` buff param).
+  It raises stacks-per-cast to the 40 cap via `tierConditionalStacks`, so every
+  cast lands at full stacks (+50 %) rather than climbing 8 at a time.

--- a/src/engine/buffs/params.ts
+++ b/src/engine/buffs/params.ts
@@ -32,6 +32,9 @@ export function paramsFromInputs(inputs: Inputs): BuffParams {
     params.bossBreakDuration = qiBreak.durationSec + breakExtensionBonus
   }
 
+  if (inputs.combatSettings?.dragonHeadFullStacks) params.allySurgingWaves = true
+  if (inputs.combatSettings?.dragonHeadLowHpMaxBonus) params.dragonHeadLowHpMaxBonus = true
+
   if (inputs.buffParams) Object.assign(params, inputs.buffParams)
 
   return params

--- a/src/engine/timeline.ts
+++ b/src/engine/timeline.ts
@@ -96,6 +96,15 @@ const QI_LOW_DMG_BOOST = 0.08
 const QI_BREAK_PEN_BASE = 5
 const QI_BREAK_PEN_BONUS = 15
 
+// "If the skill hits a non-player target without Qi or with depleted Qi, the
+// damage dealt is doubled" (Dragon Head - Plus, official text in
+// `reference/locale/zhToEnOfficial.json`). Depleted Qi is the qi-break window;
+// the sim has no "target has no Qi bar at all" state, so only the window
+// triggers it. Multiplicative on top of (1+H), hence `correction` rather than
+// an allDamageBoost effect — a +1.0 boost would be diluted by the additive pool.
+const QI_BREAK_DOUBLE_TAG = "prop:hasQiBreakDoubleDamage"
+const QI_BREAK_DAMAGE_MULTIPLIER = 2
+
 // A post-(1+H) multiplicative factor (via `art.correction`, not a
 // {statKey,amount} effect) applied only to these two bleed skills.
 // Combustion is deliberately absent — un-attuned on the site.
@@ -460,6 +469,8 @@ export function simulateTimeline(inputs: Inputs): Result {
       })()
     : null
 
+  const qiBreakEnabled = inputs.combatSettings?.qiBreak?.enabled ?? true
+
   const crosswindTracker =
     buffEngine && buffEngine.paramOn("swordHorizon")
       ? new CrosswindTracker(buffEngine.paramTier("swordHorizon") >= 6)
@@ -699,6 +710,9 @@ export function simulateTimeline(inputs: Inputs): Result {
         (art.extraPhysPenetration ?? 0) +
         QI_BREAK_PEN_BASE +
         (inQiBreak || hasLingeringBone ? QI_BREAK_PEN_BONUS : 0)
+    }
+    if (inQiBreak && qiBreakEnabled && tags?.includes(QI_BREAK_DOUBLE_TAG)) {
+      art.correction = (art.correction ?? 1) * QI_BREAK_DAMAGE_MULTIPLIER
     }
     const { expectedDamage } = computeSkillDamage(art, padSlots([]), st.ctx, 1)
     const hitInWindow = inWindow(frame)

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -33,6 +33,8 @@ export interface CombatSettings {
   healerBuff: boolean
   breakExtension: boolean
   revelryScript: boolean
+  dragonHeadFullStacks: boolean
+  dragonHeadLowHpMaxBonus: boolean
 }
 
 export function defaultCombatSettings(): CombatSettings {
@@ -42,6 +44,8 @@ export function defaultCombatSettings(): CombatSettings {
     healerBuff: false,
     breakExtension: false,
     revelryScript: false,
+    dragonHeadFullStacks: false,
+    dragonHeadLowHpMaxBonus: false,
   }
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -309,6 +309,14 @@ function hydrateInputs(inputs: Inputs): Inputs {
       healerBuff: typeof r.healerBuff === "boolean" ? r.healerBuff : def.healerBuff,
       breakExtension: typeof r.breakExtension === "boolean" ? r.breakExtension : def.breakExtension,
       revelryScript: typeof r.revelryScript === "boolean" ? r.revelryScript : def.revelryScript,
+      dragonHeadFullStacks:
+        typeof r.dragonHeadFullStacks === "boolean"
+          ? r.dragonHeadFullStacks
+          : def.dragonHeadFullStacks,
+      dragonHeadLowHpMaxBonus:
+        typeof r.dragonHeadLowHpMaxBonus === "boolean"
+          ? r.dragonHeadLowHpMaxBonus
+          : def.dragonHeadLowHpMaxBonus,
     }
   }
   return withZeroedDerivedStats(next)
@@ -523,18 +531,73 @@ interface CustomSkillsBlob {
   skills: Skill[]
 }
 
+// A Skill Editor copy saved before the tag existed still scores Dragon Head -
+// Plus without its qi-break doubling, and nothing in the UI would show that.
+const QI_BREAK_DOUBLE_TAG = "prop:hasQiBreakDoubleDamage"
+
+function healSkillTags(id: string, tags: string[]): string[] {
+  if (!id.endsWith("-dragon-head-plus") || tags.includes(QI_BREAK_DOUBLE_TAG)) return tags
+  return [...tags, QI_BREAK_DOUBLE_TAG]
+}
+
+// The Dragon Head coefficients were replaced wholesale (2026-08-08), so a
+// stored copy carrying the superseded workbook numbers scores ~69x low. Only
+// an untouched copy is rewritten — a hit the user actually edited is left
+// alone, since we cannot tell a stale value from a deliberate one once it
+// differs.
+const SUPERSEDED_DRAGON_HEAD_HITS: Record<
+  string,
+  { from: [number, number, number]; to: [number, number, number] }
+> = {
+  "-dragon-head-plus": {
+    from: [25.200406, 4695.46, 37.800609],
+    to: [17.3793, 3237, 26.0689],
+  },
+  "-dragon-head": {
+    from: [36.00058, 6707.8, 54.00087],
+    to: [24.827571, 4624.285714, 37.241286],
+  },
+}
+
+function healDragonHeadCoefficients(id: string, hits: SkillHit[]): SkillHit[] {
+  const suffix = id.endsWith("-dragon-head-plus") ? "-dragon-head-plus" : "-dragon-head"
+  if (!id.endsWith(suffix)) return hits
+  const swap = SUPERSEDED_DRAGON_HEAD_HITS[suffix]
+  if (!swap) return hits
+  return hits.map((hit) => {
+    const untouched =
+      hit.physMultiplier === swap.from[0] &&
+      hit.physFixed === swap.from[1] &&
+      hit.attributeMultiplier === swap.from[2]
+    if (!untouched) return hit
+    return {
+      ...hit,
+      physMultiplier: swap.to[0],
+      physFixed: swap.to[1],
+      attributeMultiplier: swap.to[2],
+    }
+  })
+}
+
 // additive — see CLAUDE.md → "localStorage migrations"
 function hydrateSkill(s: Skill): Skill {
   if (!s || typeof s !== "object") return s
   const { abilityTag: _legacyAbilityTag, ...rest } = s as Skill & { abilityTag?: string }
   void _legacyAbilityTag
+  const id = migrateEntityId(s.id)
+  const tags = Array.isArray(s.tags) ? s.tags.filter((t): t is string => typeof t === "string") : []
   return {
     ...rest,
-    id: migrateEntityId(s.id),
+    id,
     classId: migrateClassId(s.classId),
     triggerable: typeof s.triggerable === "boolean" ? s.triggerable : true,
-    tags: Array.isArray(s.tags) ? s.tags.filter((t): t is string => typeof t === "string") : [],
-    hits: Array.isArray(s.hits) ? s.hits.map((h) => hydrateSkillHit(h)) : s.hits,
+    tags: healSkillTags(id, tags),
+    hits: Array.isArray(s.hits)
+      ? healDragonHeadCoefficients(
+          id,
+          s.hits.map((h) => hydrateSkillHit(h)),
+        )
+      : s.hits,
   }
 }
 

--- a/src/ui/features/overview/encounter-settings-panel/EncounterSettingsPanel.tsx
+++ b/src/ui/features/overview/encounter-settings-panel/EncounterSettingsPanel.tsx
@@ -46,6 +46,11 @@ export function EncounterSettingsPanel({ inputs, onChange }: Props) {
             on={settings.revelryScript}
             onToggle={() => setCombat("revelryScript", !settings.revelryScript)}
           />
+          <ToggleChip
+            label={t("Max Low-HP Bonus (Dragon Head)")}
+            on={settings.dragonHeadLowHpMaxBonus}
+            onToggle={() => setCombat("dragonHeadLowHpMaxBonus", !settings.dragonHeadLowHpMaxBonus)}
+          />
         </div>
       </div>
 
@@ -103,6 +108,11 @@ export function EncounterSettingsPanel({ inputs, onChange }: Props) {
             label={t("Break Extension")}
             on={settings.breakExtension}
             onToggle={() => setCombat("breakExtension", !settings.breakExtension)}
+          />
+          <ToggleChip
+            label={t("40 Stacks (Dragon Head)")}
+            on={settings.dragonHeadFullStacks}
+            onToggle={() => setCombat("dragonHeadFullStacks", !settings.dragonHeadFullStacks)}
           />
         </div>
       </div>

--- a/tests/engine/bellstrikeUmbraParity.test.ts
+++ b/tests/engine/bellstrikeUmbraParity.test.ts
@@ -62,6 +62,8 @@ const inputs: Inputs = {
     healerBuff: false,
     breakExtension: false,
     revelryScript: false,
+    dragonHeadFullStacks: false,
+    dragonHeadLowHpMaxBonus: false,
   },
   shareDebuff5HenZhi: false,
   shareEasyHurt: false,

--- a/tests/engine/combatSettingsMigration.test.ts
+++ b/tests/engine/combatSettingsMigration.test.ts
@@ -58,6 +58,8 @@ describe("combatSettings migration (additive field, no version bump)", () => {
       healerBuff: true,
       breakExtension: false,
       revelryScript: false,
+      dragonHeadFullStacks: false,
+      dragonHeadLowHpMaxBonus: false,
     }
     writeProfilesBlob({ combatSettings: custom })
     const first = loadProfiles()

--- a/tests/engine/dragonHead.test.ts
+++ b/tests/engine/dragonHead.test.ts
@@ -7,6 +7,7 @@ import { computeSkillDamage } from "../../src/engine/formula"
 import type { FormulaContext } from "../../src/engine/formula"
 import { simulateTimeline } from "../../src/engine/timeline"
 import { defaultInputs } from "../../src/engine/defaults"
+import { defaultCombatSettings } from "../../src/engine/types"
 import { builtinSkillsForClass } from "../../src/engine/builtinLibrary"
 import { makeRotation, makeStep } from "../../src/engine/rotation"
 import { GLOBAL_BUFF_DEFS } from "../../src/data/skills/buffs"
@@ -42,9 +43,9 @@ describe("Dragon Head registry — universal mystic, both versions", () => {
 
       const baseHit = base!.hits[0]
       const plusHit = plus!.hits[0]
-      expect(plusHit.physMultiplier).toBeCloseTo(25.200406, 9)
-      expect(plusHit.attributeMultiplier).toBeCloseTo(37.800609, 9)
-      expect(plusHit.physFixed).toBeCloseTo(4695.46, 9)
+      expect(plusHit.physMultiplier).toBeCloseTo(17.3793, 9)
+      expect(plusHit.attributeMultiplier).toBeCloseTo(26.0689, 9)
+      expect(plusHit.physFixed).toBeCloseTo(3237, 9)
       expect(plusHit.physMultiplier).toBeCloseTo(baseHit.physMultiplier * 0.7, 4)
       expect(plusHit.attributeMultiplier).toBeCloseTo(baseHit.attributeMultiplier * 0.7, 4)
       expect(plusHit.physFixed).toBeCloseTo(baseHit.physFixed * 0.7, 4)
@@ -68,9 +69,9 @@ const art_ = (a: Record<string, unknown>) => a as unknown as Art
 const slots = ["N/A", "N/A", "N/A", "N/A", "N/A"] as const
 
 const DRAGON_HEAD_ROW = {
-  physMultiplier: 36.00058,
-  physFixed: 6707.8,
-  attributeMultiplier: 54.00087,
+  physMultiplier: 24.827571,
+  physFixed: 4624.285714,
+  attributeMultiplier: 37.241286,
   attributeFixed: 0,
   skillType: "mystic",
   mysticCategory: "burst",
@@ -137,9 +138,9 @@ describe("guaranteedPrecision — never abrades, crit/affinity still roll", () =
   const plus = art_({
     name: "Dragon Head - Plus",
     ...DRAGON_HEAD_ROW,
-    physMultiplier: 25.200406,
-    physFixed: 4695.46,
-    attributeMultiplier: 37.800609,
+    physMultiplier: 17.3793,
+    physFixed: 3237,
+    attributeMultiplier: 26.0689,
     guaranteedPrecision: 1,
   })
 
@@ -177,13 +178,20 @@ function rotationOf(classId: string, skillNames: string[]) {
   return makeRotation(classId, { name: `test-${skillNames.join("+")}`, steps })
 }
 
-function simulate(skillNames: string[]) {
+function simulate(skillNames: string[], overrides: Partial<Inputs> = {}) {
   const inputs: Inputs = {
     ...defaultInputs,
     classId: "bellstrikeUmbra",
     activeCustomRotation: rotationOf("bellstrikeUmbra", skillNames),
+    ...overrides,
   }
   return simulateTimeline(inputs)
+}
+
+function withFullStacks(): Partial<Inputs> {
+  return {
+    combatSettings: { ...defaultCombatSettings(), dragonHeadFullStacks: true },
+  }
 }
 
 function skillDamage(result: ReturnType<typeof simulateTimeline>, name: string): number {
@@ -226,5 +234,152 @@ describe("Surging Waves in the timeline (Bellstrike Umbra)", () => {
       skillDamage(base, "Dragon Head"),
       6,
     )
+  })
+})
+
+describe("40 Stacks (Dragon Head) teammate buff", () => {
+  const surgingWavesStacks = (result: ReturnType<typeof simulateTimeline>) =>
+    (result.casts ?? []).map((c) => c.buffs.find((b) => b.id === "surgingWaves")?.stacks ?? 0)
+
+  it("holds every cast at the 40-stack cap instead of climbing 8 at a time", () => {
+    const fiveCasts = Array(5).fill("Dragon Head - Plus")
+    const selfOnly = surgingWavesStacks(simulate(fiveCasts))
+    expect(selfOnly[0]).toBeLessThan(40)
+    expect(selfOnly).toEqual([...selfOnly].sort((left, right) => left - right))
+    expect(surgingWavesStacks(simulate(fiveCasts, withFullStacks()))).toEqual([40, 40, 40, 40, 40])
+  })
+
+  it("raises the first cast's damage over the self-only 8 stacks", () => {
+    const selfOnly = skillDamage(simulate(["Dragon Head - Plus"]), "Dragon Head - Plus")
+    const withAllies = skillDamage(
+      simulate(["Dragon Head - Plus"], withFullStacks()),
+      "Dragon Head - Plus",
+    )
+    expect(withAllies).toBeGreaterThan(selfOnly)
+  })
+
+  it("leaves other skills untouched", () => {
+    const alone = skillDamage(simulate(["Sword Martial Q"]), "Sword Martial Q")
+    const afterPlus = skillDamage(
+      simulate(["Dragon Head - Plus", "Sword Martial Q"], withFullStacks()),
+      "Sword Martial Q",
+    )
+    expect(afterPlus).toBeCloseTo(alone, 6)
+  })
+})
+
+describe("Max Low-HP Bonus (Dragon Head)", () => {
+  const withLowHp = (): Partial<Inputs> => ({
+    combatSettings: { ...defaultCombatSettings(), dragonHeadLowHpMaxBonus: true },
+  })
+
+  it("is a global buff def applying the sourced 45 % cap, gated to the Plus", () => {
+    const def = GLOBAL_BUFF_DEFS.find((d) => d.id === "dragonHeadLowHp")
+    expect(def).toBeTruthy()
+    expect(def!.bonus).toEqual({ type: "buffBonus", value: 0.45 })
+    expect(def!.affects).toEqual(["Dragon Head - Plus"])
+    expect(def!.enabledParam).toBe("dragonHeadLowHpMaxBonus")
+    expect(def!.alwaysActive).toBe(true)
+  })
+
+  it("does nothing until the toggle is on", () => {
+    const plain = skillDamage(simulate(["Dragon Head - Plus"]), "Dragon Head - Plus")
+    const boosted = skillDamage(simulate(["Dragon Head - Plus"], withLowHp()), "Dragon Head - Plus")
+    expect(boosted).toBeGreaterThan(plain)
+  })
+
+  // Cross-checked against Revelry Script, a known +0.30 into the same additive
+  // pool: it fixes the pool size independently, which then predicts the 0.45.
+  it("adds exactly 0.45 to the same additive pool Revelry Script feeds", () => {
+    const withRevelry = (): Partial<Inputs> => ({
+      combatSettings: { ...defaultCombatSettings(), revelryScript: true },
+    })
+    const plain = skillDamage(simulate(["Dragon Head - Plus"]), "Dragon Head - Plus")
+    const revelry = skillDamage(
+      simulate(["Dragon Head - Plus"], withRevelry()),
+      "Dragon Head - Plus",
+    )
+    const lowHp = skillDamage(simulate(["Dragon Head - Plus"], withLowHp()), "Dragon Head - Plus")
+
+    const pool = 0.3 / (revelry / plain - 1)
+    expect(lowHp / plain).toBeCloseTo((pool + 0.45) / pool, 9)
+  })
+
+  it("does not touch the base version or any other skill", () => {
+    for (const name of ["Dragon Head", "Sword Martial Q"]) {
+      const alone = skillDamage(simulate([name]), name)
+      const withBonus = skillDamage(simulate([name], withLowHp()), name)
+      expect(withBonus, name).toBeCloseTo(alone, 6)
+    }
+  })
+})
+
+describe("Dragon Head - Plus doubles into a depleted-Qi target", () => {
+  const qiBreak = (enabled: boolean, startSec: number): Partial<Inputs> => ({
+    combatSettings: {
+      ...defaultCombatSettings(),
+      qiBreak: { enabled, startSec, durationSec: 10 },
+    },
+  })
+
+  // the cast is 246 frames, so a break opening at 0 s still covers the hit
+  const insideBreak = qiBreak(true, 0)
+  const outsideBreak = qiBreak(true, 60)
+
+  it("carries the tag on every class's built-in Plus, and never on the base version", () => {
+    for (const classId of ALL_CLASS_IDS) {
+      const skills = builtinSkillsForClass(classId)
+      const plus = skills.find((s) => s.name === "Dragon Head - Plus")!
+      const base = skills.find((s) => s.name === "Dragon Head")!
+      expect(plus.tags, classId).toContain("prop:hasQiBreakDoubleDamage")
+      expect(base.tags, classId).not.toContain("prop:hasQiBreakDoubleDamage")
+    }
+  })
+
+  // Same id, so it replaces the built-in wholesale: identical name, hits and
+  // buff triggers, differing only by the tag. Comparing against the window's
+  // pre-existing +10 % boost instead would not isolate the doubling.
+  const withoutTheTag = (): Inputs["customSkills"] => {
+    const plus = builtinSkillsForClass("bellstrikeUmbra").find(
+      (s) => s.name === "Dragon Head - Plus",
+    )!
+    return [{ ...plus, tags: (plus.tags ?? []).filter((t) => t !== "prop:hasQiBreakDoubleDamage") }]
+  }
+
+  it("is worth exactly x2 inside the window", () => {
+    const tagged = skillDamage(simulate(["Dragon Head - Plus"], insideBreak), "Dragon Head - Plus")
+    const untagged = skillDamage(
+      simulate(["Dragon Head - Plus"], { ...insideBreak, customSkills: withoutTheTag() }),
+      "Dragon Head - Plus",
+    )
+    expect(tagged / untagged).toBeCloseTo(2, 9)
+  })
+
+  it("changes nothing outside the window", () => {
+    const tagged = skillDamage(simulate(["Dragon Head - Plus"], outsideBreak), "Dragon Head - Plus")
+    const untagged = skillDamage(
+      simulate(["Dragon Head - Plus"], { ...outsideBreak, customSkills: withoutTheTag() }),
+      "Dragon Head - Plus",
+    )
+    expect(tagged).toBeCloseTo(untagged, 6)
+  })
+
+  it("does not double when the Qi Break Window toggle is off", () => {
+    const off = skillDamage(
+      simulate(["Dragon Head - Plus"], qiBreak(false, 0)),
+      "Dragon Head - Plus",
+    )
+    const outside = skillDamage(
+      simulate(["Dragon Head - Plus"], outsideBreak),
+      "Dragon Head - Plus",
+    )
+    expect(off).toBeCloseTo(outside, 6)
+  })
+
+  it("does not double the base version, which only gets the window's boost", () => {
+    const outside = skillDamage(simulate(["Dragon Head"], outsideBreak), "Dragon Head")
+    const inside = skillDamage(simulate(["Dragon Head"], insideBreak), "Dragon Head")
+    expect(inside).toBeGreaterThan(outside)
+    expect(inside / outside).toBeLessThan(1.5)
   })
 })

--- a/tests/engine/dragonHeadPlusTagMigration.test.ts
+++ b/tests/engine/dragonHeadPlusTagMigration.test.ts
@@ -1,0 +1,62 @@
+// Additive field, no version bump — see CLAUDE.md → "localStorage migrations".
+import { beforeEach, describe, expect, it } from "vitest"
+import { kvStore } from "../../src/kvStore"
+import { loadCustomSkills } from "../../src/storage"
+import { builtinSkillsForClass } from "../../src/engine/builtinLibrary"
+import type { Skill } from "../../src/engine/skill"
+
+const CUSTOM_SKILLS_KEY = "wwm.customSkills"
+const CUSTOM_SKILLS_VERSION = 3
+const TAG = "prop:hasQiBreakDoubleDamage"
+
+function writeStoredSkills(skills: Skill[]): void {
+  kvStore.set(CUSTOM_SKILLS_KEY, JSON.stringify({ v: CUSTOM_SKILLS_VERSION, skills }))
+}
+
+function builtin(name: string): Skill {
+  return builtinSkillsForClass("bellstrikeUmbra").find((s) => s.name === name)!
+}
+
+function withoutTag(skill: Skill): Skill {
+  return { ...skill, tags: (skill.tags ?? []).filter((t) => t !== TAG) }
+}
+
+describe("Dragon Head - Plus qi-break tag on Skill Editor copies", () => {
+  beforeEach(() => {
+    try {
+      kvStore.remove(CUSTOM_SKILLS_KEY)
+    } catch {}
+  })
+
+  it("adds the tag to a copy saved before it existed", () => {
+    const stale = withoutTag(builtin("Dragon Head - Plus"))
+    expect(stale.tags).not.toContain(TAG)
+    writeStoredSkills([stale])
+
+    const healed = loadCustomSkills().find((s) => s.id === stale.id)!
+    expect(healed.tags).toContain(TAG)
+  })
+
+  it("preserves the user's other tags and edits while healing", () => {
+    const stale = withoutTag(builtin("Dragon Head - Plus"))
+    stale.tags = [...(stale.tags ?? []), "user:favourite"]
+    stale.hits[0].physMultiplier = 99
+    writeStoredSkills([stale])
+
+    const healed = loadCustomSkills().find((s) => s.id === stale.id)!
+    expect(healed.tags).toContain("user:favourite")
+    expect(healed.tags).toContain("mystic:burst")
+    expect(healed.hits[0].physMultiplier).toBe(99)
+  })
+
+  it("is idempotent — a copy that already has the tag keeps exactly one", () => {
+    writeStoredSkills([builtin("Dragon Head - Plus")])
+    const healed = loadCustomSkills().find((s) => s.name === "Dragon Head - Plus")!
+    expect((healed.tags ?? []).filter((t) => t === TAG)).toHaveLength(1)
+  })
+
+  it("leaves the base version and unrelated skills alone", () => {
+    writeStoredSkills([builtin("Dragon Head"), builtin("Sword Martial Q")])
+    for (const skill of loadCustomSkills()) expect(skill.tags).not.toContain(TAG)
+  })
+})


### PR DESCRIPTION
Mechanics added:

- Qi-break doubling. "If the skill hits a non-player target without Qi or with depleted Qi, the damage dealt is doubled" (official text). New skill tag prop:hasQiBreakDoubleDamage, alongside the existing qi-phase tags, gated on the qi-break window and the Qi Break Window toggle. Multiplies art.correction, not allDamageBoost: the wording is a doubling and the boost lane is additive, so a +1.0 effect there lands well under x2. Keyed to the hit frame, not cast start - the 246-frame channel can begin outside the window and land inside. A target with no Qi bar at all stays unmodeled.

- "40 Stacks (Dragon Head)" teammate toggle. Ally-contributed Surging Waves (up to 10 per ally on top of the self-granted 8) pins stacks-per-cast at the 40 cap via tierConditionalStacks, so every cast lands at +50 % rather than climbing 8 at a time. Affects both versions.

- "Max Low-HP Bonus (Dragon Head)" toggle. Applies the officially sourced 45 % cap of the HP-lost bonus, into the additive allDamageBoost pool (the workbook accounts for it in the same "Universal DMG Boost" cell as the stacks). Scoped to the Plus only per user decision.

  The scaling curve is NOT sourced and must not be guessed: the client strings give the two tiers' caps (25 % / 45 %) and no rate, unlike every other HP-scaling mechanic in the game. The workbook's single data point - 32 stacks + 50 % HP, universal boost 0.57 - leaves 0.17 for the HP term after netting out the stacks, matching neither linear reading (0.225 at a 45 % cap, 0.125 at 25 %). Hence a cap-only toggle and no "HP at x %" input.

Migrations (both additive, no version bump):

- combatSettings gains dragonHeadFullStacks / dragonHeadLowHpMaxBonus, defaulted false on stored profiles.
- wwm.customSkills: Skill Editor copies of Dragon Head - Plus predate the qi-break tag and would silently score without the doubling, so hydrateSkill adds it. The same hydrator rewrites superseded Dragon Head coefficients, but only when a hit matches the old built-in values exactly - an edited hit is left alone, since a stale value and a deliberate one are indistinguishable once they differ.