### PR TITLE
Stonesplit strength inner way naming fixes and snowparting vc coeff fix

### DIFF
--- a/docs/CALCULATION.md
+++ b/docs/CALCULATION.md
@@ -367,7 +367,7 @@ divergences (Implemented), and known gaps, which contribute 0 unless noted
   either debuff. Only hits laid by the rotation roll
   the proc — DoT ticks and trigger-enqueued hits do not — the same structural
   limitation Hawkwing and Concentration have.
-- **Lone Loyalty / Mountain Splitter** — tier 3 opens a 10-second Mountain
+- **Steadfast Devotion / Mountain Splitter** — tier 3 opens a 10-second Mountain
   Splitter window when Inner Passion is active and a generated Modao Anxi
   Soldier attack lands, with a 15-second ICD on that activation route. Its
   final-crit rule is evaluated after precision: at 75% or higher the affected
@@ -439,7 +439,7 @@ source-of-truth note this table summarizes.
 | Thousand Mountain Law / `mountainsMight` | Panel + buff engine | Disjoint. |
 | Throat-Pierce / `throatPierced` | Panel + buff engine | Disjoint. |
 | Star-Picker / `starReacher` | Panel + buff engine | Disjoint. |
-| Lone Loyalty / `steadfastDevotion` | Panel + buff engine | Disjoint. Tier 3 Mountain Splitter, tier 4 consumption-gated Phalanx damage, and tier 6 Enhanced Charge are statefully modeled; see the implemented entry above. |
+| Steadfast Devotion / `steadfastDevotion` | Panel + buff engine | Disjoint. Tier 3 Mountain Splitter, tier 4 consumption-gated Phalanx damage, and tier 6 Enhanced Charge are statefully modeled; see the implemented entry above. |
 | Boat on Wood / `towlineSweep` (bamboocutDust) | Panel + buff engine (`towlineSweepT6Special` forceCrit bonus) | Disjoint; `forceCrit` is now consumed, so this def is live. |
 | Morale Chant / `moraleChant` | Panel + `timeline.ts` stack schedule (`buffs/morale.ts`) | Stacks drive `allDamageBoost` + `phys.penetration`; tier 6 adds Yi River ticks. |
 | Tang Anthem / `songOfTang` | Panel (`precision 0.059`, `critDamageBoost 0.04`) + buff engine (`tangMelody`: triggered, stacking `critDmg 0.03`×≤5, rate-limited) | **Verified NOT a double-count** — a flat always-on tier stat vs a distinct triggered mechanic that ramps and decays independently. |

--- a/docs/CALCULATION.md
+++ b/docs/CALCULATION.md
@@ -434,7 +434,7 @@ source-of-truth note this table summarizes.
 | --- | --- | --- |
 | Sword Horizon / `swordHorizon` (bellstrikeUmbra signature) | Panel tier stats + buff engine + `crosswind.ts` | Tier stats, T6 detonation retain, the charge counter and guaranteed-affinity are all modeled. The crosswindBlade/bloodBurst mode toggle is unimplemented — but bloodBurst is the site's own default and the app never applies the crosswindBlade conversion, so the omission is **correctly inert**. |
 | Moon Above Flowers / `combo` (silkbindJade signature) | Panel + buff engine (combo-count buffs) | Disjoint channels. |
-| Frostwhite Night / `frostCladNight` (stonesplitStrength signature) | Panel + buff engine (Frost-Clad Snowbreak procs, Forgetfulness) | Disjoint channels. |
+| Frost-Clad Night / `frostCladNight` (stonesplitStrength signature) | Panel + buff engine (Frost-Clad Snowbreak procs, Forgetfulness) | Disjoint channels. |
 | Wolfchaser's Art / `wolfchasersArt` | Panel + buff engine | Disjoint channels. The extra-detonation FSM is an unmodeled gap. |
 | Thousand Mountain Law / `mountainsMight` | Panel + buff engine | Disjoint. |
 | Throat-Pierce / `throatPierced` | Panel + buff engine | Disjoint. |

--- a/reference/workbook/legacy/mindMethods.json
+++ b/reference/workbook/legacy/mindMethods.json
@@ -95,7 +95,7 @@
       "undefined": 6
     },
     {
-      "name": "Lone Loyalty",
+      "name": "Steadfast Devotion",
       "undefined": 0.04
     }
   ],
@@ -280,7 +280,7 @@
     },
     {
       "row": 26,
-      "A": "Lone Loyalty",
+      "A": "Steadfast Devotion",
       "B": "tier 6",
       "C": "tier 6"
     },
@@ -462,7 +462,7 @@
     },
     {
       "row": 64,
-      "A": "Lone Loyalty",
+      "A": "Steadfast Devotion",
       "E": 0.054,
       "I": 0.04
     }

--- a/reference/workbook/legacy/mindMethods.json
+++ b/reference/workbook/legacy/mindMethods.json
@@ -22,7 +22,7 @@
       "undefined": 0.028
     },
     {
-      "name": "Frostwhite Night",
+      "name": "Frost-Clad Night",
       "undefined": 0.046
     },
     {
@@ -178,7 +178,7 @@
     },
     {
       "row": 8,
-      "A": "Frostwhite Night",
+      "A": "Frost-Clad Night",
       "B": "tier 6",
       "C": "tier 6"
     },
@@ -352,7 +352,7 @@
     },
     {
       "row": 46,
-      "A": "Frostwhite Night",
+      "A": "Frost-Clad Night",
       "C": 54.8,
       "G": 0.046
     },

--- a/reference/workbook/legacy/panelDefaults.json
+++ b/reference/workbook/legacy/panelDefaults.json
@@ -124,7 +124,7 @@
     "t": "s"
   },
   "K8": {
-    "v": "Frostwhite Night",
+    "v": "Frost-Clad Night",
     "f": "HLOOKUP($C$2,Class!$A$1:$H$11,11,0)",
     "t": "s"
   },

--- a/reference/workbook/legacy/panelDefaults.json
+++ b/reference/workbook/legacy/panelDefaults.json
@@ -129,7 +129,7 @@
     "t": "s"
   },
   "M8": {
-    "v": "Lone Loyalty",
+    "v": "Steadfast Devotion",
     "t": "s"
   },
   "O8": {

--- a/src/data/baseStats/mindMethodPanelStats.json
+++ b/src/data/baseStats/mindMethodPanelStats.json
@@ -19,7 +19,7 @@
     "critRate": 0.073,
     "physBoost": 0.028
   },
-  "Frostwhite Night": {
+  "Frost-Clad Night": {
     "phys.min": 74.4,
     "directCritRate": 0.046
   },

--- a/src/data/baseStats/mindMethodPanelStats.json
+++ b/src/data/baseStats/mindMethodPanelStats.json
@@ -89,7 +89,7 @@
     "primaryAttr.min": 12.7,
     "primaryAttr.penetration": 0.06
   },
-  "Lone Loyalty": {
+  "Steadfast Devotion": {
     "critRate": 0.077,
     "critDamageBoost": 0.04
   },

--- a/src/data/classes/schools.json
+++ b/src/data/classes/schools.json
@@ -87,7 +87,7 @@
     "primaryAttribute": "Stonesplit",
     "attributeMultiplier": 51.5,
     "permanentBuffs": ["Hengdao Derivative Boost", "Phalanx Charge Boost"],
-    "classMindGroup": "Frostwhite Night",
+    "classMindGroup": "Frost-Clad Night",
     "allowedMindMethods": ["Morale Chant", "Throat-Pierce", "Steadfast Devotion", "Bitter Season"],
     "classBuffs": [],
     "weapons": ["Hengdao", "Modao"],

--- a/src/data/classes/schools.json
+++ b/src/data/classes/schools.json
@@ -88,7 +88,7 @@
     "attributeMultiplier": 51.5,
     "permanentBuffs": ["Hengdao Derivative Boost", "Phalanx Charge Boost"],
     "classMindGroup": "Frostwhite Night",
-    "allowedMindMethods": ["Morale Chant", "Throat-Pierce", "Lone Loyalty", "Bitter Season"],
+    "allowedMindMethods": ["Morale Chant", "Throat-Pierce", "Steadfast Devotion", "Bitter Season"],
     "classBuffs": [],
     "weapons": ["Hengdao", "Modao"],
     "rotations": ["Dual-Cut"]

--- a/src/data/rotations/defaultRotations.json
+++ b/src/data/rotations/defaultRotations.json
@@ -8725,7 +8725,7 @@
         "prePullHitsCount": false,
         "createdAt": "2026-07-19T00:00:00.000Z",
         "updatedAt": "2026-07-19T00:00:00.000Z",
-        "description": "Use vs to replace toad"
+        "description": "Use vc to replace toad"
       }
     ],
     "defaultRotationId": "builtin-stonesplitStrength-tilla-dummy-rotation"

--- a/src/data/skills/stonesplit-strength/snowpartingvc.json
+++ b/src/data/skills/stonesplit-strength/snowpartingvc.json
@@ -17,10 +17,10 @@
     {
       "id": "hit-0",
       "frame": 0,
-      "physMultiplier": 2.8245,
-      "attributeMultiplier": 4.2368,
-      "physFixed": 782,
-      "attributeFixed": 425,
+      "physMultiplier": 2.0769,
+      "attributeMultiplier": 3.1153,
+      "physFixed": 575,
+      "attributeFixed": 313,
       "extraCritDamage": 0,
       "triggers": [
         {

--- a/src/engine/buffs/paramMap.ts
+++ b/src/engine/buffs/paramMap.ts
@@ -51,7 +51,7 @@ const SELECTABLE_INNER_WAYS: Record<string, InnerWayMapping> = {
   songOfTang: { mindMethod: "Tang Anthem" },
   starReacher: { mindMethod: "Star-Picker" },
   artOfResistance: { mindMethod: "Endurance Doctrine" },
-  steadfastDevotion: { mindMethod: "Lone Loyalty" },
+  steadfastDevotion: { mindMethod: "Steadfast Devotion" },
   towlineSweep: { mindMethod: "Boat on Wood" },
   moraleChant: { mindMethod: "Morale Chant" },
 }

--- a/src/engine/buffs/paramMap.ts
+++ b/src/engine/buffs/paramMap.ts
@@ -59,7 +59,7 @@ const SELECTABLE_INNER_WAYS: Record<string, InnerWayMapping> = {
 const CLASS_SIGNATURE_INNER_WAYS: Record<string, InnerWayMapping> = {
   swordHorizon: { mindMethod: "Sword Horizon", classSignature: true },
   combo: { mindMethod: "Moon Above Flowers", classSignature: true },
-  frostCladNight: { mindMethod: "Frostwhite Night", classSignature: true },
+  frostCladNight: { mindMethod: "Frost-Clad Night", classSignature: true },
 }
 
 export const SITE_PARAM_TO_INNER_WAY: Record<string, InnerWayMapping> = {

--- a/src/migrations/V10__renameFrostCladNight.ts
+++ b/src/migrations/V10__renameFrostCladNight.ts
@@ -1,0 +1,25 @@
+import type { Migration, RawProfilesBlob } from "./types"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value)
+
+export const V10__renameFrostCladNight: Migration = {
+  to: 10,
+  name: "V10__renameFrostCladNight",
+  migrate(blob: RawProfilesBlob): RawProfilesBlob {
+    const profiles = Array.isArray(blob.profiles)
+      ? blob.profiles.map((profile) => {
+          if (!isRecord(profile) || !isRecord(profile.inputs)) return profile
+          const mindMethods = profile.inputs.mindMethods
+          if (!Array.isArray(mindMethods)) return profile
+          const renamed = mindMethods.map((slot) =>
+            isRecord(slot) && slot.name === "Frostwhite Night"
+              ? { ...slot, name: "Frost-Clad Night" }
+              : slot,
+          )
+          return { ...profile, inputs: { ...profile.inputs, mindMethods: renamed } }
+        })
+      : blob.profiles
+    return { ...blob, v: 10, profiles }
+  },
+}

--- a/src/migrations/V9__renameSteadfastDevotion.ts
+++ b/src/migrations/V9__renameSteadfastDevotion.ts
@@ -1,0 +1,25 @@
+import type { Migration, RawProfilesBlob } from "./types"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value)
+
+export const V9__renameSteadfastDevotion: Migration = {
+  to: 9,
+  name: "V9__renameSteadfastDevotion",
+  migrate(blob: RawProfilesBlob): RawProfilesBlob {
+    const profiles = Array.isArray(blob.profiles)
+      ? blob.profiles.map((profile) => {
+          if (!isRecord(profile) || !isRecord(profile.inputs)) return profile
+          const mindMethods = profile.inputs.mindMethods
+          if (!Array.isArray(mindMethods)) return profile
+          const renamed = mindMethods.map((slot) =>
+            isRecord(slot) && slot.name === "Lone Loyalty"
+              ? { ...slot, name: "Steadfast Devotion" }
+              : slot,
+          )
+          return { ...profile, inputs: { ...profile.inputs, mindMethods: renamed } }
+        })
+      : blob.profiles
+    return { ...blob, v: 9, profiles }
+  },
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -5,6 +5,7 @@ import { V6__dropDerivedStats } from "./V6__dropDerivedStats"
 import { V7__clampSingleMysticWordRoll } from "./V7__clampSingleMysticWordRoll"
 import { V8__dropRemovedArmorSets } from "./V8__dropRemovedArmorSets"
 import { V9__renameSteadfastDevotion } from "./V9__renameSteadfastDevotion"
+import { V10__renameFrostCladNight } from "./V10__renameFrostCladNight"
 
 export type { Migration, MigrationRunResult, RawProfilesBlob } from "./types"
 export {
@@ -19,6 +20,7 @@ export const PROFILE_MIGRATIONS: readonly Migration[] = [
   V7__clampSingleMysticWordRoll,
   V8__dropRemovedArmorSets,
   V9__renameSteadfastDevotion,
+  V10__renameFrostCladNight,
 ]
 
 const VERSION_BEFORE_THIS_FOLDER = 4

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -4,6 +4,7 @@ import { V5__englishIdsWithoutSitePrefix } from "./V5__englishIdsWithoutSitePref
 import { V6__dropDerivedStats } from "./V6__dropDerivedStats"
 import { V7__clampSingleMysticWordRoll } from "./V7__clampSingleMysticWordRoll"
 import { V8__dropRemovedArmorSets } from "./V8__dropRemovedArmorSets"
+import { V9__renameSteadfastDevotion } from "./V9__renameSteadfastDevotion"
 
 export type { Migration, MigrationRunResult, RawProfilesBlob } from "./types"
 export {
@@ -17,6 +18,7 @@ export const PROFILE_MIGRATIONS: readonly Migration[] = [
   V6__dropDerivedStats,
   V7__clampSingleMysticWordRoll,
   V8__dropRemovedArmorSets,
+  V9__renameSteadfastDevotion,
 ]
 
 const VERSION_BEFORE_THIS_FOLDER = 4

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -146,6 +146,10 @@ const LEGACY_GEAR_WORD_RENAMES: Record<string, string> = {
   "Max Formless": "Max Void Attack",
 }
 
+const LEGACY_MIND_METHOD_RENAMES: Record<string, string> = {
+  "Lone Loyalty": "Steadfast Devotion",
+}
+
 // additive — see CLAUDE.md → "localStorage migrations"
 function hydrateInputs(inputs: Inputs): Inputs {
   const { resistance: _legacyResistance, ...rest } = inputs as Inputs & { resistance?: number }
@@ -245,11 +249,15 @@ function hydrateInputs(inputs: Inputs): Inputs {
     const seen = new Set<string>()
     next.mindMethods = next.mindMethods.map((slot) => {
       if (!slot) return slot
-      const disallowed = !!slot.name && allowed.size > 0 && !allowed.has(slot.name)
-      const duplicate = !!slot.name && seen.has(slot.name)
+      const name = LEGACY_MIND_METHOD_RENAMES[slot.name] ?? slot.name
+      const disallowed = !!name && allowed.size > 0 && !allowed.has(name)
+      const duplicate = !!name && seen.has(name)
       if (disallowed || duplicate) return { ...slot, name: "", stacks: "" }
-      if (slot.name) seen.add(slot.name)
-      return slot.name && !slot.stacks ? { ...slot, stacks: "tier 6" } : slot
+      if (name) seen.add(name)
+      if (name !== slot.name || (name && !slot.stacks)) {
+        return { ...slot, name, stacks: slot.stacks || "tier 6" }
+      }
+      return slot
     }) as Inputs["mindMethods"]
   }
   {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -148,6 +148,7 @@ const LEGACY_GEAR_WORD_RENAMES: Record<string, string> = {
 
 const LEGACY_MIND_METHOD_RENAMES: Record<string, string> = {
   "Lone Loyalty": "Steadfast Devotion",
+  "Frostwhite Night": "Frost-Clad Night",
 }
 
 // additive — see CLAUDE.md → "localStorage migrations"

--- a/tests/engine/mountainSplitter.test.ts
+++ b/tests/engine/mountainSplitter.test.ts
@@ -31,7 +31,7 @@ function affectedSkill(name = "PhalanxCharged-S3") {
   })
 }
 
-describe("Lone Loyalty Mountain Splitter", () => {
+describe("Steadfast Devotion Mountain Splitter", () => {
   it("requires Inner Passion and accepts generated Modao Anxi Soldier triggers at tier 3", () => {
     const withoutInnerPassion = engine(3)
     withoutInnerPassion.processSkillCast("AnxiSoldierMoDown", 1, { generated: true })
@@ -101,7 +101,7 @@ describe("Lone Loyalty Mountain Splitter", () => {
       ...defaultInputs,
       classId: CLASS,
       mindMethods: [
-        { name: "Lone Loyalty", stacks: "tier 4" },
+        { name: "Steadfast Devotion", stacks: "tier 4" },
         { ...emptyMindMethod },
         { ...emptyMindMethod },
         { ...emptyMindMethod },
@@ -110,7 +110,7 @@ describe("Lone Loyalty Mountain Splitter", () => {
 
     expect(row).toMatchObject({
       effect: "×1.32 damage after resource consumption",
-      requires: "Lone Loyalty tier 4+",
+      requires: "Steadfast Devotion tier 4+",
       active: true,
     })
   })
@@ -229,7 +229,7 @@ describe("Lone Loyalty Mountain Splitter", () => {
       affinityRate: 0,
       directAffinityRate: 0,
       mindMethods: [
-        { name: "Lone Loyalty", stacks: "tier 6" },
+        { name: "Steadfast Devotion", stacks: "tier 6" },
         { ...emptyMindMethod },
         { ...emptyMindMethod },
         { ...emptyMindMethod },

--- a/tests/migrations/profileV10RenameFrostCladNight.test.ts
+++ b/tests/migrations/profileV10RenameFrostCladNight.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { importProfile, loadProfiles } from "../../src/storage"
+import {
+  LATEST_PROFILES_VERSION,
+  runProfileMigrations,
+  type RawProfilesBlob,
+} from "../../src/migrations"
+import { V10__renameFrostCladNight } from "../../src/migrations/V10__renameFrostCladNight"
+import type { Inputs, StoredProfile } from "../../src/engine/types"
+import legacyProfileFile from "./testProfiles/profile-v9.json"
+
+const PROFILES_KEY = "wwm.profiles"
+const LEGACY_INPUTS_KEY = "wwm.inputs"
+
+type LegacyFile = { v: number; profile: StoredProfile }
+const LEGACY = legacyProfileFile as unknown as LegacyFile
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function blobOf(profile: StoredProfile): RawProfilesBlob {
+  return { v: LEGACY.v, profiles: [profile], activeId: profile.id }
+}
+
+function inputsOf(blob: RawProfilesBlob): Inputs {
+  return (blob.profiles[0] as StoredProfile).inputs
+}
+
+function frostCladName(inputs: Inputs): string {
+  return inputs.mindMethods[0].name
+}
+
+describe("profile-v9 fixture", () => {
+  it("is v9 and still carries the pre-v10 name", () => {
+    expect(LEGACY.v).toBe(9)
+    expect(LEGACY.v).toBe(V10__renameFrostCladNight.to - 1)
+    expect(LEGACY.profile.inputs.classId).toBe("stonesplitStrength")
+    expect(frostCladName(LEGACY.profile.inputs)).toBe("Frostwhite Night")
+    expect(LEGACY.profile.inputs.inventory.length).toBeGreaterThan(0)
+  })
+})
+
+describe("V10__renameFrostCladNight — called directly", () => {
+  it("renames the stored inner way without changing its tier", () => {
+    const migrated = V10__renameFrostCladNight.migrate(blobOf(clone(LEGACY.profile)))
+    expect(migrated.v).toBe(V10__renameFrostCladNight.to)
+    expect(inputsOf(migrated).mindMethods[0]).toEqual({
+      name: "Frost-Clad Night",
+      stacks: "tier 6",
+    })
+  })
+
+  it("touches nothing else in the inputs", () => {
+    const before = blobOf(clone(LEGACY.profile))
+    const migrated = V10__renameFrostCladNight.migrate(clone(before))
+    const expected = clone(inputsOf(before))
+    expected.mindMethods[0].name = "Frost-Clad Night"
+    expect(inputsOf(migrated)).toEqual(expected)
+  })
+
+  it("leaves an already-correct name unchanged", () => {
+    const profile = clone(LEGACY.profile)
+    profile.inputs.mindMethods[0].name = "Frost-Clad Night"
+    const migrated = V10__renameFrostCladNight.migrate(blobOf(profile))
+    expect(inputsOf(migrated)).toEqual(profile.inputs)
+  })
+
+  it("does not mutate its input and is idempotent", () => {
+    const input = blobOf(clone(LEGACY.profile))
+    const snapshot = clone(input)
+    const once = V10__renameFrostCladNight.migrate(input)
+    expect(input).toEqual(snapshot)
+    expect(V10__renameFrostCladNight.migrate(clone(once))).toEqual(once)
+  })
+})
+
+describe("V10__renameFrostCladNight — registered in the chain", () => {
+  it("walks the v9 fixture through the rename", () => {
+    const result = runProfileMigrations(blobOf(clone(LEGACY.profile)))!
+    expect(result.applied).toContain("V10__renameFrostCladNight")
+    expect(result.blob.v).toBe(LATEST_PROFILES_VERSION)
+    expect(frostCladName(inputsOf(result.blob))).toBe("Frost-Clad Night")
+  })
+})
+
+describe("V10__renameFrostCladNight — storage paths", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("upgrades and persists a saved profile without losing its build", () => {
+    localStorage.setItem(PROFILES_KEY, JSON.stringify(blobOf(clone(LEGACY.profile))))
+    const { profiles } = loadProfiles()
+    const loaded = profiles[0]
+    expect(frostCladName(loaded.inputs)).toBe("Frost-Clad Night")
+    expect(loaded.id).toBe(LEGACY.profile.id)
+    expect(loaded.name).toBe(LEGACY.profile.name)
+    expect(loaded.inputs.breakthrough).toBe(LEGACY.profile.inputs.breakthrough)
+    expect(loaded.inputs.arsenal).toBe(LEGACY.profile.inputs.arsenal)
+    expect(loaded.inputs.inventory).toHaveLength(LEGACY.profile.inputs.inventory.length)
+    expect(loaded.inputs.equipped).toEqual(LEGACY.profile.inputs.equipped)
+
+    const persisted = JSON.parse(localStorage.getItem(PROFILES_KEY)!)
+    expect(persisted.v).toBe(LATEST_PROFILES_VERSION)
+    expect(persisted.profiles[0].inputs.mindMethods[0].name).toBe("Frost-Clad Night")
+  })
+
+  it("is idempotent across repeated loads", () => {
+    localStorage.setItem(PROFILES_KEY, JSON.stringify(blobOf(clone(LEGACY.profile))))
+    const once = loadProfiles()
+    expect(loadProfiles()).toEqual(once)
+  })
+
+  it("renames the old name in a bare imported profile", () => {
+    expect(frostCladName(importProfile(JSON.stringify(LEGACY.profile)).inputs)).toBe(
+      "Frost-Clad Night",
+    )
+  })
+
+  it("renames the old name in the legacy inputs store", () => {
+    localStorage.setItem(
+      LEGACY_INPUTS_KEY,
+      JSON.stringify({ v: 5, inputs: clone(LEGACY.profile.inputs) }),
+    )
+    expect(frostCladName(loadProfiles().profiles[0].inputs)).toBe("Frost-Clad Night")
+  })
+})

--- a/tests/migrations/profileV4.test.ts
+++ b/tests/migrations/profileV4.test.ts
@@ -59,6 +59,7 @@ describe("V5 step — v4 → v5 in isolation", () => {
       "V6__dropDerivedStats",
       "V7__clampSingleMysticWordRoll",
       "V8__dropRemovedArmorSets",
+      "V9__renameSteadfastDevotion",
     ])
     expect(result.blob.v).toBe(LATEST_PROFILES_VERSION)
   })

--- a/tests/migrations/profileV4.test.ts
+++ b/tests/migrations/profileV4.test.ts
@@ -60,6 +60,7 @@ describe("V5 step — v4 → v5 in isolation", () => {
       "V7__clampSingleMysticWordRoll",
       "V8__dropRemovedArmorSets",
       "V9__renameSteadfastDevotion",
+      "V10__renameFrostCladNight",
     ])
     expect(result.blob.v).toBe(LATEST_PROFILES_VERSION)
   })

--- a/tests/migrations/profileV8DropRemovedArmorSets.test.ts
+++ b/tests/migrations/profileV8DropRemovedArmorSets.test.ts
@@ -55,7 +55,7 @@ function loadOne(): StoredProfile {
 describe("profile-v7 fixture", () => {
   it("is v7 and still carries the pre-v8 shape", () => {
     expect(LEGACY.v).toBe(7)
-    expect(LEGACY.v).toBe(LATEST_PROFILES_VERSION - 1)
+    expect(LEGACY.v).toBe(V8__dropRemovedArmorSets.to - 1)
     expect(LEGACY.profile.inputs.classId).toBe("bellstrikeUmbra")
     expect(LEGACY.profile.inputs.set).toBe("Hawking")
     expect(LEGACY.profile.inputs.inventory.length).toBeGreaterThan(0)

--- a/tests/migrations/profileV9RenameSteadfastDevotion.test.ts
+++ b/tests/migrations/profileV9RenameSteadfastDevotion.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { importProfile, loadProfiles } from "../../src/storage"
+import {
+  LATEST_PROFILES_VERSION,
+  runProfileMigrations,
+  type RawProfilesBlob,
+} from "../../src/migrations"
+import { V9__renameSteadfastDevotion } from "../../src/migrations/V9__renameSteadfastDevotion"
+import type { Inputs, StoredProfile } from "../../src/engine/types"
+import legacyProfileFile from "./testProfiles/profile-v8.json"
+
+const PROFILES_KEY = "wwm.profiles"
+const LEGACY_INPUTS_KEY = "wwm.inputs"
+
+type LegacyFile = { v: number; profile: StoredProfile }
+const LEGACY = legacyProfileFile as unknown as LegacyFile
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function blobOf(profile: StoredProfile): RawProfilesBlob {
+  return { v: LEGACY.v, profiles: [profile], activeId: profile.id }
+}
+
+function inputsOf(blob: RawProfilesBlob): Inputs {
+  return (blob.profiles[0] as StoredProfile).inputs
+}
+
+function steadfastName(inputs: Inputs): string {
+  return inputs.mindMethods[2].name
+}
+
+describe("profile-v8 fixture", () => {
+  it("is v8 and still carries the pre-v9 name", () => {
+    expect(LEGACY.v).toBe(8)
+    expect(LEGACY.v).toBe(V9__renameSteadfastDevotion.to - 1)
+    expect(LEGACY.profile.inputs.classId).toBe("stonesplitStrength")
+    expect(steadfastName(LEGACY.profile.inputs)).toBe("Lone Loyalty")
+    expect(LEGACY.profile.inputs.inventory.length).toBeGreaterThan(0)
+  })
+})
+
+describe("V9__renameSteadfastDevotion — called directly", () => {
+  it("renames the stored inner way without changing its tier", () => {
+    const migrated = V9__renameSteadfastDevotion.migrate(blobOf(clone(LEGACY.profile)))
+    expect(migrated.v).toBe(V9__renameSteadfastDevotion.to)
+    expect(inputsOf(migrated).mindMethods[2]).toEqual({
+      name: "Steadfast Devotion",
+      stacks: "tier 6",
+    })
+  })
+
+  it("touches nothing else in the inputs", () => {
+    const before = blobOf(clone(LEGACY.profile))
+    const migrated = V9__renameSteadfastDevotion.migrate(clone(before))
+    const expected = clone(inputsOf(before))
+    expected.mindMethods[2].name = "Steadfast Devotion"
+    expect(inputsOf(migrated)).toEqual(expected)
+  })
+
+  it("leaves an already-correct name unchanged", () => {
+    const profile = clone(LEGACY.profile)
+    profile.inputs.mindMethods[2].name = "Steadfast Devotion"
+    const migrated = V9__renameSteadfastDevotion.migrate(blobOf(profile))
+    expect(inputsOf(migrated)).toEqual(profile.inputs)
+  })
+
+  it("does not mutate its input and is idempotent", () => {
+    const input = blobOf(clone(LEGACY.profile))
+    const snapshot = clone(input)
+    const once = V9__renameSteadfastDevotion.migrate(input)
+    expect(input).toEqual(snapshot)
+    expect(V9__renameSteadfastDevotion.migrate(clone(once))).toEqual(once)
+  })
+})
+
+describe("V9__renameSteadfastDevotion — registered in the chain", () => {
+  it("walks the v8 fixture through the rename", () => {
+    const result = runProfileMigrations(blobOf(clone(LEGACY.profile)))!
+    expect(result.applied).toContain("V9__renameSteadfastDevotion")
+    expect(result.blob.v).toBe(LATEST_PROFILES_VERSION)
+    expect(steadfastName(inputsOf(result.blob))).toBe("Steadfast Devotion")
+  })
+})
+
+describe("V9__renameSteadfastDevotion — storage paths", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("upgrades and persists a saved profile without losing its build", () => {
+    localStorage.setItem(PROFILES_KEY, JSON.stringify(blobOf(clone(LEGACY.profile))))
+    const { profiles } = loadProfiles()
+    const loaded = profiles[0]
+    expect(steadfastName(loaded.inputs)).toBe("Steadfast Devotion")
+    expect(loaded.id).toBe(LEGACY.profile.id)
+    expect(loaded.name).toBe(LEGACY.profile.name)
+    expect(loaded.inputs.breakthrough).toBe(LEGACY.profile.inputs.breakthrough)
+    expect(loaded.inputs.arsenal).toBe(LEGACY.profile.inputs.arsenal)
+    expect(loaded.inputs.inventory).toHaveLength(LEGACY.profile.inputs.inventory.length)
+    expect(loaded.inputs.equipped).toEqual(LEGACY.profile.inputs.equipped)
+
+    const persisted = JSON.parse(localStorage.getItem(PROFILES_KEY)!)
+    expect(persisted.v).toBe(LATEST_PROFILES_VERSION)
+    expect(persisted.profiles[0].inputs.mindMethods[2].name).toBe("Steadfast Devotion")
+  })
+
+  it("is idempotent across repeated loads", () => {
+    localStorage.setItem(PROFILES_KEY, JSON.stringify(blobOf(clone(LEGACY.profile))))
+    const once = loadProfiles()
+    expect(loadProfiles()).toEqual(once)
+  })
+
+  it("renames the old name in a bare imported profile", () => {
+    expect(steadfastName(importProfile(JSON.stringify(LEGACY.profile)).inputs)).toBe(
+      "Steadfast Devotion",
+    )
+  })
+
+  it("renames the old name in the legacy inputs store", () => {
+    localStorage.setItem(
+      LEGACY_INPUTS_KEY,
+      JSON.stringify({ v: 5, inputs: clone(LEGACY.profile.inputs) }),
+    )
+    expect(steadfastName(loadProfiles().profiles[0].inputs)).toBe("Steadfast Devotion")
+  })
+})

--- a/tests/migrations/testProfiles/profile-v8.json
+++ b/tests/migrations/testProfiles/profile-v8.json
@@ -1,0 +1,776 @@
+{
+  "v": 8,
+  "profile": {
+    "id": "pr-ms9h5obb-umkihk-2",
+    "name": "Mizukee",
+    "inputs": {
+      "classId": "stonesplitStrength",
+      "breakthrough": 16,
+      "allDamageBoost": 0,
+      "mindMethods": [
+        {
+          "name": "Bitter Season",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Throat-Pierce",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Lone Loyalty",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Morale Chant",
+          "stacks": "tier 6"
+        }
+      ],
+      "food": true,
+      "tianGongElement": "fire",
+      "set": "Hawking",
+      "shareDebuff5HenZhi": false,
+      "shareEasyHurt": false,
+      "bowSet": "affinity",
+      "arsenal": "stonesplit",
+      "dummyMode": true,
+      "rotation": null,
+      "activeCustomRotation": null,
+      "inventory": [
+        {
+          "id": "gp-ms9h9cgs-269r62-1",
+          "slot": "leftWeapon",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 65,
+          "maxPhys": 151,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Void Attack",
+              "value": 37.3,
+              "retuned": false
+            },
+            {
+              "word": "Max Void Attack",
+              "value": 39.2,
+              "retuned": false
+            },
+            {
+              "word": "Sword Martial Boost",
+              "value": 0.058,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 73.1,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 45.6,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.107,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hahfr-5uvjeo-2",
+          "slot": "rightWeapon",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 59,
+          "maxPhys": 136,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 70.4,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 45.9,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.041,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 44.4,
+              "retuned": true
+            },
+            {
+              "word": "Max Phys",
+              "value": 73.1,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hccrh-6y8qcx-3",
+          "slot": "disc",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 86,
+          "maxPhys": 0,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 63.5,
+              "retuned": false
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 34,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 60,
+              "retuned": false
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.024,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hdmcx-30tt7f-4",
+          "slot": "pendant",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 116,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 70.4,
+              "retuned": false
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.02,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 41.8,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 64.5,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 44.8,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.093,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hfcpj-r5uvyj-5",
+          "slot": "helm",
+          "level": 91,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4614,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.035,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.034,
+              "retuned": false
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 34.4,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.069,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 63.8,
+              "retuned": true
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.05,
+          "relayed": false
+        },
+        {
+          "id": "gp-ms9hh82z-aba86x-6",
+          "slot": "armor",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 9227,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 40.4,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 63.8,
+              "retuned": true
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": false
+            },
+            {
+              "word": "Max Bamboocut",
+              "value": 36.2,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.052,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hiw6b-wxbo56-7",
+          "slot": "greaves",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4153,
+          "physDef": 32,
+          "words": [
+            {
+              "word": "Power",
+              "value": 44.6,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 70.5,
+              "retuned": false
+            },
+            {
+              "word": "Damage VS Boss %",
+              "value": 0.03,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": true
+            },
+            {
+              "word": "Power",
+              "value": 44.6,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.058,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hkp0q-4bwvf2-8",
+          "slot": "bracer",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4153,
+          "physDef": 16,
+          "words": [
+            {
+              "word": "Power",
+              "value": 38,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.07,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 60,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 38,
+              "retuned": true
+            },
+            {
+              "word": "Power",
+              "value": 38,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.05,
+          "relayed": true
+        },
+        {
+          "id": "gp-msausuvc-l1u40i-4",
+          "slot": "armor",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 9227,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.043,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.044,
+              "retuned": true
+            },
+            {
+              "word": "Min Silkbind",
+              "value": 44.2,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 68.6,
+              "retuned": false
+            },
+            {
+              "word": "Single-Target Mystic Skill DMG Boost",
+              "value": 0.078,
+              "retuned": false
+            }
+          ],
+          "attunement": "",
+          "attunementValue": 0,
+          "relayed": false
+        },
+        {
+          "id": "gp-mscbnonp-1zyh3n-1",
+          "slot": "helm",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4614,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": true
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 36.2,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 70.8,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 44.8,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.055,
+          "relayed": true
+        },
+        {
+          "id": "gp-mshtzfiu-b8llz0-2",
+          "slot": "disc",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 86,
+          "maxPhys": 0,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 68.2,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 45.5,
+              "retuned": true
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.032,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 76,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.07,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": false
+        }
+      ],
+      "equipped": {
+        "leftWeapon": "gp-ms9h9cgs-269r62-1",
+        "rightWeapon": "gp-ms9hahfr-5uvjeo-2",
+        "disc": "gp-ms9hccrh-6y8qcx-3",
+        "pendant": "gp-ms9hdmcx-30tt7f-4",
+        "helm": "gp-mscbnonp-1zyh3n-1",
+        "armor": "gp-ms9hh82z-aba86x-6",
+        "greaves": "gp-ms9hiw6b-wxbo56-7",
+        "bracer": "gp-ms9hkp0q-4bwvf2-8"
+      },
+      "martialArtsTalents": [
+        {
+          "id": "default-bellstrikeUmbra-0",
+          "name": "Affinity Rate UP",
+          "enabled": true,
+          "stat": "affinityRate",
+          "maxBonus": 0.043,
+          "scalesWith": "power",
+          "scaleMax": 280
+        },
+        {
+          "id": "default-bellstrikeUmbra-1",
+          "name": "Physical Attack UP",
+          "enabled": true,
+          "stat": "maxPhys",
+          "maxBonus": 73.9,
+          "scalesWith": "power",
+          "scaleMax": 280
+        },
+        {
+          "id": "default-bellstrikeUmbra-2",
+          "name": "Sword Bellstrike Attack Min",
+          "enabled": true,
+          "stat": "minBellstrike",
+          "maxBonus": 98,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-3",
+          "name": "Sword Bellstrike Attack Max",
+          "enabled": true,
+          "stat": "maxBellstrike",
+          "maxBonus": 196,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-4",
+          "name": "Spear Bellstrike Attack Min",
+          "enabled": true,
+          "stat": "minBellstrike",
+          "maxBonus": 98,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-5",
+          "name": "Spear Bellstrike Attack Max",
+          "enabled": true,
+          "stat": "maxBellstrike",
+          "maxBonus": 196,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-6",
+          "name": "Bellstrike Penetration Scale",
+          "enabled": true,
+          "stat": "bellstrikePenetration",
+          "maxBonus": 0.22,
+          "scalesWith": "bellstrike.max",
+          "scaleMax": 655
+        },
+        {
+          "id": "default-bellstrikeUmbra-7",
+          "name": "Attribute Damage Scale",
+          "enabled": true,
+          "stat": "attributeDamage",
+          "maxBonus": 0.11,
+          "scalesWith": "bellstrike.max",
+          "scaleMax": 655
+        }
+      ],
+      "oddities": {
+        "Qinghe": [
+          {
+            "id": 1,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Kaifeng": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 7,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 8,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 9,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 10,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Hexi": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Kaifeng Palace": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Hidden Mountain: Suixiang": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ]
+      },
+      "combatSettings": {
+        "qiBreak": {
+          "enabled": true,
+          "startSec": 25,
+          "durationSec": 10
+        },
+        "dragonsBreath": false,
+        "healerBuff": false,
+        "breakExtension": false,
+        "revelryScript": false
+      },
+      "selectedBuiltinRotationId": null
+    }
+  }
+}

--- a/tests/migrations/testProfiles/profile-v9.json
+++ b/tests/migrations/testProfiles/profile-v9.json
@@ -1,0 +1,776 @@
+{
+  "v": 9,
+  "profile": {
+    "id": "pr-ms9h5obb-umkihk-2",
+    "name": "Mizukee",
+    "inputs": {
+      "classId": "stonesplitStrength",
+      "breakthrough": 16,
+      "allDamageBoost": 0,
+      "mindMethods": [
+        {
+          "name": "Frostwhite Night",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Throat-Pierce",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Steadfast Devotion",
+          "stacks": "tier 6"
+        },
+        {
+          "name": "Morale Chant",
+          "stacks": "tier 6"
+        }
+      ],
+      "food": true,
+      "tianGongElement": "fire",
+      "set": "Hawking",
+      "shareDebuff5HenZhi": false,
+      "shareEasyHurt": false,
+      "bowSet": "affinity",
+      "arsenal": "stonesplit",
+      "dummyMode": true,
+      "rotation": null,
+      "activeCustomRotation": null,
+      "inventory": [
+        {
+          "id": "gp-ms9h9cgs-269r62-1",
+          "slot": "leftWeapon",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 65,
+          "maxPhys": 151,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Void Attack",
+              "value": 37.3,
+              "retuned": false
+            },
+            {
+              "word": "Max Void Attack",
+              "value": 39.2,
+              "retuned": false
+            },
+            {
+              "word": "Sword Martial Boost",
+              "value": 0.058,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 73.1,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 45.6,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.107,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hahfr-5uvjeo-2",
+          "slot": "rightWeapon",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 59,
+          "maxPhys": 136,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 70.4,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 45.9,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.041,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 44.4,
+              "retuned": true
+            },
+            {
+              "word": "Max Phys",
+              "value": 73.1,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hccrh-6y8qcx-3",
+          "slot": "disc",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 86,
+          "maxPhys": 0,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 63.5,
+              "retuned": false
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 34,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 60,
+              "retuned": false
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.024,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hdmcx-30tt7f-4",
+          "slot": "pendant",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 116,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 70.4,
+              "retuned": false
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.02,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 41.8,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 64.5,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 44.8,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.093,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hfcpj-r5uvyj-5",
+          "slot": "helm",
+          "level": 91,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4614,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.035,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.034,
+              "retuned": false
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 34.4,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.069,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 63.8,
+              "retuned": true
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.05,
+          "relayed": false
+        },
+        {
+          "id": "gp-ms9hh82z-aba86x-6",
+          "slot": "armor",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 9227,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 40.4,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 63.8,
+              "retuned": true
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": false
+            },
+            {
+              "word": "Max Bamboocut",
+              "value": 36.2,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.052,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hiw6b-wxbo56-7",
+          "slot": "greaves",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4153,
+          "physDef": 32,
+          "words": [
+            {
+              "word": "Power",
+              "value": 44.6,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 70.5,
+              "retuned": false
+            },
+            {
+              "word": "Damage VS Boss %",
+              "value": 0.03,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.038,
+              "retuned": true
+            },
+            {
+              "word": "Power",
+              "value": 44.6,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.058,
+          "relayed": true
+        },
+        {
+          "id": "gp-ms9hkp0q-4bwvf2-8",
+          "slot": "bracer",
+          "level": 96,
+          "rarity": "epic",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4153,
+          "physDef": 16,
+          "words": [
+            {
+              "word": "Power",
+              "value": 38,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.07,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 60,
+              "retuned": false
+            },
+            {
+              "word": "Momentum",
+              "value": 38,
+              "retuned": true
+            },
+            {
+              "word": "Power",
+              "value": 38,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.05,
+          "relayed": true
+        },
+        {
+          "id": "gp-msausuvc-l1u40i-4",
+          "slot": "armor",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 9227,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.043,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.044,
+              "retuned": true
+            },
+            {
+              "word": "Min Silkbind",
+              "value": 44.2,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 68.6,
+              "retuned": false
+            },
+            {
+              "word": "Single-Target Mystic Skill DMG Boost",
+              "value": 0.078,
+              "retuned": false
+            }
+          ],
+          "attunement": "",
+          "attunementValue": 0,
+          "relayed": false
+        },
+        {
+          "id": "gp-mscbnonp-1zyh3n-1",
+          "slot": "helm",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 0,
+          "maxPhys": 0,
+          "hp": 4614,
+          "physDef": 18,
+          "words": [
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": false
+            },
+            {
+              "word": "Affinity",
+              "value": 0.04,
+              "retuned": true
+            },
+            {
+              "word": "Max Bellstrike",
+              "value": 36.2,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 70.8,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 44.8,
+              "retuned": false
+            }
+          ],
+          "attunement": "bleedingDamage",
+          "attunementValue": 0.055,
+          "relayed": true
+        },
+        {
+          "id": "gp-mshtzfiu-b8llz0-2",
+          "slot": "disc",
+          "level": 96,
+          "rarity": "legendary",
+          "minPhys": 86,
+          "maxPhys": 0,
+          "hp": 0,
+          "physDef": 0,
+          "words": [
+            {
+              "word": "Max Phys",
+              "value": 68.2,
+              "retuned": false
+            },
+            {
+              "word": "Power",
+              "value": 45.5,
+              "retuned": true
+            },
+            {
+              "word": "All Martial Boost",
+              "value": 0.032,
+              "retuned": false
+            },
+            {
+              "word": "Max Phys",
+              "value": 76,
+              "retuned": false
+            },
+            {
+              "word": "Crit",
+              "value": 0.07,
+              "retuned": false
+            }
+          ],
+          "attunement": "physPen",
+          "attunementValue": 0.098,
+          "relayed": false
+        }
+      ],
+      "equipped": {
+        "leftWeapon": "gp-ms9h9cgs-269r62-1",
+        "rightWeapon": "gp-ms9hahfr-5uvjeo-2",
+        "disc": "gp-ms9hccrh-6y8qcx-3",
+        "pendant": "gp-ms9hdmcx-30tt7f-4",
+        "helm": "gp-mscbnonp-1zyh3n-1",
+        "armor": "gp-ms9hh82z-aba86x-6",
+        "greaves": "gp-ms9hiw6b-wxbo56-7",
+        "bracer": "gp-ms9hkp0q-4bwvf2-8"
+      },
+      "martialArtsTalents": [
+        {
+          "id": "default-bellstrikeUmbra-0",
+          "name": "Affinity Rate UP",
+          "enabled": true,
+          "stat": "affinityRate",
+          "maxBonus": 0.043,
+          "scalesWith": "power",
+          "scaleMax": 280
+        },
+        {
+          "id": "default-bellstrikeUmbra-1",
+          "name": "Physical Attack UP",
+          "enabled": true,
+          "stat": "maxPhys",
+          "maxBonus": 73.9,
+          "scalesWith": "power",
+          "scaleMax": 280
+        },
+        {
+          "id": "default-bellstrikeUmbra-2",
+          "name": "Sword Bellstrike Attack Min",
+          "enabled": true,
+          "stat": "minBellstrike",
+          "maxBonus": 98,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-3",
+          "name": "Sword Bellstrike Attack Max",
+          "enabled": true,
+          "stat": "maxBellstrike",
+          "maxBonus": 196,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-4",
+          "name": "Spear Bellstrike Attack Min",
+          "enabled": true,
+          "stat": "minBellstrike",
+          "maxBonus": 98,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-5",
+          "name": "Spear Bellstrike Attack Max",
+          "enabled": true,
+          "stat": "maxBellstrike",
+          "maxBonus": 196,
+          "scalesWith": "power",
+          "scaleMax": 0
+        },
+        {
+          "id": "default-bellstrikeUmbra-6",
+          "name": "Bellstrike Penetration Scale",
+          "enabled": true,
+          "stat": "bellstrikePenetration",
+          "maxBonus": 0.22,
+          "scalesWith": "bellstrike.max",
+          "scaleMax": 655
+        },
+        {
+          "id": "default-bellstrikeUmbra-7",
+          "name": "Attribute Damage Scale",
+          "enabled": true,
+          "stat": "attributeDamage",
+          "maxBonus": 0.11,
+          "scalesWith": "bellstrike.max",
+          "scaleMax": 655
+        }
+      ],
+      "oddities": {
+        "Qinghe": [
+          {
+            "id": 1,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Kaifeng": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 7,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 8,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 9,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 10,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Hexi": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Kaifeng Palace": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ],
+        "Hidden Mountain: Suixiang": [
+          {
+            "id": 1,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 2,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 3,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 4,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 5,
+            "stat": "minPhys",
+            "value": 4,
+            "enabled": true
+          },
+          {
+            "id": 6,
+            "stat": "maxPhys",
+            "value": 4,
+            "enabled": true
+          }
+        ]
+      },
+      "combatSettings": {
+        "qiBreak": {
+          "enabled": true,
+          "startSec": 25,
+          "durationSec": 10
+        },
+        "dragonsBreath": false,
+        "healerBuff": false,
+        "breakExtension": false,
+        "revelryScript": false
+      },
+      "selectedBuiltinRotationId": null
+    }
+  }
+}


### PR DESCRIPTION
This PR:
- Renamed Lone Loyalty to Steadfast Devotion
- Renamed Frostwhite Night to Frost-Clad Night
- Fixed an issue where the 36% boost from Frost-Clad Night was being applied to the coeffs of snowparting vc already. This brings down the DPS generated by snowparting vc down about 50k for the switch without toad rotation which matches the ingame test data

Tested locally and the existing profiles auto selected the correct inner ways