### PR TITLE
feat(gear): import a build from the official WWM dashboard

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,7 +1,7 @@
 # TESTING.md — test conventions
 
-`pnpm test` runs vitest (jsdom, globals on, `tests/setup.ts`). Today: **573 tests
-across 65 files**, all green. Keep it that way — a red suite on `main` is not a
+`pnpm test` runs vitest (jsdom, globals on, `tests/setup.ts`). Today: **816 tests
+across 82 files**, all green. Keep it that way — a red suite on `main` is not a
 state this repo tolerates.
 
 ## Class scoping — the suite is Umbra-only

--- a/src/engine/gearStats.ts
+++ b/src/engine/gearStats.ts
@@ -6,9 +6,11 @@ import { addStatDelta, resolveEnginePath } from "./statPaths"
 
 export const RELAYED_FACTOR = 0.94
 
+// Kept to the precision the UI shows — two decimals, which for a percent word
+// means four on the stored fraction.
 export function relayedCapValue(amount: number, unit: "raw" | "percent"): number {
   const raw = amount * RELAYED_FACTOR
-  return unit === "percent" ? Math.round(raw * 1000) / 1000 : Math.round(raw * 10) / 10
+  return unit === "percent" ? Math.round(raw * 10000) / 10000 : Math.round(raw * 100) / 100
 }
 
 export interface GearBaseStats {
@@ -73,21 +75,26 @@ const GEAR_BASE_STATS: Partial<
       epic: { minPhys: 0, maxPhys: 116, hp: 0, physDef: 0 },
       legendary: { minPhys: 0, maxPhys: 129, hp: 0, physDef: 0 },
     },
+    // lv96 armor, from a live lvl-96 build (2026-08-11): helm legendary 22/5774,
+    // armor legendary 22/11547, greaves epic 39/5196, bracer epic 20/5196. Helm and
+    // bracer share one row and armor is twice helm, which fixes the other three
+    // cells; only greaves legendary defense is extrapolated (39 × the observed
+    // 22/20 rarity step) and is the one number here still to be confirmed in game.
     helm: {
-      epic: { minPhys: 0, maxPhys: 0, hp: 4153, physDef: 16 },
-      legendary: { minPhys: 0, maxPhys: 0, hp: 4614, physDef: 18 },
+      epic: { minPhys: 0, maxPhys: 0, hp: 5196, physDef: 20 },
+      legendary: { minPhys: 0, maxPhys: 0, hp: 5774, physDef: 22 },
     },
     armor: {
-      epic: { minPhys: 0, maxPhys: 0, hp: 8305, physDef: 16 },
-      legendary: { minPhys: 0, maxPhys: 0, hp: 9227, physDef: 18 },
+      epic: { minPhys: 0, maxPhys: 0, hp: 10392, physDef: 20 },
+      legendary: { minPhys: 0, maxPhys: 0, hp: 11547, physDef: 22 },
     },
     greaves: {
-      epic: { minPhys: 0, maxPhys: 0, hp: 4153, physDef: 32 },
-      legendary: { minPhys: 0, maxPhys: 0, hp: 4614, physDef: 36 },
+      epic: { minPhys: 0, maxPhys: 0, hp: 5196, physDef: 39 },
+      legendary: { minPhys: 0, maxPhys: 0, hp: 5774, physDef: 43 },
     },
     bracer: {
-      epic: { minPhys: 0, maxPhys: 0, hp: 4153, physDef: 16 },
-      legendary: { minPhys: 0, maxPhys: 0, hp: 4614, physDef: 18 },
+      epic: { minPhys: 0, maxPhys: 0, hp: 5196, physDef: 20 },
+      legendary: { minPhys: 0, maxPhys: 0, hp: 5774, physDef: 22 },
     },
   },
 }
@@ -99,6 +106,55 @@ export function gearBaseStatsFor(
 ): GearBaseStats {
   const byLevel = GEAR_BASE_STATS[piece.level] ?? GEAR_BASE_STATS[91]!
   return byLevel[piece.slot]?.[piece.rarity] ?? ZERO_BASE
+}
+
+export interface GearIdentity {
+  level: GearLevel
+  rarity: GearRarity
+}
+
+export interface InferredGearIdentity {
+  level: GearLevel | null
+  rarity: GearRarity | null
+  candidates: readonly GearIdentity[]
+}
+
+const TABLED_LEVELS: readonly GearLevel[] = [91, 96]
+const RARITIES: readonly GearRarity[] = ["legendary", "epic"]
+
+function comparedFields(slot: GearSlot): readonly (keyof GearBaseStats)[] {
+  return isWeaponSlot(slot) ? ["minPhys", "maxPhys"] : ["hp", "physDef"]
+}
+
+/**
+ * Recovers a piece's level and rarity from the base stats the game reports for
+ * it. An axis that the observed stats cannot pin comes back null with every
+ * candidate listed; lv86 has no table row and is never inferred.
+ */
+export function inferGearIdentity(
+  slot: GearSlot,
+  observed: Partial<GearBaseStats>,
+): InferredGearIdentity {
+  const fields = comparedFields(slot).filter((field) => typeof observed[field] === "number")
+  if (!fields.length) return { level: null, rarity: null, candidates: [] }
+
+  const candidates: GearIdentity[] = []
+  for (const level of TABLED_LEVELS) {
+    for (const rarity of RARITIES) {
+      const tabled = gearBaseStatsFor({ slot, level, rarity })
+      if (fields.every((field) => tabled[field] === observed[field])) {
+        candidates.push({ level, rarity })
+      }
+    }
+  }
+
+  const levels = new Set(candidates.map((candidate) => candidate.level))
+  const rarities = new Set(candidates.map((candidate) => candidate.rarity))
+  return {
+    level: levels.size === 1 ? [...levels][0]! : null,
+    rarity: rarities.size === 1 ? [...rarities][0]! : null,
+    candidates,
+  }
 }
 
 export interface GearContribEntry {

--- a/src/engine/gearStats.ts
+++ b/src/engine/gearStats.ts
@@ -75,11 +75,12 @@ const GEAR_BASE_STATS: Partial<
       epic: { minPhys: 0, maxPhys: 116, hp: 0, physDef: 0 },
       legendary: { minPhys: 0, maxPhys: 129, hp: 0, physDef: 0 },
     },
-    // lv96 armor, from a live lvl-96 build (2026-08-11): helm legendary 22/5774,
-    // armor legendary 22/11547, greaves epic 39/5196, bracer epic 20/5196. Helm and
-    // bracer share one row and armor is twice helm, which fixes the other three
-    // cells; only greaves legendary defense is extrapolated (39 × the observed
-    // 22/20 rarity step) and is the one number here still to be confirmed in game.
+    // lv96 armor, reported from a live lvl-96 build (2026-08-11): helm legendary
+    // 22/5774, armor legendary 22/11547, greaves 39 epic and 44 legendary defense
+    // over 5196 hp, bracer epic 20/5196. Helm and bracer share one row and armor is
+    // twice helm, which fills the cells not observed directly. Note greaves defense
+    // is twice helm's at legendary but not at epic (39, not 40), so the two rarities
+    // do not scale from one another here.
     helm: {
       epic: { minPhys: 0, maxPhys: 0, hp: 5196, physDef: 20 },
       legendary: { minPhys: 0, maxPhys: 0, hp: 5774, physDef: 22 },
@@ -90,7 +91,7 @@ const GEAR_BASE_STATS: Partial<
     },
     greaves: {
       epic: { minPhys: 0, maxPhys: 0, hp: 5196, physDef: 39 },
-      legendary: { minPhys: 0, maxPhys: 0, hp: 5774, physDef: 43 },
+      legendary: { minPhys: 0, maxPhys: 0, hp: 5774, physDef: 44 },
     },
     bracer: {
       epic: { minPhys: 0, maxPhys: 0, hp: 5196, physDef: 20 },

--- a/src/ui/components/confirm-dialog/ConfirmDialog.module.scss
+++ b/src/ui/components/confirm-dialog/ConfirmDialog.module.scss
@@ -1,7 +1,9 @@
 .confirmOverlay {
   position: fixed;
   inset: 0;
-  z-index: 1100;
+  // Above every dialog (1200) and the combobox dropdown portal (1300): a confirm
+  // blocks the thing that raised it.
+  z-index: 1400;
   background: var(--color-overlay);
   backdrop-filter: blur(2px);
   display: flex;

--- a/src/ui/components/number-inputs/NumberInputs.tsx
+++ b/src/ui/components/number-inputs/NumberInputs.tsx
@@ -50,7 +50,11 @@ function NumberLikeInput({
   )
 }
 
-const numFormat = (v: number) => String(v)
+// Display only — the stored value keeps its full precision until the user edits
+// the field. Imported gear rolls carry many decimals (45.568999…), and the
+// sub-0.01 branch is what stops a small coefficient from rendering as plain 0.
+const numFormat = (v: number) =>
+  String(v !== 0 && Math.abs(v) < 0.01 ? +v.toFixed(4) : +v.toFixed(2))
 const numParse = (s: string) => Number(s)
 const pctFormat = (v: number) => String(+(v * 100).toFixed(2))
 const pctParse = (s: string) => Number(s) / 100

--- a/src/ui/features/gear/gear-piece-form/GearPieceForm.module.scss
+++ b/src/ui/features/gear/gear-piece-form/GearPieceForm.module.scss
@@ -80,16 +80,24 @@
   margin-bottom: 6px;
 }
 
+/* One grid for every word row, with the rows themselves transparent — a grid per
+   row would size its `auto` max column to its own text, so a wider figure in one
+   row would leave that row's border-left out of line with the others. */
 .gearWordsGrid {
-  display: flex;
-  flex-direction: column;
-}
-
-.wordRow {
   display: grid;
   grid-template-columns: 1fr 90px 32px auto;
   column-gap: 6px;
   align-items: center;
+}
+
+/* Without the max figures a row contributes three cells, and a fourth track would
+   pull the next row's first cell into it. */
+.gearWordsGridNoMax {
+  grid-template-columns: 1fr 90px 32px;
+}
+
+.wordRow {
+  display: contents;
 }
 
 .wordRow > input,
@@ -116,6 +124,7 @@
 .gearWordMax {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 6px;
   margin-left: 6px;
   padding: 0 2px 0 10px;
@@ -129,11 +138,11 @@
   font-variant-numeric: tabular-nums;
   text-align: right;
   white-space: nowrap;
-  min-width: 2.4em;
+  min-width: 3.6em;
   color: var(--color-text-dim);
 }
 .maxDelta {
-  min-width: 2.8em;
+  min-width: 3em;
 }
 .maxDelta:global(.is-positive) {
   color: var(--color-positive);

--- a/src/ui/features/gear/gear-piece-form/GearPieceForm.tsx
+++ b/src/ui/features/gear/gear-piece-form/GearPieceForm.tsx
@@ -106,9 +106,10 @@ export function GearPieceForm({
     if (!spec) return null
     return relayed ? relayedCapValue(spec.amount, spec.unit) : spec.amount
   }
-  function round1(value: number, isPercent: boolean): number {
+  // Two decimals as displayed, so a percent word keeps four on its fraction.
+  function roundToShownPrecision(value: number, isPercent: boolean): number {
     if (!Number.isFinite(value)) return value
-    return isPercent ? Math.round(value * 1000) / 1000 : Math.round(value * 10) / 10
+    return isPercent ? Math.round(value * 10000) / 10000 : Math.round(value * 100) / 100
   }
 
   function patch(fields: Partial<GearPiece>): void {
@@ -129,7 +130,7 @@ export function GearPieceForm({
     const spec = wordSpecs.find((candidate) => candidate.word === word)
     if (!spec || !Number.isFinite(value)) return value
     const cap = relayed ? relayedCapValue(spec.amount, spec.unit) : spec.amount
-    return round1(Math.min(Math.max(value, 0), cap), spec.unit === "percent")
+    return roundToShownPrecision(Math.min(Math.max(value, 0), cap), spec.unit === "percent")
   }
   function patchWord(idx: number, patchedFields: Partial<GearWordEntry>): void {
     const next = [...piece.words] as GearPiece["words"]
@@ -204,7 +205,9 @@ export function GearPieceForm({
             {t("Relayed")}
           </label>
         </div>
-        <div className={styles.gearWordsGrid}>
+        <div
+          className={styles.gearWordsGrid + (showWordMax ? "" : ` ${styles.gearWordsGridNoMax}`)}
+        >
           {piece.words.map((word, idx) => {
             const spec = wordSpecs.find((candidate) => candidate.word === word.word)
             const isPercent = spec?.unit === "percent"
@@ -220,8 +223,8 @@ export function GearPieceForm({
             if (wm && wm.evaluated) {
               maxValueText =
                 wm.unit === "percent"
-                  ? `${(wm.capValue * 100).toFixed(1)}%`
-                  : wm.capValue.toFixed(1)
+                  ? `${(wm.capValue * 100).toFixed(2)}%`
+                  : wm.capValue.toFixed(2)
               deltaText = fmtDpsDelta(wm.deltaDps)
               deltaSign = deltaSignClass(wm.deltaDps)
               deltaTitle = `${t("Full-cast 94%")}: ${maxValueText} → ${deltaText} DPS`

--- a/src/ui/features/gear/gear-tab/GearTab.tsx
+++ b/src/ui/features/gear/gear-tab/GearTab.tsx
@@ -6,7 +6,7 @@ import type {
   Inputs,
   StoredProfile,
 } from "../../../../engine/types"
-import { GEAR_SLOTS } from "../../../../engine/types"
+import { EMPTY_EQUIPPED, GEAR_SLOTS } from "../../../../engine/types"
 import { newGearPieceId } from "../../../../storage"
 import { useI18n } from "../../../../i18n/i18nContext"
 import { useConfirm } from "../../../components/confirm-dialog/confirmContext"
@@ -16,6 +16,7 @@ import { GearInventoryPanel } from "../gear-inventory-panel/GearInventoryPanel"
 import type { InventoryRow } from "../gear-inventory-panel/inventoryRows"
 import { GearSwapPreviewPanel } from "../gear-swap-preview-panel/GearSwapPreviewPanel"
 import { NewGearPieceDialog } from "../new-gear-piece-dialog/NewGearPieceDialog"
+import { ImportGearDialog } from "../import-gear-dialog/ImportGearDialog"
 import { RetunementAnalyzerPanel } from "../retunement-analyzer-panel/RetunementAnalyzerPanel"
 import { ReattunementAnalyzerPanel } from "../reattunement-analyzer-panel/ReattunementAnalyzerPanel"
 import type { DpsDeltaMap } from "../../../hooks/useDpsDeltas"
@@ -53,6 +54,7 @@ export function GearTab({
   const [selectedSlot, setSelectedSlot] = useState<GearSlot | null>(null)
   const [showGlobal, setShowGlobal] = useState(false)
   const [newPieceOpen, setNewPieceOpen] = useState(false)
+  const [importOpen, setImportOpen] = useState(false)
 
   const inventory = inputs.inventory
   const equipped = inputs.equipped
@@ -163,6 +165,38 @@ export function GearTab({
     }
   }
 
+  async function importGear(imported: GearPiece[], keepDisplaced: boolean): Promise<void> {
+    const displaced = GEAR_SLOTS.map((slot) => equipped[slot]).filter(
+      (pieceId): pieceId is string => !!pieceId,
+    )
+    const filledSlots = new Set(imported.map((piece) => piece.slot))
+    const emptiedCount = GEAR_SLOTS.filter(
+      (slot) => equipped[slot] && !filledSlots.has(slot),
+    ).length
+    if (
+      emptiedCount > 0 &&
+      !(await confirm(
+        `${t("This import has nothing for")} ${emptiedCount} ${t("of your equipped slots. Empty them?")}`,
+      ))
+    ) {
+      return
+    }
+
+    const kept = keepDisplaced
+      ? inventory
+      : inventory.filter((piece) => !displaced.includes(piece.id))
+    const nextEquipped: EquippedSlots = { ...EMPTY_EQUIPPED }
+    for (const piece of imported) nextEquipped[piece.slot] = piece.id
+
+    setImportOpen(false)
+    commitGearChange([...kept, ...imported], nextEquipped)
+    const first = imported[0]
+    if (first) {
+      setSelectedSlot(first.slot)
+      setSelectedPieceId(first.id)
+    }
+  }
+
   function selectSlot(slot: GearSlot, pieceId: string | null): void {
     setSelectedSlot(slot)
     setSelectedPieceId(pieceId)
@@ -171,7 +205,12 @@ export function GearTab({
   return (
     <>
       <div className="panel">
-        <h2>{t("Equipped")}</h2>
+        <div className="panel-head">
+          <h2>{t("Equipped")}</h2>
+          <button type="button" className="btn primary" onClick={() => setImportOpen(true)}>
+            {t("Import gear")}
+          </button>
+        </div>
         <GearSlotTiles
           inventory={inventory}
           equipped={equipped}
@@ -252,6 +291,14 @@ export function GearTab({
           inputs={inputs}
           onCancel={() => setNewPieceOpen(false)}
           onSave={handleCreateSave}
+        />
+      )}
+
+      {importOpen && (
+        <ImportGearDialog
+          inputs={inputs}
+          onCancel={() => setImportOpen(false)}
+          onImport={importGear}
         />
       )}
     </>

--- a/src/ui/features/gear/import-gear-dialog/ImportGearDialog.module.scss
+++ b/src/ui/features/gear/import-gear-dialog/ImportGearDialog.module.scss
@@ -1,0 +1,181 @@
+@use "mixins";
+@use "breakpoints";
+
+.wideModal {
+  width: min(95vw, 940px);
+}
+
+.steps {
+  margin: 0 0 10px;
+  padding-left: 20px;
+  font-size: 0.85em;
+  color: var(--color-text-dim);
+  line-height: 1.7;
+}
+
+.steps a {
+  color: var(--color-accent);
+}
+
+.bookmarklet {
+  display: inline-block;
+  padding: 3px 10px;
+  border: 1px solid var(--color-accent);
+  border-radius: 4px;
+  background: var(--color-surface-raised);
+  color: var(--color-accent-bright);
+  font-weight: 600;
+  cursor: grab;
+  text-decoration: none;
+}
+
+.toolRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.paste {
+  @include mixins.field-input;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 80px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 0.8em;
+}
+
+.paste:focus {
+  @include mixins.field-focus;
+}
+
+.summary {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 10px 0 8px;
+  font-size: 0.9em;
+  color: var(--color-text);
+}
+
+.pieceList {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: 8px;
+}
+
+.piece {
+  border: 1px solid var(--color-border);
+  border-radius: 5px;
+  padding: 8px 10px;
+  background: var(--color-bg);
+}
+
+.skipped {
+  opacity: 0.6;
+}
+
+.pieceHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pieceSlot {
+  font-size: 0.85em;
+  color: var(--color-accent);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.identityRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 6px 0;
+  flex-wrap: wrap;
+}
+
+.identityPicker {
+  width: 96px;
+}
+
+.affixList {
+  display: grid;
+  gap: 2px;
+}
+
+.affix {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  font-size: 0.82em;
+  padding: 1px 0;
+}
+
+.affixPicker {
+  min-width: 0;
+}
+
+.affixName {
+  color: var(--color-text);
+}
+
+.affixValue {
+  color: var(--color-accent-bright);
+  font-variant-numeric: tabular-nums;
+}
+
+.affixNote {
+  font-size: 0.9em;
+}
+
+.affixNote:global(.is-negative) {
+  color: var(--color-negative);
+}
+
+.unresolved .affixName,
+.unresolved .affixValue {
+  color: var(--color-text-muted);
+}
+
+.overflow {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--color-border);
+}
+
+.modeChoice {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.modeChoice > :global(.section-label) {
+  margin: 0;
+}
+
+.modeChoice label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.82em;
+  color: var(--color-text-dim);
+  white-space: nowrap;
+}
+
+@include breakpoints.below(breakpoints.$bp-760) {
+  .pieceList {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/ui/features/gear/import-gear-dialog/ImportGearDialog.tsx
+++ b/src/ui/features/gear/import-gear-dialog/ImportGearDialog.tsx
@@ -1,0 +1,548 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import type { GearLevel, GearPiece, GearRarity, GearSlot, Inputs } from "../../../../engine/types"
+import { GEAR_SLOTS, isWeaponSlot } from "../../../../engine/types"
+import { gearBaseStatsFor } from "../../../../engine/gearStats"
+import { useI18n } from "../../../../i18n/i18nContext"
+import { fmt } from "../../../utils/statFormatting"
+import { Combobox, type ComboboxOption } from "../../../components/combobox/Combobox"
+import dialogChrome from "../shared/gearDialog.module.scss"
+import bookmarkletSource from "./gearImportBookmarklet.js?raw"
+import { bookmarkletHref } from "./bookmarkletHref"
+import {
+  AFFIX_MAPPINGS_FILE_NAME,
+  exportAffixChoices,
+  loadAffixChoices,
+  parseAffixChoicesFile,
+  saveAffixChoices,
+} from "./affixChoiceStore"
+import { loadKeepDisplaced, saveKeepDisplaced } from "./importPreferences"
+import {
+  GearImportError,
+  buildImportDiagnostics,
+  parseDashboardGearPayload,
+  previewablePieces,
+  summarizeImport,
+  targetKey,
+  targetLabel,
+  type AffixTarget,
+  type GearImportResult,
+  type ImportedAffix,
+  type ImportedPiece,
+} from "./dashboardGearPayload"
+import {
+  effectiveIdentity,
+  resolveAgainstBuild,
+  toGearPieces,
+  type AffixChoices,
+  type IdentityOverrides,
+} from "./importedGearPieces"
+import styles from "./ImportGearDialog.module.scss"
+
+export const DASHBOARD_URL = "https://www.wherewindsmeetgame.com/m/2025h5sjgj/en/"
+
+const SLOT_LABEL_KEYS: Record<GearSlot, string> = {
+  leftWeapon: "Left Weapon",
+  rightWeapon: "Right Weapon",
+  disc: "Disc",
+  pendant: "Pendant",
+  helm: "Helm",
+  armor: "Armor",
+  greaves: "Greaves",
+  bracer: "Bracer",
+}
+
+const LEVEL_OPTIONS: ComboboxOption[] = [
+  { value: "86", label: "lv86" },
+  { value: "91", label: "lv91" },
+  { value: "96", label: "lv96" },
+]
+
+// An unmapped line's units are unknown, and two decimals alone would render both
+// a 0.044 ceiling and a 0.04 one as "0.04" — so sub-1 magnitudes read as percent.
+function fmtUnmapped(value: number | null): string {
+  if (value === null) return "—"
+  return fmt(value, Math.abs(value) < 1)
+}
+
+interface Props {
+  inputs: Inputs
+  onCancel(): void
+  onImport(pieces: GearPiece[], keepDisplaced: boolean): void
+}
+
+export function ImportGearDialog({ inputs, onCancel, onImport }: Props) {
+  const { t } = useI18n()
+  const [pasted, setPasted] = useState("")
+  const [overrides, setOverrides] = useState<IdentityOverrides>({})
+  const [choices, setChoices] = useState<AffixChoices>(loadAffixChoices)
+  const [keepDisplaced, setKeepDisplaced] = useState(loadKeepDisplaced)
+  const [copyNotice, setCopyNotice] = useState("")
+  const mappingFileRef = useRef<HTMLInputElement | null>(null)
+
+  // Set through a ref rather than the href prop so React never inspects the
+  // javascript: URL, and on every mount because the anchor unmounts while a
+  // parsed capture is on screen.
+  function attachBookmarklet(anchor: HTMLAnchorElement | null): void {
+    anchor?.setAttribute("href", bookmarkletHref(bookmarkletSource))
+  }
+
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (event.key !== "Escape") return
+      if (event.defaultPrevented) return
+      onCancel()
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const parsed = useMemo((): { result: GearImportResult | null; error: string } => {
+    if (!pasted.trim()) return { result: null, error: "" }
+    try {
+      return {
+        result: resolveAgainstBuild(parseDashboardGearPayload(pasted), inputs, choices),
+        error: "",
+      }
+    } catch (failure) {
+      if (failure instanceof GearImportError) return { result: null, error: failure.message }
+      throw failure
+    }
+  }, [pasted, inputs, choices])
+
+  const result = parsed.result
+  const summary = useMemo(() => (result ? summarizeImport(result) : null), [result])
+  const pieces = useMemo(() => (result ? toGearPieces(result, overrides) : []), [result, overrides])
+  const shown = useMemo(() => (result ? previewablePieces(result) : []), [result])
+
+  const filledSlots = new Set(pieces.map((piece) => piece.slot))
+  const emptiedSlots = GEAR_SLOTS.filter((slot) => !filledSlots.has(slot))
+  const assumedIdentitySlots = shown
+    .filter((piece) => piece.slot.kind === "mapped" && piece.identity?.rarity == null)
+    .map((piece) => (piece.slot as { slot: GearSlot }).slot)
+
+  async function copyToClipboard(text: string, notice: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopyNotice(notice)
+    } catch {
+      setCopyNotice(t("Copying failed — select the text and copy it manually."))
+    }
+  }
+
+  function setOverride(
+    gameSlotId: string,
+    patch: { level?: GearLevel; rarity?: GearRarity },
+  ): void {
+    setOverrides((previous) => ({
+      ...previous,
+      [gameSlotId]: { ...previous[gameSlotId], ...patch },
+    }))
+  }
+
+  function chooseKeepDisplaced(keep: boolean): void {
+    setKeepDisplaced(keep)
+    saveKeepDisplaced(keep)
+  }
+
+  function clearPaste(): void {
+    setPasted("")
+    setOverrides({})
+    setCopyNotice("")
+  }
+
+  function commitChoices(next: AffixChoices): void {
+    setChoices(next)
+    saveAffixChoices(next)
+  }
+
+  function chooseTarget(affixId: string, key: string): void {
+    commitChoices({ ...choices, [affixId]: key })
+  }
+
+  function exportMappings(): void {
+    const url = URL.createObjectURL(
+      new Blob([exportAffixChoices(choices)], { type: "application/json" }),
+    )
+    const link = document.createElement("a")
+    link.href = url
+    link.download = AFFIX_MAPPINGS_FILE_NAME
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  async function importMappings(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file) return
+    try {
+      const loaded = parseAffixChoicesFile(await file.text())
+      commitChoices({ ...choices, ...loaded })
+      setCopyNotice(`${Object.keys(loaded).length} ${t("mappings loaded.")}`)
+    } catch (failure) {
+      setCopyNotice(failure instanceof Error ? failure.message : String(failure))
+    }
+  }
+
+  return (
+    <div
+      className={dialogChrome.overlay}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="import-gear-title"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onCancel()
+      }}
+    >
+      <div className={`${dialogChrome.modal} ${styles.wideModal}`}>
+        <div className={dialogChrome.header}>
+          <h2 id="import-gear-title">{t("Import gear")}</h2>
+        </div>
+
+        <div className={dialogChrome.body}>
+          {!result && (
+            <>
+              <ol className={styles.steps}>
+                <li>
+                  {t("Drag this to your bookmarks bar:")}{" "}
+                  <a
+                    ref={attachBookmarklet}
+                    className={styles.bookmarklet}
+                    onClick={(event) => event.preventDefault()}
+                  >
+                    {t("Import WWM Gear")}
+                  </a>
+                </li>
+                <li>
+                  {t("Open the")}{" "}
+                  <a href={DASHBOARD_URL} target="_blank" rel="noreferrer">
+                    {t("official WWM dashboard")}
+                  </a>{" "}
+                  {t("and sign in, then click the bookmark.")}
+                </li>
+                <li>{t("Paste what it copied below.")}</li>
+              </ol>
+
+              {copyNotice && <div className="hint">{copyNotice}</div>}
+
+              <textarea
+                className={styles.paste}
+                value={pasted}
+                spellCheck={false}
+                placeholder={t("Paste the copied gear JSON here")}
+                onChange={(event) => setPasted(event.target.value)}
+              />
+
+              {parsed.error && <div className="warnings">⚠ {parsed.error}</div>}
+            </>
+          )}
+
+          {result && summary && (
+            <>
+              <div className={styles.summary}>
+                <span>
+                  {result.roleName ?? t("Unnamed character")}
+                  {result.characterLevel !== null
+                    ? ` · ${t("Level")} ${result.characterLevel}`
+                    : ""}
+                </span>
+                <span className="hint">
+                  {`${summary.mappedPieceCount}/${summary.pieceCount} ${t("pieces matched")} · ${summary.resolvedAffixCount} ${t("stats read")}${summary.unmappedAffixCount ? ` · ${summary.unmappedAffixCount} ${t("unmapped")}` : ""}${summary.clampedCount ? ` · ${summary.clampedCount} ${t("clamped")}` : ""}`}
+                </span>
+              </div>
+
+              {summary.unmappedAffixCount > 0 && (
+                <div className="warnings">
+                  ⚠ {summary.unmappedAffixCount}{" "}
+                  {t(
+                    "stat lines have no mapping yet. Pick the stat each one is — a ✓ marks the ones whose max roll fits, and every choice is remembered for next time.",
+                  )}{" "}
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() =>
+                      copyToClipboard(
+                        buildImportDiagnostics(result),
+                        t("Diagnostics copied — they contain no account details."),
+                      )
+                    }
+                  >
+                    {t("Copy diagnostics")}
+                  </button>
+                </div>
+              )}
+
+              <div className={styles.toolRow}>
+                <span className="section-label">{t("Stat-line mappings")}</span>
+                <button
+                  type="button"
+                  className="btn"
+                  disabled={!Object.keys(choices).length}
+                  onClick={exportMappings}
+                >
+                  {t("Export as JSON")}
+                </button>
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => mappingFileRef.current?.click()}
+                >
+                  {t("Import JSON")}
+                </button>
+                <span className="hint">
+                  {Object.keys(choices).length} {t("mapped by you")}
+                </span>
+                <input
+                  ref={mappingFileRef}
+                  type="file"
+                  accept="application/json,.json"
+                  style={{ display: "none" }}
+                  onChange={importMappings}
+                />
+              </div>
+
+              {copyNotice && <div className="hint">{copyNotice}</div>}
+
+              {!shown.length && (
+                <div className="warnings">
+                  ⚠ {t("This capture holds no gear this app can import.")}
+                </div>
+              )}
+
+              <div className={styles.pieceList}>
+                {shown.map((piece) => (
+                  <PiecePreview
+                    key={piece.gameSlotId}
+                    piece={piece}
+                    allPieces={result.pieces}
+                    overrides={overrides}
+                    onOverride={setOverride}
+                    onChooseTarget={chooseTarget}
+                  />
+                ))}
+              </div>
+
+              {assumedIdentitySlots.length > 0 && (
+                <div className="warnings">
+                  ⚠{" "}
+                  {t(
+                    "These pieces report base stats this app has no tier for, so their level and rarity are a guess — set them yourself",
+                  )}
+                  : {assumedIdentitySlots.map((slot) => t(SLOT_LABEL_KEYS[slot])).join(", ")}.{" "}
+                  {t("On armor this only changes the HP and defense shown, never the DPS.")}
+                </div>
+              )}
+
+              {emptiedSlots.length > 0 && (
+                <div className="warnings">
+                  ⚠ {emptiedSlots.length} {t("slots aren't in this payload and will be emptied")}:{" "}
+                  {emptiedSlots.map((slot) => t(SLOT_LABEL_KEYS[slot])).join(", ")}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className={dialogChrome.footer}>
+          {result && (
+            <div className={styles.modeChoice}>
+              <span className="section-label">{t("Gear you have now")}</span>
+              <label>
+                <input
+                  type="radio"
+                  checked={!keepDisplaced}
+                  onChange={() => chooseKeepDisplaced(false)}
+                />
+                {t("Remove replaced")}
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  checked={keepDisplaced}
+                  onChange={() => chooseKeepDisplaced(true)}
+                />
+                {t("Keep in inventory")}
+              </label>
+            </div>
+          )}
+          <span className="spacer" />
+          <span className="hint">{t("Nothing is written until you press Save.")}</span>
+          {result && (
+            <button type="button" className="btn" onClick={clearPaste}>
+              {t("Back")}
+            </button>
+          )}
+          <button type="button" className="btn" onClick={onCancel}>
+            {t("Cancel")}
+          </button>
+          <button
+            type="button"
+            className="btn primary"
+            disabled={!pieces.length}
+            onClick={() => onImport(pieces, keepDisplaced)}
+          >
+            {t("Import gear")}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function identityHint(piece: ImportedPiece): string {
+  if (piece.identity?.level && piece.identity.rarity) return "read from this piece's base stats"
+  if (piece.identity?.rarity) return "rarity read from base stats; level assumed"
+  if (piece.observedBaseStats) return "base stats match no known tier — assumed"
+  return "no base stats in the payload — assumed"
+}
+
+function PiecePreview({
+  piece,
+  allPieces,
+  overrides,
+  onOverride,
+  onChooseTarget,
+}: {
+  piece: ImportedPiece
+  allPieces: readonly ImportedPiece[]
+  overrides: IdentityOverrides
+  onOverride(gameSlotId: string, patch: { level?: GearLevel; rarity?: GearRarity }): void
+  onChooseTarget(affixId: string, key: string): void
+}) {
+  const { t } = useI18n()
+  const rarityOptions: ComboboxOption[] = [
+    { value: "legendary", label: t("Legendary") },
+    { value: "epic", label: t("Epic") },
+  ]
+
+  if (piece.slot.kind !== "mapped") {
+    return (
+      <div className={`${styles.piece} ${styles.skipped}`}>
+        <div className={styles.pieceHead}>
+          <span className={styles.pieceSlot}>
+            {t("Game slot")} {piece.gameSlotId}
+          </span>
+          <span className="hint">{t("unknown slot — skipped")}</span>
+        </div>
+      </div>
+    )
+  }
+
+  const slot = piece.slot.slot
+  const identity = effectiveIdentity(piece, allPieces, overrides)
+  const base = gearBaseStatsFor({ slot, ...identity })
+
+  return (
+    <div className={styles.piece}>
+      <div className={styles.pieceHead}>
+        <span className={styles.pieceSlot}>{t(SLOT_LABEL_KEYS[slot])}</span>
+        <span className="hint">
+          {isWeaponSlot(slot)
+            ? `${t("Min Phys")} ${base.minPhys} · ${t("Max Phys")} ${base.maxPhys}`
+            : `${t("HP")} ${base.hp} · ${t("Phys Defense")} ${base.physDef}`}
+        </span>
+      </div>
+
+      <div className={styles.identityRow}>
+        <Combobox
+          className={styles.identityPicker}
+          value={String(identity.level)}
+          options={LEVEL_OPTIONS}
+          onChange={(value) => onOverride(piece.gameSlotId, { level: Number(value) as GearLevel })}
+        />
+        <Combobox
+          className={styles.identityPicker}
+          value={identity.rarity}
+          options={rarityOptions}
+          onChange={(value) => onOverride(piece.gameSlotId, { rarity: value as GearRarity })}
+        />
+        <span className="hint">{t(identityHint(piece))}</span>
+      </div>
+
+      <div className={styles.affixList}>
+        {piece.affixes.map((affix, index) => (
+          <AffixRow key={index} affix={affix} onChooseTarget={onChooseTarget} />
+        ))}
+        {piece.attunement && (
+          <AffixRow affix={piece.attunement} isAttunement onChooseTarget={onChooseTarget} />
+        )}
+      </div>
+
+      {piece.overflowAffixes.length > 0 && (
+        <div className={styles.overflow}>
+          <span className="hint">{t("Beyond the 5 tunement rows — not imported")}</span>
+          {piece.overflowAffixes.map((affix, index) => (
+            <AffixRow key={index} affix={affix} onChooseTarget={onChooseTarget} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function targetOptions(
+  suggestions: readonly AffixTarget[],
+  choosable: readonly AffixTarget[],
+  t: (key: string) => string,
+): ComboboxOption[] {
+  const suggested = new Set(suggestions.map(targetKey))
+  const rest = choosable.filter((target) => !suggested.has(targetKey(target)))
+  return [...suggestions, ...rest].map((target) => ({
+    value: targetKey(target),
+    label: suggested.has(targetKey(target))
+      ? `${t(targetLabel(target))} ✓`
+      : t(targetLabel(target)),
+  }))
+}
+
+function AffixRow({
+  affix,
+  isAttunement = false,
+  onChooseTarget,
+}: {
+  affix: ImportedAffix
+  isAttunement?: boolean
+  onChooseTarget(affixId: string, key: string): void
+}) {
+  const { t } = useI18n()
+  const resolution = affix.resolution
+  const options = targetOptions(resolution.suggestions, resolution.choosableTargets, t)
+
+  if (resolution.kind !== "resolved") {
+    return (
+      <div className={`${styles.affix} ${styles.unresolved}`}>
+        <Combobox
+          className={styles.affixPicker}
+          value=""
+          options={options}
+          placeholder={`#${affix.affixId}${affix.derivedMax !== null ? ` · ${t("max")} ${fmtUnmapped(affix.derivedMax)}` : ""}`}
+          onChange={(value) => onChooseTarget(affix.affixId, value)}
+        />
+        <span className={styles.affixValue}>{fmtUnmapped(affix.rawValue)}</span>
+        <span className="hint">{isAttunement ? t("attunement — pick one") : t("pick one")}</span>
+      </div>
+    )
+  }
+
+  const target = resolution.target
+  const isPercent = target.kind === "attunement" || target.unit === "percent"
+
+  return (
+    <div className={styles.affix}>
+      <Combobox
+        className={styles.affixPicker}
+        value={targetKey(target)}
+        options={options}
+        onChange={(value) => onChooseTarget(affix.affixId, value)}
+      />
+      <span className={styles.affixValue}>{fmt(resolution.value, isPercent)}</span>
+      {resolution.clampedFrom !== null ? (
+        <span className={`${styles.affixNote} is-negative`}>
+          {`${fmt(resolution.clampedFrom, isPercent)} → ${t("in range")}`}
+        </span>
+      ) : (
+        <span />
+      )}
+    </div>
+  )
+}

--- a/src/ui/features/gear/import-gear-dialog/affixChoiceStore.ts
+++ b/src/ui/features/gear/import-gear-dialog/affixChoiceStore.ts
@@ -1,0 +1,65 @@
+import { kvStore } from "../../../../kvStore"
+import type { AffixChoices } from "./importedGearPieces"
+
+const AFFIX_CHOICES_KEY = "wwm.gearImportAffixChoices"
+const FILE_SOURCE = "wwm-gear-affix-mappings"
+export const AFFIX_MAPPINGS_FILE_VERSION = 1
+export const AFFIX_MAPPINGS_FILE_NAME = "wwm-gear-affix-mappings.json"
+
+function readMappingRecord(value: unknown): AffixChoices {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+  const out: Record<string, string> = {}
+  for (const [affixId, target] of Object.entries(value)) {
+    if (typeof target === "string") out[affixId] = target
+  }
+  return out
+}
+
+export function loadAffixChoices(): AffixChoices {
+  const stored = kvStore.get(AFFIX_CHOICES_KEY)
+  if (!stored) return {}
+  try {
+    return readMappingRecord(JSON.parse(stored))
+  } catch {
+    return {}
+  }
+}
+
+export function saveAffixChoices(choices: AffixChoices): void {
+  kvStore.set(AFFIX_CHOICES_KEY, JSON.stringify(choices))
+}
+
+/** Keys are sorted so two exports of the same mappings diff cleanly. */
+export function exportAffixChoices(choices: AffixChoices): string {
+  const mappings: Record<string, string> = {}
+  for (const affixId of Object.keys(choices).sort()) mappings[affixId] = choices[affixId]!
+  return `${JSON.stringify({ source: FILE_SOURCE, v: AFFIX_MAPPINGS_FILE_VERSION, mappings }, null, 2)}\n`
+}
+
+export function parseAffixChoicesFile(text: string): AffixChoices {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new Error("That file is not valid JSON.")
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("That file does not hold stat-line mappings.")
+  }
+
+  const envelope = parsed as Record<string, unknown>
+  const source = envelope.source
+  if (typeof source === "string" && source !== FILE_SOURCE) {
+    throw new Error(`That file came from "${source}", not a stat-line mapping export.`)
+  }
+  const version = envelope.v
+  if (typeof version === "number" && version > AFFIX_MAPPINGS_FILE_VERSION) {
+    throw new Error(`That file was written by a newer version (v${version}).`)
+  }
+
+  // A bare `{ "<affixId>": "word:…" }` object is accepted too, so the table in
+  // affixStatLineTable.ts can be pasted straight back in.
+  const mappings = readMappingRecord(envelope.mappings ?? envelope)
+  if (!Object.keys(mappings).length) throw new Error("That file holds no stat-line mappings.")
+  return mappings
+}

--- a/src/ui/features/gear/import-gear-dialog/affixStatLineTable.ts
+++ b/src/ui/features/gear/import-gear-dialog/affixStatLineTable.ts
@@ -1,0 +1,55 @@
+/**
+ * Affix id → the stat line it is, as a `targetKey`: `word:<name>` matching a
+ * `getWordSpecs` entry, or `attunement:<id>` matching an `AttunementOption`.
+ *
+ * This table is the only authority on what a stat line means. The payload also
+ * reports `value / maxRoll` per affix, which pins the roll's ceiling, but a
+ * ceiling narrows the field without deciding it — 44.2 is Max Bellstrike and Max
+ * Bamboocut alike — so a derived ceiling only *offers* candidates in the import
+ * dialog. An id absent here imports nothing until it is mapped, either by an entry
+ * below or by the user picking it in the dialog (remembered per id from then on,
+ * and exportable as JSON to be pasted back into this file).
+ *
+ * The same stat carries a different id per equip slot — Affinity is 9743005,
+ * 9793120, 9794120 and 9794014 — so a stat needs one entry per slot it rolls on,
+ * and this table is expected to stay incomplete until every slot has been seen.
+ *
+ * Tunements are 7-digit `97xxxxx` ids, attunements 6-digit `280xxx`. Values are in
+ * this app's units: percent tunements arrive as fractions, attunements as percent
+ * and are scaled in `importedGearPieces.ts`.
+ *
+ * Confirmed against live captures, 2026-08-11.
+ */
+export const AFFIX_ID_TO_STAT_LINE: Readonly<Record<string, string>> = {
+  "280101": "attunement:bleedingDamage",
+  "280103": "attunement:bleedingDamage",
+  "280701": "attunement:physPen",
+  "9712002": "word:Max Phys",
+  "9713004": "word:Max Void Attack",
+  "9732002": "word:Max Phys",
+  "9733002": "word:Max Phys",
+  "9743005": "word:Affinity",
+  "9752007": "word:Power",
+  "9793005": "word:Momentum",
+  "9793008": "word:Max Phys",
+  "9793011": "word:Max Void Attack",
+  "9793015": "word:Sword Martial Boost",
+  "9793102": "word:Power",
+  "9793108": "word:Max Phys",
+  "9793111": "word:Max Bellstrike",
+  "9793117": "word:Max Bamboocut",
+  "9793119": "word:Crit",
+  "9793120": "word:Affinity",
+  "9793121": "word:All Martial Boost",
+  "9794002": "word:Power",
+  "9794005": "word:Momentum",
+  "9794008": "word:Max Phys",
+  "9794014": "word:Affinity",
+  "9794102": "word:Power",
+  "9794105": "word:Momentum",
+  "9794108": "word:Max Phys",
+  "9794119": "word:Crit",
+  "9794120": "word:Affinity",
+  "9794121": "word:All Martial Boost",
+  "9794124": "word:Damage VS Boss %",
+}

--- a/src/ui/features/gear/import-gear-dialog/bookmarkletHref.ts
+++ b/src/ui/features/gear/import-gear-dialog/bookmarkletHref.ts
@@ -1,0 +1,7 @@
+export const BOOKMARKLET_SCHEME = "javascript:"
+
+// Percent-encoding is load-bearing, not cosmetic: an unescaped `#` truncates the
+// URL at a fragment and an unescaped `%` misparses.
+export function bookmarkletHref(source: string): string {
+  return BOOKMARKLET_SCHEME + encodeURIComponent(source)
+}

--- a/src/ui/features/gear/import-gear-dialog/dashboardGearMaps.ts
+++ b/src/ui/features/gear/import-gear-dialog/dashboardGearMaps.ts
@@ -1,0 +1,25 @@
+import type { GearSlot } from "../../../../engine/types"
+
+/**
+ * Game equip-slot ids as used by the official dashboard's `wearEquips` /
+ * `wearEquipsDetailed` maps. Mapping confirmed against a live account
+ * (user report, 2026-08-11).
+ *
+ * Slot 9 is the bow and slot 21 the ring; neither is a modeled gear slot — the
+ * bow is `Inputs.bowSet`, not a `GearPiece` — so both are hidden from the preview.
+ *
+ * A key mapped to null is a game slot we know about and have no app slot for; a
+ * key that is absent entirely means the payload surprised us.
+ */
+export const GAME_SLOT_TO_GEAR_SLOT: Readonly<Record<string, GearSlot | null>> = {
+  "1": "leftWeapon",
+  "2": "rightWeapon",
+  "3": "helm",
+  "4": "armor",
+  "5": "greaves",
+  "8": "bracer",
+  "9": null,
+  "10": "disc",
+  "11": "pendant",
+  "21": null,
+}

--- a/src/ui/features/gear/import-gear-dialog/dashboardGearPayload.ts
+++ b/src/ui/features/gear/import-gear-dialog/dashboardGearPayload.ts
@@ -1,0 +1,319 @@
+import type { GearBaseStats, InferredGearIdentity } from "../../../../engine/gearStats"
+import { GEAR_SLOTS, type GearSlot } from "../../../../engine/types"
+import { GAME_SLOT_TO_GEAR_SLOT } from "./dashboardGearMaps"
+
+export const BOOKMARKLET_ENVELOPE_VERSION = 1
+const ENVELOPE_SOURCE = "wwm-dashboard"
+
+export class GearImportError extends Error {}
+
+export type AffixTarget =
+  | { kind: "word"; word: string; unit: "raw" | "percent"; cap: number }
+  | { kind: "attunement"; attunementId: string; label: string; min: number; max: number }
+
+export type AffixResolution =
+  | {
+      kind: "resolved"
+      target: AffixTarget
+      value: number
+      clampedFrom: number | null
+      /** Targets whose max roll matches this affix's ceiling — offered, not decisive. */
+      suggestions: readonly AffixTarget[]
+      choosableTargets: readonly AffixTarget[]
+    }
+  | {
+      kind: "unmapped"
+      /** Set when the id is mapped to a stat that is illegal for this build. */
+      mappedTo: string | null
+      suggestions: readonly AffixTarget[]
+      choosableTargets: readonly AffixTarget[]
+    }
+
+export interface ImportedAffix {
+  affixId: string
+  rawValue: number | null
+  /** `value / maxRoll`, as reported by the game. */
+  rolledRatio: number | null
+  /** `rawValue / rolledRatio` — the roll's ceiling, which is what identifies the stat. */
+  derivedMax: number | null
+  isAttunementAffix: boolean
+  /** The payload entry verbatim, so diagnostics survive a shape change. */
+  raw: unknown
+  resolution: AffixResolution
+}
+
+export type SlotResolution =
+  { kind: "mapped"; slot: GearSlot } | { kind: "noAppEquivalent" } | { kind: "unknownSlotId" }
+
+export interface ImportedPiece {
+  gameSlotId: string
+  itemId: number | null
+  slot: SlotResolution
+  observedBaseStats: Partial<GearBaseStats> | null
+  identity: InferredGearIdentity | null
+  affixes: ImportedAffix[]
+  overflowAffixes: ImportedAffix[]
+  attunement: ImportedAffix | null
+}
+
+export interface GearImportResult {
+  roleName: string | null
+  characterLevel: number | null
+  pieces: ImportedPiece[]
+  unrecognizedPayloadKeys: readonly string[]
+}
+
+/**
+ * Attunement ("suffix") affixes are 6-digit ids in a `280xxx` block; tunements are
+ * 7-digit `97xxxxx` ids (live capture, 2026-08-11). The two namespaces overlap in
+ * max roll — physical penetration exists as both — so the id is what separates them.
+ */
+const LOWEST_TUNEMENT_AFFIX_ID = 1_000_000
+
+const BASE_STAT_KEYS: Readonly<Record<keyof GearBaseStats, readonly string[]>> = {
+  minPhys: ["MIN_W_ATK", "minPhys"],
+  maxPhys: ["MAX_W_ATK", "maxPhys"],
+  hp: ["HP_MAX", "hp"],
+  physDef: ["W_DEF", "physDef"],
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) {
+    return Number(value)
+  }
+  return null
+}
+
+function firstNumber(source: Record<string, unknown>, keys: readonly string[]): number | null {
+  for (const key of keys) {
+    const found = asNumber(source[key])
+    if (found !== null) return found
+  }
+  return null
+}
+
+function resolveSlot(gameSlotId: string): SlotResolution {
+  if (!Object.prototype.hasOwnProperty.call(GAME_SLOT_TO_GEAR_SLOT, gameSlotId)) {
+    return { kind: "unknownSlotId" }
+  }
+  const slot = GAME_SLOT_TO_GEAR_SLOT[gameSlotId]
+  return slot ? { kind: "mapped", slot } : { kind: "noAppEquivalent" }
+}
+
+function unresolvedAffix(
+  affixId: string,
+  rawValue: number | null,
+  rolledRatio: number | null,
+  raw: unknown,
+): ImportedAffix {
+  const numericId = Number(affixId)
+  return {
+    affixId,
+    rawValue,
+    rolledRatio,
+    derivedMax: rawValue !== null && rolledRatio ? rawValue / rolledRatio : null,
+    isAttunementAffix: Number.isFinite(numericId) && numericId < LOWEST_TUNEMENT_AFFIX_ID,
+    raw,
+    resolution: { kind: "unmapped", mappedTo: null, suggestions: [], choosableTargets: [] },
+  }
+}
+
+function readAffix(entry: unknown): ImportedAffix {
+  if (typeof entry === "number") return unresolvedAffix(String(entry), null, null, entry)
+  if (!isRecord(entry)) return unresolvedAffix("?", null, null, entry)
+
+  const tuple = entry.equipmentDetails
+  if (Array.isArray(tuple)) {
+    const affixId = asNumber(tuple[0])
+    return unresolvedAffix(
+      affixId !== null ? String(affixId) : "?",
+      asNumber(tuple[1]),
+      asNumber(tuple[2]),
+      entry,
+    )
+  }
+
+  const affixId = firstNumber(entry, ["id", "affixId", "propertyId"])
+  return unresolvedAffix(
+    affixId !== null ? String(affixId) : "?",
+    firstNumber(entry, ["value", "val", "amount"]),
+    firstNumber(entry, ["ratio", "rolledRatio"]),
+    entry,
+  )
+}
+
+function readObservedBaseStats(sources: readonly unknown[]): Partial<GearBaseStats> | null {
+  const observed: Partial<GearBaseStats> = {}
+  for (const source of sources) {
+    if (!isRecord(source)) continue
+    for (const field of Object.keys(BASE_STAT_KEYS) as (keyof GearBaseStats)[]) {
+      if (observed[field] !== undefined) continue
+      const found = firstNumber(source, BASE_STAT_KEYS[field])
+      if (found !== null) observed[field] = found
+    }
+  }
+  return Object.keys(observed).length ? observed : null
+}
+
+function unwrapEnvelope(parsed: unknown): Record<string, unknown> {
+  if (!isRecord(parsed)) {
+    throw new GearImportError(
+      "That JSON is not an object. Run the bookmarklet and paste its output.",
+    )
+  }
+  const source = parsed.source
+  if (typeof source === "string" && source !== ENVELOPE_SOURCE) {
+    throw new GearImportError(`That JSON came from "${source}", not the WWM dashboard bookmarklet.`)
+  }
+  const version = parsed.v
+  if (typeof version === "number" && version > BOOKMARKLET_ENVELOPE_VERSION) {
+    throw new GearImportError(
+      `That JSON was made by a newer bookmarklet (v${version}). Re-drag the bookmarklet from this dialog.`,
+    )
+  }
+  // The dashboard nests the same fields under `data`; accept a raw capture too.
+  if (!parsed.wearEquipsDetailed && isRecord(parsed.data)) return parsed.data
+  return parsed
+}
+
+export function parseDashboardGearPayload(text: string): GearImportResult {
+  if (!text.trim()) throw new GearImportError("Paste the JSON the bookmarklet copied.")
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new GearImportError("That is not valid JSON. Copy the bookmarklet's output again.")
+  }
+
+  const envelope = unwrapEnvelope(parsed)
+  const detailed = envelope.wearEquipsDetailed
+  if (!isRecord(detailed)) {
+    throw new GearImportError(
+      "No gear data in that JSON — it has no wearEquipsDetailed. Make sure your character loaded on the dashboard before running the bookmarklet.",
+    )
+  }
+  const wearEquips = isRecord(envelope.wearEquips) ? envelope.wearEquips : {}
+
+  const pieces: ImportedPiece[] = Object.keys(detailed).map((gameSlotId) => {
+    const detail = isRecord(detailed[gameSlotId])
+      ? (detailed[gameSlotId] as Record<string, unknown>)
+      : null
+    const exVo = detail && isRecord(detail.exVo) ? detail.exVo : null
+    const rawList = exVo && Array.isArray(exVo.baseAffixes) ? exVo.baseAffixes : []
+    const all = rawList.map(readAffix)
+    const tunements = all.filter((affix) => !affix.isAttunementAffix)
+
+    return {
+      gameSlotId,
+      itemId: asNumber(wearEquips[gameSlotId]) ?? asNumber(detail?.no) ?? null,
+      slot: resolveSlot(gameSlotId),
+      observedBaseStats: readObservedBaseStats([exVo?.baseAttrs, detail, exVo]),
+      identity: null,
+      affixes: tunements.slice(0, 5),
+      overflowAffixes: tunements.slice(5),
+      attunement: all.find((affix) => affix.isAttunementAffix) ?? null,
+    }
+  })
+
+  const declaredExtras = envelope.unrecognizedPayloadKeys
+  return {
+    roleName: typeof envelope.roleName === "string" ? envelope.roleName : null,
+    characterLevel: asNumber(envelope.level),
+    pieces,
+    unrecognizedPayloadKeys: Array.isArray(declaredExtras)
+      ? declaredExtras.filter((key): key is string => typeof key === "string")
+      : [],
+  }
+}
+
+/**
+ * Drops the slots the game has and this app deliberately does not model, and puts
+ * the rest in `GEAR_SLOTS` order so the preview reads like the Equipped card
+ * rather than like the payload's key order. Slots with no app equivalent sort last.
+ */
+export function previewablePieces(result: GearImportResult): ImportedPiece[] {
+  const order = (piece: ImportedPiece): number =>
+    piece.slot.kind === "mapped" ? GEAR_SLOTS.indexOf(piece.slot.slot) : GEAR_SLOTS.length
+  return result.pieces
+    .filter((piece) => piece.slot.kind !== "noAppEquivalent")
+    .sort((left, right) => order(left) - order(right))
+}
+
+export function targetKey(target: AffixTarget): string {
+  return target.kind === "word" ? `word:${target.word}` : `attunement:${target.attunementId}`
+}
+
+export function targetLabel(target: AffixTarget): string {
+  return target.kind === "word" ? target.word : target.label
+}
+
+export interface GearImportSummary {
+  pieceCount: number
+  mappedPieceCount: number
+  resolvedAffixCount: number
+  unmappedAffixCount: number
+  clampedCount: number
+  overflowCount: number
+}
+
+function affixRows(piece: ImportedPiece): ImportedAffix[] {
+  return piece.attunement ? [...piece.affixes, piece.attunement] : piece.affixes
+}
+
+export function summarizeImport(result: GearImportResult): GearImportSummary {
+  const summary: GearImportSummary = {
+    pieceCount: 0,
+    mappedPieceCount: 0,
+    resolvedAffixCount: 0,
+    unmappedAffixCount: 0,
+    clampedCount: 0,
+    overflowCount: 0,
+  }
+  for (const piece of previewablePieces(result)) {
+    summary.pieceCount += 1
+    if (piece.slot.kind === "mapped") summary.mappedPieceCount += 1
+    summary.overflowCount += piece.overflowAffixes.length
+    for (const affix of affixRows(piece)) {
+      if (affix.resolution.kind !== "resolved") {
+        summary.unmappedAffixCount += 1
+        continue
+      }
+      summary.resolvedAffixCount += 1
+      if (affix.resolution.clampedFrom !== null) summary.clampedCount += 1
+    }
+  }
+  return summary
+}
+
+/** Ids and raw entries only — no role name, no role id. */
+export function buildImportDiagnostics(result: GearImportResult): string {
+  return JSON.stringify(
+    {
+      source: ENVELOPE_SOURCE,
+      v: BOOKMARKLET_ENVELOPE_VERSION,
+      unrecognizedPayloadKeys: result.unrecognizedPayloadKeys,
+      pieces: result.pieces.map((piece) => ({
+        gameSlotId: piece.gameSlotId,
+        slot: piece.slot,
+        observedBaseStats: piece.observedBaseStats,
+        baseAffixes: [...piece.affixes, ...piece.overflowAffixes].map((affix) => ({
+          affixId: affix.affixId,
+          derivedMax: affix.derivedMax,
+          resolved:
+            affix.resolution.kind === "resolved" ? targetKey(affix.resolution.target) : null,
+        })),
+        attunement: piece.attunement
+          ? { affixId: piece.attunement.affixId, derivedMax: piece.attunement.derivedMax }
+          : null,
+      })),
+    },
+    null,
+    2,
+  )
+}

--- a/src/ui/features/gear/import-gear-dialog/gearImportBookmarklet.js
+++ b/src/ui/features/gear/import-gear-dialog/gearImportBookmarklet.js
@@ -1,0 +1,154 @@
+// Runs in the browser on the official WWM dashboard, not in this app. Kept to
+// ES5 syntax and executed via `new Function` in tests: a bookmarklet gets no
+// transpiler, and a parse error inside a javascript: URL is silent.
+(function () {
+  var CACHE_KEY = "getAreaServer"
+  var TOKEN_KEY = "h72na_data_token"
+  var ROLE_INFO_URL = "https://s2.easebar.com/78ae9d90792a3e9b/role/roleInfo"
+  var CARRIED_FIELDS = ["roleName", "level", "school", "wearEquips", "wearEquipsDetailed"]
+
+  function looksLikeRoleInfo(value) {
+    return !!value && typeof value === "object" && !!value.wearEquipsDetailed
+  }
+
+  function readCache() {
+    var stored
+    try {
+      stored = window.localStorage.getItem(CACHE_KEY)
+    } catch (storageBlocked) {
+      return null
+    }
+    if (!stored) return null
+    try {
+      var parsed = JSON.parse(stored)
+      return looksLikeRoleInfo(parsed) ? parsed : null
+    } catch (notJson) {
+      return null
+    }
+  }
+
+  function readToken() {
+    try {
+      var stored = window.localStorage.getItem(TOKEN_KEY)
+      if (stored) return stored
+    } catch (storageBlocked) {
+      // fall through to the cookie
+    }
+    var fromCookie = /(?:^|;\s*)token=([^;]+)/.exec(document.cookie || "")
+    return fromCookie ? fromCookie[1] : null
+  }
+
+  function fetchRoleInfo(onDone) {
+    var token = readToken()
+    if (!token) {
+      onDone(null, "Not logged in on this page. Open the dashboard, sign in, then run this again.")
+      return
+    }
+    var request = new XMLHttpRequest()
+    request.open("GET", ROLE_INFO_URL, true)
+    request.withCredentials = true
+    request.setRequestHeader("access_token", token)
+    request.onload = function () {
+      var payload
+      try {
+        payload = JSON.parse(request.responseText)
+      } catch (notJson) {
+        onDone(null, "The dashboard returned something unreadable.")
+        return
+      }
+      if (!looksLikeRoleInfo(payload && payload.data)) {
+        onDone(null, "The dashboard returned no gear data.")
+        return
+      }
+      onDone(payload.data, null)
+    }
+    request.onerror = function () {
+      onDone(null, "Could not reach the dashboard.")
+    }
+    request.send()
+  }
+
+  function buildEnvelope(roleInfo) {
+    var envelope = { source: "wwm-dashboard", v: 1, capturedAt: new Date().toISOString() }
+    for (var i = 0; i < CARRIED_FIELDS.length; i += 1) {
+      var field = CARRIED_FIELDS[i]
+      if (roleInfo[field] !== undefined) envelope[field] = roleInfo[field]
+    }
+    // Names only, never values — this is drift detection, not a second payload.
+    var extras = []
+    for (var key in roleInfo) {
+      if (!Object.prototype.hasOwnProperty.call(roleInfo, key)) continue
+      if (CARRIED_FIELDS.indexOf(key) === -1) extras.push(key)
+    }
+    envelope.unrecognizedPayloadKeys = extras
+    return envelope
+  }
+
+  function countPieces(envelope) {
+    var detailed = envelope.wearEquipsDetailed || {}
+    var total = 0
+    for (var key in detailed) {
+      if (Object.prototype.hasOwnProperty.call(detailed, key)) total += 1
+    }
+    return total
+  }
+
+  function copyViaTextarea(text) {
+    var holder = document.createElement("textarea")
+    holder.value = text
+    holder.setAttribute("readonly", "readonly")
+    holder.style.cssText = "position:fixed;top:-1000px;left:-1000px;opacity:0"
+    document.body.appendChild(holder)
+    holder.select()
+    var copied = false
+    try {
+      copied = document.execCommand("copy")
+    } catch (notAllowed) {
+      copied = false
+    }
+    document.body.removeChild(holder)
+    return copied
+  }
+
+  function copy(text, onDone) {
+    if (window.navigator && window.navigator.clipboard) {
+      window.navigator.clipboard.writeText(text).then(
+        function () {
+          onDone(true)
+        },
+        function () {
+          onDone(copyViaTextarea(text))
+        },
+      )
+      return
+    }
+    onDone(copyViaTextarea(text))
+  }
+
+  function deliver(roleInfo) {
+    var envelope = buildEnvelope(roleInfo)
+    var text = JSON.stringify(envelope)
+    copy(text, function (copied) {
+      if (!copied) {
+        window.prompt("Copy this, then paste it into Import Gear:", text)
+        return
+      }
+      window.alert(
+        "Copied " + countPieces(envelope) + " gear pieces. Paste them into Import Gear.",
+      )
+    })
+  }
+
+  var cached = readCache()
+  if (cached) {
+    deliver(cached)
+    return
+  }
+  fetchRoleInfo(function (roleInfo, failure) {
+    if (failure) {
+      window.alert(failure)
+      return
+    }
+    deliver(roleInfo)
+  })
+})()

--- a/src/ui/features/gear/import-gear-dialog/importPreferences.ts
+++ b/src/ui/features/gear/import-gear-dialog/importPreferences.ts
@@ -1,0 +1,15 @@
+import { kvStore } from "../../../../kvStore"
+
+const KEEP_DISPLACED_KEY = "wwm.gearImportKeepDisplaced"
+
+export const DEFAULT_KEEP_DISPLACED = false
+
+export function loadKeepDisplaced(): boolean {
+  const stored = kvStore.get(KEEP_DISPLACED_KEY)
+  if (stored !== "true" && stored !== "false") return DEFAULT_KEEP_DISPLACED
+  return stored === "true"
+}
+
+export function saveKeepDisplaced(keepDisplaced: boolean): void {
+  kvStore.set(KEEP_DISPLACED_KEY, String(keepDisplaced))
+}

--- a/src/ui/features/gear/import-gear-dialog/importedGearPieces.ts
+++ b/src/ui/features/gear/import-gear-dialog/importedGearPieces.ts
@@ -1,0 +1,215 @@
+import { attunementsFor } from "../../../../engine/attunements"
+import { gearBaseStatsFor, inferGearIdentity } from "../../../../engine/gearStats"
+import { getWordSpecs } from "../../../../engine/itemRanking"
+import { emptyGearWord } from "../../../../engine/types"
+import type {
+  GearLevel,
+  GearPiece,
+  GearRarity,
+  GearSlot,
+  GearWordEntry,
+  Inputs,
+} from "../../../../engine/types"
+import { newGearPieceId } from "../../../../storage"
+import { AFFIX_ID_TO_STAT_LINE } from "./affixStatLineTable"
+import { targetKey } from "./dashboardGearPayload"
+import type {
+  AffixTarget,
+  GearImportResult,
+  ImportedAffix,
+  ImportedPiece,
+} from "./dashboardGearPayload"
+
+export const FALLBACK_LEVEL: GearLevel = 96
+export const FALLBACK_RARITY: GearRarity = "legendary"
+
+export type IdentityOverrides = Readonly<Record<string, { level?: GearLevel; rarity?: GearRarity }>>
+/** Affix id → `targetKey`, mapped by the user in the dialog and remembered. */
+export type AffixChoices = Readonly<Record<string, string>>
+
+// The game reports attunement rolls in percent (10.7 for 10.7 %) and tunement
+// rolls as fractions, without saying which — so a target whose ceiling matches
+// the raw ceiling is used as-is, and one that matches it divided by 100 is scaled.
+const VALUE_SCALES: readonly number[] = [1, 0.01]
+const MAX_ROLL_TOLERANCE = 1e-3
+
+function matchesMaxRoll(derivedMax: number, knownMax: number): boolean {
+  return Math.abs(derivedMax - knownMax) <= Math.abs(knownMax) * MAX_ROLL_TOLERANCE
+}
+
+function ceilingOf(target: AffixTarget): number {
+  return target.kind === "attunement" ? target.max : target.cap
+}
+
+/**
+ * A tunement row can only become a word and an attunement row only an
+ * attunement — `toGearPieces` reads the two from different places, so crossing
+ * them would drop the line instead of importing it.
+ */
+function legalTargets(affix: ImportedAffix, slot: GearSlot | null, inputs: Inputs): AffixTarget[] {
+  if (affix.isAttunementAffix) {
+    if (!slot) return []
+    return attunementsFor(slot, inputs.classId).map((option) => ({
+      kind: "attunement",
+      attunementId: option.id,
+      label: option.label,
+      min: option.min,
+      max: option.max,
+    }))
+  }
+  return getWordSpecs(inputs).map((spec) => ({
+    kind: "word",
+    word: spec.word,
+    unit: spec.unit,
+    cap: spec.amount,
+  }))
+}
+
+/**
+ * The ceiling the payload reports narrows the list a user has to choose from; it
+ * is offered as a suggestion only, and never used to pick on its own.
+ */
+function suggestedTargets(affix: ImportedAffix, targets: readonly AffixTarget[]): AffixTarget[] {
+  if (affix.derivedMax === null) return []
+  for (const scale of VALUE_SCALES) {
+    const scaledMax = affix.derivedMax * scale
+    const matching = targets.filter((target) => matchesMaxRoll(scaledMax, ceilingOf(target)))
+    if (matching.length) return matching
+  }
+  return []
+}
+
+function scaleFor(affix: ImportedAffix, target: AffixTarget): number {
+  if (affix.derivedMax === null) return 1
+  for (const scale of VALUE_SCALES) {
+    if (matchesMaxRoll(affix.derivedMax * scale, ceilingOf(target))) return scale
+  }
+  return 1
+}
+
+function resolveAffix(
+  affix: ImportedAffix,
+  slot: GearSlot | null,
+  inputs: Inputs,
+  choices: AffixChoices,
+): ImportedAffix {
+  const targets = legalTargets(affix, slot, inputs)
+  const suggestions = suggestedTargets(affix, targets)
+  const mappedKey = choices[affix.affixId] ?? AFFIX_ID_TO_STAT_LINE[affix.affixId]
+  const target = mappedKey
+    ? targets.find((candidate) => targetKey(candidate) === mappedKey)
+    : undefined
+
+  if (!target || affix.rawValue === null) {
+    return {
+      ...affix,
+      resolution: {
+        kind: "unmapped",
+        mappedTo: mappedKey ?? null,
+        suggestions,
+        choosableTargets: targets,
+      },
+    }
+  }
+
+  const scaled = affix.rawValue * scaleFor(affix, target)
+  const lowest = target.kind === "attunement" ? target.min : 0
+  const value = Math.min(Math.max(scaled, lowest), ceilingOf(target))
+
+  return {
+    ...affix,
+    resolution: {
+      kind: "resolved",
+      target,
+      value,
+      clampedFrom: value === scaled ? null : scaled,
+      suggestions,
+      choosableTargets: targets,
+    },
+  }
+}
+
+/** Fallback for a piece whose own base stats pin no level, e.g. one the payload reports none for. */
+function levelAgreedByWeapons(pieces: readonly ImportedPiece[]): GearLevel | null {
+  const levels = new Set<GearLevel>()
+  for (const piece of pieces) {
+    if (piece.identity?.level) levels.add(piece.identity.level)
+  }
+  return levels.size === 1 ? [...levels][0]! : null
+}
+
+export function resolveAgainstBuild(
+  result: GearImportResult,
+  inputs: Inputs,
+  choices: AffixChoices = {},
+): GearImportResult {
+  const pieces = result.pieces.map((piece) => {
+    const slot = piece.slot.kind === "mapped" ? piece.slot.slot : null
+    return {
+      ...piece,
+      identity:
+        slot && piece.observedBaseStats ? inferGearIdentity(slot, piece.observedBaseStats) : null,
+      affixes: piece.affixes.map((affix) => resolveAffix(affix, slot, inputs, choices)),
+      overflowAffixes: piece.overflowAffixes.map((affix) =>
+        resolveAffix(affix, slot, inputs, choices),
+      ),
+      attunement: piece.attunement ? resolveAffix(piece.attunement, slot, inputs, choices) : null,
+    }
+  })
+  return { ...result, pieces }
+}
+
+export function effectiveIdentity(
+  piece: ImportedPiece,
+  pieces: readonly ImportedPiece[],
+  overrides: IdentityOverrides,
+): { level: GearLevel; rarity: GearRarity } {
+  const override = overrides[piece.gameSlotId]
+  return {
+    level:
+      override?.level ?? piece.identity?.level ?? levelAgreedByWeapons(pieces) ?? FALLBACK_LEVEL,
+    rarity: override?.rarity ?? piece.identity?.rarity ?? FALLBACK_RARITY,
+  }
+}
+
+export function importablePieces(result: GearImportResult): ImportedPiece[] {
+  return result.pieces.filter((piece) => piece.slot.kind === "mapped")
+}
+
+export function toGearPieces(result: GearImportResult, overrides: IdentityOverrides): GearPiece[] {
+  return importablePieces(result).map((piece) => {
+    const slot = (piece.slot as { kind: "mapped"; slot: GearSlot }).slot
+    const { level, rarity } = effectiveIdentity(piece, result.pieces, overrides)
+    const base = gearBaseStatsFor({ slot, level, rarity })
+
+    const words = [0, 1, 2, 3, 4].map((index) => {
+      const resolution = piece.affixes[index]?.resolution
+      if (resolution?.kind !== "resolved" || resolution.target.kind !== "word") {
+        return emptyGearWord()
+      }
+      return { word: resolution.target.word, value: resolution.value, retuned: false }
+    }) as [GearWordEntry, GearWordEntry, GearWordEntry, GearWordEntry, GearWordEntry]
+
+    const attunement = piece.attunement?.resolution
+    const attuned =
+      attunement?.kind === "resolved" && attunement.target.kind === "attunement"
+        ? { id: attunement.target.attunementId, value: attunement.value }
+        : null
+
+    return {
+      id: newGearPieceId(),
+      slot,
+      level,
+      rarity,
+      minPhys: base.minPhys,
+      maxPhys: base.maxPhys,
+      hp: base.hp,
+      physDef: base.physDef,
+      words,
+      attunement: attuned?.id ?? "",
+      attunementValue: attuned?.value ?? 0,
+      relayed: false,
+      isNew: true,
+    }
+  })
+}

--- a/src/ui/features/gear/new-gear-piece-dialog/NewGearPieceDialog.tsx
+++ b/src/ui/features/gear/new-gear-piece-dialog/NewGearPieceDialog.tsx
@@ -5,7 +5,7 @@ import { gearBaseStatsFor } from "../../../../engine/gearStats"
 import { newGearPieceId } from "../../../../storage"
 import { useI18n } from "../../../../i18n/i18nContext"
 import { GearPieceForm } from "../gear-piece-form/GearPieceForm"
-import styles from "./NewGearPieceDialog.module.scss"
+import dialogChrome from "../shared/gearDialog.module.scss"
 
 interface Props {
   initialSlot: GearSlot
@@ -53,7 +53,7 @@ export function NewGearPieceDialog({ initialSlot, inputs, onCancel, onSave }: Pr
 
   return (
     <div
-      className={styles.gearDialogOverlay}
+      className={dialogChrome.overlay}
       role="dialog"
       aria-modal="true"
       aria-labelledby="gear-dialog-title"
@@ -61,11 +61,11 @@ export function NewGearPieceDialog({ initialSlot, inputs, onCancel, onSave }: Pr
         if (e.target === e.currentTarget) onCancel()
       }}
     >
-      <div className={styles.gearDialogModal}>
-        <div className={styles.gearDialogHeader}>
+      <div className={dialogChrome.modal}>
+        <div className={dialogChrome.header}>
           <h2 id="gear-dialog-title">{t("New gear piece")}</h2>
         </div>
-        <div className={styles.gearDialogBody}>
+        <div className={dialogChrome.body}>
           <GearPieceForm
             piece={draft}
             inputs={inputs}
@@ -76,7 +76,7 @@ export function NewGearPieceDialog({ initialSlot, inputs, onCancel, onSave }: Pr
             showWordMax={false}
           />
         </div>
-        <div className={styles.gearDialogFooter}>
+        <div className={dialogChrome.footer}>
           <button type="button" className="btn" onClick={onCancel}>
             {t("Cancel")}
           </button>

--- a/src/ui/features/gear/shared/gearDialog.module.scss
+++ b/src/ui/features/gear/shared/gearDialog.module.scss
@@ -1,4 +1,4 @@
-.gearDialogOverlay {
+.overlay {
   position: fixed;
   inset: 0;
   z-index: 1200;
@@ -12,7 +12,7 @@
   overflow-y: auto;
 }
 
-.gearDialogModal {
+.modal {
   background: var(--color-surface-alt);
   border: 1px solid #3a3a3a;
   border-radius: 8px;
@@ -24,12 +24,12 @@
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
 }
 
-.gearDialogHeader {
+.header {
   padding: 16px 20px 10px;
   border-bottom: 1px solid #2c2c2c;
 }
 
-.gearDialogHeader h2 {
+.header h2 {
   margin: 0;
   font-size: 1.05em;
   color: var(--color-accent);
@@ -38,16 +38,18 @@
   font-weight: 600;
 }
 
-.gearDialogBody {
+.body {
   padding: 12px 20px;
   overflow-y: auto;
 }
 
-.gearDialogFooter {
+.footer {
   padding: 12px 20px;
   border-top: 1px solid #2c2c2c;
   display: flex;
+  align-items: center;
   justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 8px;
   background: var(--color-bg);
 }

--- a/tests/engine/inferGearIdentity.test.ts
+++ b/tests/engine/inferGearIdentity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import { gearBaseStatsFor, inferGearIdentity } from "../../src/engine/gearStats"
+import { GEAR_SLOTS, type GearLevel, type GearRarity } from "../../src/engine/types"
+
+const TABLED_LEVELS: GearLevel[] = [91, 96]
+const RARITIES: GearRarity[] = ["legendary", "epic"]
+
+describe("inferGearIdentity", () => {
+  it("pins both axes for a weapon slot", () => {
+    for (const level of TABLED_LEVELS) {
+      for (const rarity of RARITIES) {
+        const observed = gearBaseStatsFor({ slot: "leftWeapon", level, rarity })
+        expect(inferGearIdentity("leftWeapon", observed)).toMatchObject({ level, rarity })
+      }
+    }
+  })
+
+  it("pins both axes for every slot, weapon and armor alike", () => {
+    for (const slot of GEAR_SLOTS) {
+      for (const level of TABLED_LEVELS) {
+        for (const rarity of RARITIES) {
+          const observed = gearBaseStatsFor({ slot, level, rarity })
+          expect(inferGearIdentity(slot, observed), `${slot} lv${level} ${rarity}`).toMatchObject({
+            level,
+            rarity,
+          })
+        }
+      }
+    }
+  })
+
+  it("leaves an axis null when the observed stats cannot pin it", () => {
+    const helm = gearBaseStatsFor({ slot: "helm", level: 96, rarity: "legendary" })
+    expect(inferGearIdentity("helm", { hp: helm.hp })).toMatchObject({
+      level: 96,
+      rarity: "legendary",
+    })
+    expect(inferGearIdentity("greaves", { hp: helm.hp })).toMatchObject({
+      level: 96,
+      rarity: "legendary",
+    })
+  })
+
+  it("compares only the fields the slot actually carries", () => {
+    const observed = gearBaseStatsFor({ slot: "disc", level: 96, rarity: "legendary" })
+    expect(inferGearIdentity("disc", { minPhys: observed.minPhys })).toMatchObject({
+      level: 96,
+      rarity: "legendary",
+    })
+  })
+
+  it("reports no candidates for stats outside the table", () => {
+    expect(inferGearIdentity("leftWeapon", { minPhys: 1, maxPhys: 2 })).toEqual({
+      level: null,
+      rarity: null,
+      candidates: [],
+    })
+  })
+
+  it("reports no candidates when nothing was observed", () => {
+    expect(inferGearIdentity("helm", {}).candidates).toEqual([])
+  })
+})

--- a/tests/migrations/profileV7ClampSingleMysticRoll.test.ts
+++ b/tests/migrations/profileV7ClampSingleMysticRoll.test.ts
@@ -79,10 +79,15 @@ describe("profile-v6 fixture — the stored blob predates the corrected max roll
 })
 
 describe("the corrected cap is what the gear form and the engine both use", () => {
-  it("getWordSpecs reports 9.797 %, and relayed gear 9.2 %", () => {
+  it("getWordSpecs reports 9.797 %, and relayed gear 9.21 %", () => {
     const spec = getWordSpecs(LEGACY.profile.inputs).find((candidate) => candidate.word === WORD)!
     expect(spec.amount).toBeCloseTo(MAX_ROLL, 10)
-    expect(relayedCapValue(spec.amount, spec.unit)).toBeCloseTo(0.092, 10)
+    expect(relayedCapValue(spec.amount, spec.unit)).toBeCloseTo(0.0921, 10)
+  })
+
+  it("only ever raises the cap a stored roll was clamped to, so v7 profiles stay legal", () => {
+    const spec = getWordSpecs(LEGACY.profile.inputs).find((candidate) => candidate.word === WORD)!
+    expect(relayedCapValue(spec.amount, spec.unit)).toBeGreaterThanOrEqual(0.092)
   })
 })
 

--- a/tests/ui/fixtures/dashboardRoleInfo.json
+++ b/tests/ui/fixtures/dashboardRoleInfo.json
@@ -1,0 +1,75 @@
+{
+  "source": "wwm-dashboard",
+  "v": 1,
+  "capturedAt": "2026-08-11T00:00:00.000Z",
+  "roleName": "Testwanderer",
+  "level": 100,
+  "school": 11,
+  "wearEquips": { "1": 1101672, "2": 1101643, "3": 1101661, "9": 1101667, "33": 1101699 },
+  "wearEquipsDetailed": {
+    "1": {
+      "no": "1101672",
+      "exVo": {
+        "durability": 26,
+        "suffix": 3,
+        "baseAttrs": { "MIN_W_ATK": 65, "MAX_W_ATK": 151 },
+        "baseAffixes": [
+          { "equipmentDetails": [9793015, 0.05828, 0.94, 3, true] },
+          { "equipmentDetails": [9793119, 0.0736, 0.8178, 2, true] },
+          { "equipmentDetails": [9793120, 0.044, 1, 3, true] },
+          { "equipmentDetails": [9793005, 45.569, 0.9224493927125507, 3, true] },
+          { "equipmentDetails": [9793008, 73.132, 0.94, 3, true] },
+          { "equipmentDetails": [280701, 10.7, 0.9727272727272727, 3, true] }
+        ]
+      }
+    },
+    "2": {
+      "no": "1101643",
+      "exVo": {
+        "durability": 26,
+        "suffix": 3,
+        "baseAttrs": { "MIN_W_ATK": 59, "MAX_W_ATK": 136 },
+        "baseAffixes": [
+          { "equipmentDetails": [9794014, 0.0409, 0.9295454545454546, 2, true] },
+          { "equipmentDetails": [9793121, 0.032, 1, 3, true] },
+          { "equipmentDetails": [9794008, 73.132, 0.94, 3, true] },
+          { "equipmentDetails": [9794002, 46.436, 0.94, 3, true] },
+          { "equipmentDetails": [9713004, 37.3, 0.8438914027149321, 2, true] },
+          { "equipmentDetails": [9999999, 12.5, 0.5, 2, true] },
+          { "equipmentDetails": [280701, 10.4, 0.9454545454545454, 3, true] }
+        ]
+      }
+    },
+    "3": {
+      "no": "1101661",
+      "exVo": {
+        "durability": 26,
+        "suffix": 4,
+        "baseAttrs": { "W_DEF": 22, "HP_MAX": 5774 },
+        "baseAffixes": [
+          { "equipmentDetails": [9743005, 0.03996, 0.9081818181818183, 2, true] },
+          { "equipmentDetails": [280103, 0.059, 0.9833333333333333, 3, true] }
+        ]
+      }
+    },
+    "9": {
+      "no": "1101667",
+      "exVo": {
+        "durability": 26,
+        "suffix": 46,
+        "baseAttrs": { "ARCHER_WEAKPOINT_DAMAGE": 342 },
+        "baseAffixes": [{ "equipmentDetails": [9773001, 0.187, 0.9444444444444444, 3, false] }]
+      }
+    },
+    "33": {
+      "no": "1101699",
+      "exVo": {
+        "durability": 26,
+        "suffix": 99,
+        "baseAttrs": {},
+        "baseAffixes": [{ "equipmentDetails": [9799999, 2.5, 0.5, 1, true] }]
+      }
+    }
+  },
+  "unrecognizedPayloadKeys": ["roleId", "xiuWeiKungFu", "battleQs"]
+}

--- a/tests/ui/gearImportAffixChoices.test.ts
+++ b/tests/ui/gearImportAffixChoices.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import {
+  AFFIX_MAPPINGS_FILE_VERSION,
+  exportAffixChoices,
+  parseAffixChoicesFile,
+} from "../../src/ui/features/gear/import-gear-dialog/affixChoiceStore"
+
+const choices = { "9793120": "word:Affinity", "280701": "attunement:physPen" }
+
+describe("exportAffixChoices", () => {
+  it("writes a versioned envelope around the mappings", () => {
+    const parsed = JSON.parse(exportAffixChoices(choices))
+    expect(parsed.source).toBe("wwm-gear-affix-mappings")
+    expect(parsed.v).toBe(AFFIX_MAPPINGS_FILE_VERSION)
+    expect(parsed.mappings).toEqual(choices)
+  })
+
+  it("sorts keys so two exports diff cleanly", () => {
+    const written = exportAffixChoices(choices)
+    expect(written.indexOf('"280701"')).toBeLessThan(written.indexOf('"9793120"'))
+  })
+
+  it("round-trips through the parser", () => {
+    expect(parseAffixChoicesFile(exportAffixChoices(choices))).toEqual(choices)
+  })
+
+  it("stays human-editable — indented and newline-terminated", () => {
+    const written = exportAffixChoices(choices)
+    expect(written).toContain("\n  ")
+    expect(written.endsWith("\n")).toBe(true)
+  })
+})
+
+describe("parseAffixChoicesFile", () => {
+  it("accepts a bare affix-id record so the shipped table can be pasted back", () => {
+    expect(parseAffixChoicesFile('{"9793119":"word:Crit"}')).toEqual({ "9793119": "word:Crit" })
+  })
+
+  it("drops non-string values instead of failing the whole file", () => {
+    expect(parseAffixChoicesFile('{"9793119":"word:Crit","9793120":42}')).toEqual({
+      "9793119": "word:Crit",
+    })
+  })
+
+  it("rejects non-JSON", () => {
+    expect(() => parseAffixChoicesFile("nope")).toThrow(/not valid JSON/)
+  })
+
+  it("rejects another tool's file", () => {
+    expect(() => parseAffixChoicesFile('{"source":"something-else","mappings":{}}')).toThrow(
+      /not a stat-line mapping export/,
+    )
+  })
+
+  it("rejects a newer file version", () => {
+    expect(() =>
+      parseAffixChoicesFile(
+        JSON.stringify({ source: "wwm-gear-affix-mappings", v: 99, mappings: choices }),
+      ),
+    ).toThrow(/newer version \(v99\)/)
+  })
+
+  it("rejects a file with no mappings", () => {
+    expect(() => parseAffixChoicesFile("{}")).toThrow(/no stat-line mappings/)
+  })
+
+  it("rejects an array", () => {
+    expect(() => parseAffixChoicesFile("[]")).toThrow(/does not hold stat-line mappings/)
+  })
+})

--- a/tests/ui/gearImportBookmarklet.test.ts
+++ b/tests/ui/gearImportBookmarklet.test.ts
@@ -1,0 +1,55 @@
+// The bookmarklet source is a .js file, so it sits outside tsc, ESLint and
+// prettier. These assertions are that exemption's guard rail.
+import { describe, expect, it } from "vitest"
+import bookmarkletSource from "../../src/ui/features/gear/import-gear-dialog/gearImportBookmarklet.js?raw"
+import {
+  BOOKMARKLET_SCHEME,
+  bookmarkletHref,
+} from "../../src/ui/features/gear/import-gear-dialog/bookmarkletHref"
+
+const CJK_FIRST = 0x4e00
+const CJK_LAST = 0x9fff
+
+describe("gear import bookmarklet source", () => {
+  it("parses as browser-executable script", () => {
+    expect(() => new Function(bookmarkletSource)).not.toThrow()
+  })
+
+  it("is self-contained", () => {
+    expect(bookmarkletSource).not.toMatch(/^\s*(import|export)\b/m)
+  })
+
+  it("carries no Chinese", () => {
+    const offending = [...bookmarkletSource].filter((character) => {
+      const code = character.codePointAt(0) ?? 0
+      return code >= CJK_FIRST && code <= CJK_LAST
+    })
+    expect(offending).toEqual([])
+  })
+
+  it("reads the cached payload before reaching for the token", () => {
+    expect(bookmarkletSource.indexOf("getAreaServer")).toBeLessThan(
+      bookmarkletSource.indexOf("h72na_data_token"),
+    )
+  })
+
+  it("never copies the token or the role id", () => {
+    const carried = /CARRIED_FIELDS = \[([^\]]*)\]/.exec(bookmarkletSource)
+    expect(carried).not.toBeNull()
+    expect(carried![1]).not.toMatch(/roleId|token/)
+  })
+})
+
+describe("bookmarkletHref", () => {
+  it("round-trips the source through the javascript: scheme", () => {
+    const href = bookmarkletHref(bookmarkletSource)
+    expect(href.startsWith(BOOKMARKLET_SCHEME)).toBe(true)
+    expect(decodeURIComponent(href.slice(BOOKMARKLET_SCHEME.length))).toBe(bookmarkletSource)
+  })
+
+  it("escapes the characters that would truncate the URL", () => {
+    const href = bookmarkletHref('var a = "#100%"')
+    expect(href).not.toMatch(/#/)
+    expect(href).toBe("javascript:var%20a%20%3D%20%22%23100%25%22")
+  })
+})

--- a/tests/ui/gearImportPayload.test.ts
+++ b/tests/ui/gearImportPayload.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest"
+import {
+  GearImportError,
+  buildImportDiagnostics,
+  parseDashboardGearPayload,
+  previewablePieces,
+} from "../../src/ui/features/gear/import-gear-dialog/dashboardGearPayload"
+import fixture from "./fixtures/dashboardRoleInfo.json"
+
+const fixtureText = JSON.stringify(fixture)
+
+function pieceFor(text: string, gameSlotId: string) {
+  const found = parseDashboardGearPayload(text).pieces.find(
+    (piece) => piece.gameSlotId === gameSlotId,
+  )
+  if (!found) throw new Error(`no piece for slot ${gameSlotId}`)
+  return found
+}
+
+describe("parseDashboardGearPayload rejections", () => {
+  it("rejects an empty paste", () => {
+    expect(() => parseDashboardGearPayload("   ")).toThrow(/Paste the JSON/)
+  })
+
+  it("rejects non-JSON", () => {
+    expect(() => parseDashboardGearPayload("not json at all")).toThrow(/not valid JSON/)
+  })
+
+  it("rejects a non-object", () => {
+    expect(() => parseDashboardGearPayload("[1,2,3]")).toThrow(/not an object/)
+  })
+
+  it("rejects another tool's envelope", () => {
+    expect(() =>
+      parseDashboardGearPayload(JSON.stringify({ source: "some-other-tool", v: 1 })),
+    ).toThrow(/not the WWM dashboard bookmarklet/)
+  })
+
+  it("rejects a newer envelope version", () => {
+    expect(() =>
+      parseDashboardGearPayload(
+        JSON.stringify({ source: "wwm-dashboard", v: 2, wearEquipsDetailed: {} }),
+      ),
+    ).toThrow(/newer bookmarklet \(v2\)/)
+  })
+
+  it("rejects a payload with no gear map", () => {
+    expect(() => parseDashboardGearPayload(JSON.stringify({ roleName: "x" }))).toThrow(
+      /no wearEquipsDetailed/,
+    )
+  })
+
+  it("throws GearImportError, not a bare Error", () => {
+    expect(() => parseDashboardGearPayload("{}")).toThrow(GearImportError)
+  })
+})
+
+describe("parseDashboardGearPayload acceptance", () => {
+  it("accepts an empty gear map as zero pieces", () => {
+    expect(parseDashboardGearPayload(JSON.stringify({ wearEquipsDetailed: {} })).pieces).toEqual([])
+  })
+
+  it("accepts a raw dashboard capture nested under data", () => {
+    const raw = JSON.stringify({ data: { roleName: "Raw", wearEquipsDetailed: { "1": {} } } })
+    const result = parseDashboardGearPayload(raw)
+    expect(result.roleName).toBe("Raw")
+    expect(result.pieces).toHaveLength(1)
+  })
+
+  it("reads the role name, character level and declared extra keys", () => {
+    const result = parseDashboardGearPayload(fixtureText)
+    expect(result.roleName).toBe("Testwanderer")
+    expect(result.characterLevel).toBe(100)
+    expect(result.unrecognizedPayloadKeys).toContain("roleId")
+  })
+
+  it("reads the item id from wearEquips", () => {
+    expect(pieceFor(fixtureText, "1").itemId).toBe(1101672)
+  })
+
+  it("falls back to the detail entry's own item number", () => {
+    const text = JSON.stringify({
+      wearEquipsDetailed: { "1": { no: "1101672", exVo: { baseAffixes: [] } } },
+    })
+    expect(pieceFor(text, "1").itemId).toBe(1101672)
+  })
+})
+
+describe("slot resolution", () => {
+  it("maps slot 3 to the helm", () => {
+    expect(pieceFor(fixtureText, "3").slot).toEqual({ kind: "mapped", slot: "helm" })
+  })
+
+  it("marks the bow as having no app equivalent", () => {
+    expect(pieceFor(fixtureText, "9").slot).toEqual({ kind: "noAppEquivalent" })
+  })
+
+  it("marks a slot id absent from the table", () => {
+    expect(pieceFor(fixtureText, "33").slot).toEqual({ kind: "unknownSlotId" })
+  })
+
+  it("hides bow and ring from the preview but keeps unknown slots visible", () => {
+    const shown = previewablePieces(parseDashboardGearPayload(fixtureText))
+    expect(shown.map((piece) => piece.gameSlotId)).toEqual(["1", "2", "3", "33"])
+  })
+
+  it("orders the preview like the Equipped card, not like the payload keys", () => {
+    const detailed: Record<string, unknown> = {}
+    // Payload order deliberately scrambled relative to GEAR_SLOTS.
+    for (const gameSlotId of ["8", "3", "11", "1", "5", "10", "4", "2"]) {
+      detailed[gameSlotId] = { exVo: { baseAffixes: [] } }
+    }
+    const shown = previewablePieces(
+      parseDashboardGearPayload(JSON.stringify({ wearEquipsDetailed: detailed })),
+    )
+    expect(
+      shown.map((piece) => (piece.slot.kind === "mapped" ? piece.slot.slot : piece.slot.kind)),
+    ).toEqual([
+      "leftWeapon",
+      "rightWeapon",
+      "disc",
+      "pendant",
+      "helm",
+      "armor",
+      "greaves",
+      "bracer",
+    ])
+  })
+})
+
+describe("affix extraction from the equipmentDetails tuple", () => {
+  it("reads id, value and rolled ratio, and derives the max roll", () => {
+    const affix = pieceFor(fixtureText, "1").affixes[0]!
+    expect(affix.affixId).toBe("9793015")
+    expect(affix.rawValue).toBe(0.05828)
+    expect(affix.rolledRatio).toBe(0.94)
+    expect(affix.derivedMax).toBeCloseTo(0.062, 10)
+  })
+
+  it("separates the six-digit attunement affix from the tunements", () => {
+    const piece = pieceFor(fixtureText, "1")
+    expect(piece.affixes.map((affix) => affix.affixId)).toEqual([
+      "9793015",
+      "9793119",
+      "9793120",
+      "9793005",
+      "9793008",
+    ])
+    expect(piece.attunement?.affixId).toBe("280701")
+    expect(piece.attunement?.isAttunementAffix).toBe(true)
+  })
+
+  it("keeps the first five tunements and overflows the rest", () => {
+    const piece = pieceFor(fixtureText, "2")
+    expect(piece.affixes).toHaveLength(5)
+    expect(piece.overflowAffixes.map((affix) => affix.affixId)).toEqual(["9999999"])
+    expect(piece.attunement?.affixId).toBe("280701")
+  })
+
+  it("reports no attunement when the piece has none", () => {
+    const text = JSON.stringify({
+      wearEquipsDetailed: {
+        "1": { exVo: { baseAffixes: [{ equipmentDetails: [9793015, 0.05, 1, 3, true] }] } },
+      },
+    })
+    expect(pieceFor(text, "1").attunement).toBeNull()
+  })
+
+  it("keeps the raw entry so diagnostics survive a shape change", () => {
+    expect(pieceFor(fixtureText, "1").affixes[0]!.raw).toEqual({
+      equipmentDetails: [9793015, 0.05828, 0.94, 3, true],
+    })
+  })
+
+  it("does not drop a sibling when one entry is unreadable", () => {
+    const text = JSON.stringify({
+      wearEquipsDetailed: {
+        "1": { exVo: { baseAffixes: [null, { equipmentDetails: [9793119, 0.09, 1, 3, true] }] } },
+      },
+    })
+    const affixes = pieceFor(text, "1").affixes
+    expect(affixes).toHaveLength(2)
+    expect(affixes[0]!.affixId).toBe("?")
+    expect(affixes[1]!.affixId).toBe("9793119")
+  })
+})
+
+describe("observed base stats", () => {
+  it("reads weapon attack from exVo.baseAttrs", () => {
+    expect(pieceFor(fixtureText, "1").observedBaseStats).toEqual({ minPhys: 65, maxPhys: 151 })
+  })
+
+  it("reads armor hp and defense from exVo.baseAttrs", () => {
+    expect(pieceFor(fixtureText, "3").observedBaseStats).toEqual({ hp: 5774, physDef: 22 })
+  })
+
+  it("reports null when baseAttrs carries nothing we model", () => {
+    expect(pieceFor(fixtureText, "9").observedBaseStats).toBeNull()
+  })
+})
+
+describe("buildImportDiagnostics", () => {
+  it("carries affix ids and derived max rolls", () => {
+    const diagnostics = JSON.parse(buildImportDiagnostics(parseDashboardGearPayload(fixtureText)))
+    const weapon = diagnostics.pieces.find(
+      (piece: { gameSlotId: string }) => piece.gameSlotId === "1",
+    )
+    expect(weapon.baseAffixes).toHaveLength(5)
+    expect(weapon.baseAffixes[0].affixId).toBe("9793015")
+    expect(weapon.attunement.affixId).toBe("280701")
+  })
+
+  it("leaks no role identity", () => {
+    const diagnostics = buildImportDiagnostics(parseDashboardGearPayload(fixtureText))
+    expect(diagnostics).not.toMatch(/Testwanderer|roleName/)
+  })
+})

--- a/tests/ui/gearImportPieces.test.ts
+++ b/tests/ui/gearImportPieces.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vitest"
+import { defaultInputs } from "../../src/engine/defaults"
+import { gearBaseStatsFor } from "../../src/engine/gearStats"
+import { getWordSpecs } from "../../src/engine/itemRanking"
+import { attunementsForClass } from "../../src/engine/attunements"
+import type { Inputs } from "../../src/engine/types"
+import {
+  parseDashboardGearPayload,
+  targetKey,
+} from "../../src/ui/features/gear/import-gear-dialog/dashboardGearPayload"
+import { AFFIX_ID_TO_STAT_LINE } from "../../src/ui/features/gear/import-gear-dialog/affixStatLineTable"
+import {
+  FALLBACK_LEVEL,
+  FALLBACK_RARITY,
+  effectiveIdentity,
+  importablePieces,
+  resolveAgainstBuild,
+  toGearPieces,
+  type AffixChoices,
+} from "../../src/ui/features/gear/import-gear-dialog/importedGearPieces"
+import fixture from "./fixtures/dashboardRoleInfo.json"
+
+const fixtureText = JSON.stringify(fixture)
+const inputs: Inputs = { ...defaultInputs, classId: "bellstrikeUmbra" }
+
+// Mirrors the ids in the fixture; the shipped table only carries what is confirmed.
+const choices: AffixChoices = {
+  "9793015": "word:Sword Martial Boost",
+  "9793120": "word:Affinity",
+  "9793005": "word:Power",
+  "9793008": "word:Min Phys",
+  "280701": "attunement:physPen",
+  "9794014": "word:Affinity",
+  "9793121": "word:All Martial Boost",
+  "9794008": "word:Max Phys",
+  "9794002": "word:Momentum",
+  "9713004": "word:Min Bellstrike",
+  "9743005": "word:Affinity",
+  "280103": "attunement:bleedingDamage",
+}
+
+function resolved(text = fixtureText, withChoices: AffixChoices = choices) {
+  return resolveAgainstBuild(parseDashboardGearPayload(text), inputs, withChoices)
+}
+
+function pieceFor(gameSlotId: string, withChoices: AffixChoices = choices) {
+  const found = resolved(fixtureText, withChoices).pieces.find(
+    (piece) => piece.gameSlotId === gameSlotId,
+  )
+  if (!found) throw new Error(`no piece for slot ${gameSlotId}`)
+  return found
+}
+
+describe("the shipped affix table is the authority", () => {
+  it("resolves an id it carries without any user choice", () => {
+    const affix = pieceFor("1", {}).affixes[1]!
+    expect(affix.affixId).toBe("9793119")
+    expect(affix.resolution).toMatchObject({ kind: "resolved", target: { word: "Crit" } })
+  })
+
+  it("resolves the whole first weapon from the table alone", () => {
+    const piece = pieceFor("1", {})
+    expect(piece.affixes.map((affix) => affix.resolution.kind)).toEqual(Array(5).fill("resolved"))
+    expect(piece.attunement!.resolution.kind).toBe("resolved")
+  })
+
+  it("leaves an id it does not carry unmapped", () => {
+    const affix = pieceFor("2", {}).overflowAffixes[0]!
+    expect(affix.affixId).toBe("9999999")
+    expect(affix.resolution.kind).toBe("unmapped")
+  })
+
+  it("names only stats this build can produce", () => {
+    const words = new Set(getWordSpecs(inputs).map((spec) => spec.word))
+    const attunements = new Set(attunementsForClass(inputs.classId).map((option) => option.id))
+    for (const key of Object.values(AFFIX_ID_TO_STAT_LINE)) {
+      const [kind, name] = [key.slice(0, key.indexOf(":")), key.slice(key.indexOf(":") + 1)]
+      if (kind === "word") expect(words.has(name) || name.endsWith(" Martial Boost")).toBe(true)
+      else expect(attunements.has(name)).toBe(true)
+    }
+  })
+
+  it("keeps each id on the side of the namespace its digits put it on", () => {
+    for (const [affixId, key] of Object.entries(AFFIX_ID_TO_STAT_LINE)) {
+      const isAttunementId = Number(affixId) < 1_000_000
+      expect(key.startsWith("attunement:")).toBe(isAttunementId)
+    }
+  })
+})
+
+describe("suggestions from the reported max roll", () => {
+  it("offers every stat sharing the affix's ceiling", () => {
+    const affix = pieceFor("1", {}).affixes[3]!
+    expect(affix.derivedMax).toBeCloseTo(49.4, 6)
+    const suggested = affix.resolution.suggestions.map(targetKey)
+    expect(suggested).toEqual(
+      expect.arrayContaining(["word:Power", "word:Agility", "word:Momentum"]),
+    )
+  })
+
+  it("offers every legal stat as choosable, not just the suggestions", () => {
+    const affix = pieceFor("1", {}).affixes[3]!
+    expect(affix.resolution.choosableTargets.length).toBeGreaterThan(
+      affix.resolution.suggestions.length,
+    )
+  })
+
+  it("offers attunements for an attunement affix", () => {
+    const affix = pieceFor("1", {}).attunement!
+    expect(affix.resolution.suggestions.map(targetKey)).toContain("attunement:physPen")
+  })
+
+  it("never offers a word for an attunement row, nor an attunement for a tunement row", () => {
+    const attunement = pieceFor("1", {}).attunement!
+    expect(
+      attunement.resolution.choosableTargets.every((target) => target.kind === "attunement"),
+    ).toBe(true)
+
+    const tunement = pieceFor("1", {}).affixes[3]!
+    expect(tunement.resolution.choosableTargets.every((target) => target.kind === "word")).toBe(
+      true,
+    )
+  })
+
+  it("refuses a word mapped onto an attunement row instead of dropping the line", () => {
+    const crossed: AffixChoices = { "280701": "word:Physical Penetration" }
+    expect(pieceFor("1", crossed).attunement!.resolution).toMatchObject({
+      kind: "unmapped",
+      mappedTo: "word:Physical Penetration",
+    })
+  })
+})
+
+describe("a user choice maps an id", () => {
+  it("resolves a chosen word and keeps the payload value", () => {
+    expect(pieceFor("1").affixes[3]!.resolution).toMatchObject({
+      kind: "resolved",
+      target: { word: "Power" },
+      value: 45.569,
+      clampedFrom: null,
+    })
+  })
+
+  it("keeps a percent word as a fraction", () => {
+    expect(pieceFor("1").affixes[2]!.resolution).toMatchObject({
+      kind: "resolved",
+      value: 0.044,
+    })
+  })
+
+  it("scales an attunement reported in percent into a fraction", () => {
+    expect(pieceFor("1").attunement!.resolution).toMatchObject({
+      kind: "resolved",
+      target: { attunementId: "physPen" },
+      value: 0.107,
+    })
+  })
+
+  it("leaves an attunement already reported as a fraction unscaled", () => {
+    expect(pieceFor("3").attunement!.resolution).toMatchObject({
+      kind: "resolved",
+      target: { attunementId: "bleedingDamage" },
+      value: 0.059,
+    })
+  })
+
+  it("clamps above the cap and records what it was", () => {
+    const cap = getWordSpecs(inputs).find((spec) => spec.word === "Crit")!.amount
+    const text = JSON.stringify({
+      wearEquipsDetailed: {
+        "1": {
+          exVo: { baseAffixes: [{ equipmentDetails: [9793119, 0.5, 5.555555555555555, 3, true] }] },
+        },
+      },
+    })
+    expect(resolved(text).pieces[0]!.affixes[0]!.resolution).toMatchObject({
+      kind: "resolved",
+      value: cap,
+      clampedFrom: 0.5,
+    })
+  })
+
+  it("keeps full precision below the cap — no rounding", () => {
+    const text = JSON.stringify({
+      wearEquipsDetailed: {
+        "1": {
+          exVo: {
+            baseAffixes: [{ equipmentDetails: [9793119, 0.0873421, 0.9704677777777778, 3, true] }],
+          },
+        },
+      },
+    })
+    expect(resolved(text).pieces[0]!.affixes[0]!.resolution).toMatchObject({
+      value: 0.0873421,
+      clampedFrom: null,
+    })
+  })
+
+  it("refuses a choice that is illegal for the resolved slot", () => {
+    const armorOnly: AffixChoices = { "280701": "attunement:bleedingDamage" }
+    expect(pieceFor("1", armorOnly).attunement!.resolution).toMatchObject({
+      kind: "unmapped",
+      mappedTo: "attunement:bleedingDamage",
+    })
+  })
+})
+
+describe("level and rarity inference", () => {
+  it("reads a legendary weapon from its attack range", () => {
+    expect(pieceFor("1").identity).toMatchObject({ level: 96, rarity: "legendary" })
+  })
+
+  it("reads an epic weapon from its attack range", () => {
+    expect(pieceFor("2").identity).toMatchObject({ level: 96, rarity: "epic" })
+  })
+
+  it("reads armor level and rarity from its hp and defense", () => {
+    const armor = pieceFor("3")
+    expect(armor.identity).toMatchObject({ level: 96, rarity: "legendary" })
+    expect(effectiveIdentity(armor, resolved().pieces, {})).toEqual({
+      level: 96,
+      rarity: "legendary",
+    })
+  })
+
+  it("falls back when nothing can be inferred", () => {
+    const text = JSON.stringify({ wearEquipsDetailed: { "3": { exVo: { baseAffixes: [] } } } })
+    const result = resolved(text)
+    expect(effectiveIdentity(result.pieces[0]!, result.pieces, {})).toEqual({
+      level: FALLBACK_LEVEL,
+      rarity: FALLBACK_RARITY,
+    })
+  })
+
+  it("lets an override win over inference", () => {
+    const result = resolved()
+    const weapon = result.pieces.find((piece) => piece.gameSlotId === "1")!
+    expect(
+      effectiveIdentity(weapon, result.pieces, { "1": { level: 91, rarity: "epic" } }),
+    ).toEqual({ level: 91, rarity: "epic" })
+  })
+})
+
+describe("toGearPieces", () => {
+  it("imports only the slots that map", () => {
+    const result = resolved()
+    expect(importablePieces(result)).toHaveLength(3)
+    expect(toGearPieces(result, {}).map((piece) => piece.slot)).toEqual([
+      "leftWeapon",
+      "rightWeapon",
+      "helm",
+    ])
+  })
+
+  it("always writes five word rows and never marks a piece relayed", () => {
+    for (const piece of toGearPieces(resolved(), {})) {
+      expect(piece.words).toHaveLength(5)
+      expect(piece.relayed).toBe(false)
+      expect(piece.isNew).toBe(true)
+    }
+  })
+
+  it("mints a unique id per piece", () => {
+    const ids = toGearPieces(resolved(), {}).map((piece) => piece.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it("derives base stats from the table, never from the payload", () => {
+    for (const piece of toGearPieces(resolved(), {})) {
+      expect(piece).toMatchObject(gearBaseStatsFor(piece))
+    }
+  })
+
+  it("pads unmapped rows in place, preserving payload order", () => {
+    const helm = toGearPieces(resolved(), {}).find((piece) => piece.slot === "helm")!
+    expect(helm.words[0]).toEqual({ word: "Affinity", value: 0.03996, retuned: false })
+    expect(helm.words.slice(1)).toEqual(Array(4).fill({ word: "", value: 0, retuned: false }))
+  })
+
+  it("writes the attunement only when it resolved", () => {
+    const weapon = toGearPieces(resolved(), {}).find((piece) => piece.slot === "leftWeapon")!
+    expect(weapon.attunement).toBe("physPen")
+    expect(weapon.attunementValue).toBeCloseTo(0.107, 10)
+
+    const unknownSuffix = JSON.stringify({
+      wearEquipsDetailed: {
+        "1": { exVo: { baseAffixes: [{ equipmentDetails: [280999, 10.7, 0.97, 3, true] }] } },
+      },
+    })
+    const unmapped = toGearPieces(resolved(unknownSuffix, {}), {})[0]!
+    expect(unmapped.attunement).toBe("")
+    expect(unmapped.attunementValue).toBe(0)
+  })
+})

--- a/tests/ui/gearImportPreferences.test.ts
+++ b/tests/ui/gearImportPreferences.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  DEFAULT_KEEP_DISPLACED,
+  loadKeepDisplaced,
+  saveKeepDisplaced,
+} from "../../src/ui/features/gear/import-gear-dialog/importPreferences"
+
+describe("gear import preferences", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("defaults to removing the pieces an import replaces", () => {
+    expect(DEFAULT_KEEP_DISPLACED).toBe(false)
+    expect(loadKeepDisplaced()).toBe(false)
+  })
+
+  it("round-trips either choice", () => {
+    saveKeepDisplaced(true)
+    expect(loadKeepDisplaced()).toBe(true)
+    saveKeepDisplaced(false)
+    expect(loadKeepDisplaced()).toBe(false)
+  })
+
+  it("falls back to the default when the stored value is not a boolean", () => {
+    localStorage.setItem("wwm.gearImportKeepDisplaced", "maybe")
+    expect(loadKeepDisplaced()).toBe(DEFAULT_KEEP_DISPLACED)
+  })
+})

--- a/tests/ui/numberInputs.test.tsx
+++ b/tests/ui/numberInputs.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { NumInput, PercentInput } from "../../src/ui/components/number-inputs/NumberInputs"
+
+function valueOf(): string {
+  return (screen.getByRole("spinbutton") as HTMLInputElement).value
+}
+
+describe("NumInput display", () => {
+  it("rounds a long fraction to two decimals", () => {
+    render(<NumInput value={45.568999999999996} onChange={() => {}} />)
+    expect(valueOf()).toBe("45.57")
+  })
+
+  it("drops trailing zeros rather than padding", () => {
+    render(<NumInput value={30} onChange={() => {}} />)
+    expect(valueOf()).toBe("30")
+  })
+
+  it("keeps four decimals below 0.01 so a small coefficient is not shown as zero", () => {
+    render(<NumInput value={0.0005} onChange={() => {}} />)
+    expect(valueOf()).toBe("0.0005")
+  })
+
+  it("shows a true zero as zero", () => {
+    render(<NumInput value={0} onChange={() => {}} />)
+    expect(valueOf()).toBe("0")
+  })
+
+  it("does not report a change just for rounding the display", () => {
+    const onChange = vi.fn()
+    render(<NumInput value={45.568999999999996} onChange={onChange} />)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe("PercentInput display", () => {
+  it("rounds the percent to two decimals", () => {
+    render(<PercentInput value={0.05828} onChange={() => {}} />)
+    expect(valueOf()).toBe("5.83")
+  })
+})


### PR DESCRIPTION
Entering a full set by hand is 8 pieces × 5 tunements plus an attunement. The
official dashboard already holds the real thing, so a bookmarklet copies it and
the Gear tab's Equipped card gains an **Import gear** button that pastes it in.

## How it works

A bookmarklet you drag to the bookmarks bar reads
`localStorage["getAreaServer"]` — where the dashboard caches the whole `roleInfo`
payload — and only falls back to the `role/roleInfo` call when that is missing, so
the common path needs no token and no network. It carries just the five fields we
consume, so the role id and anything session-shaped never reach the clipboard, and
it reports the *names* of the keys it dropped so payload drift stays visible.

Paste the result into the dialog and it shows every piece and stat line it found,
then rewrites the eight gear slots in one `commitGearChange`.

## What the payload actually looks like

Reverse-engineered from the dashboard bundle rather than guessed, which corrected
three assumptions worth recording:

- Gear is `wearEquipsDetailed[slot].exVo`, base stats in `baseAttrs`
  (`MIN_W_ATK` / `MAX_W_ATK` / `HP_MAX` / `W_DEF`), stat lines in `baseAffixes` as
  `[id, value, valueOverMax, tier, flag]`.
- `exVo.suffix` is an **equip category** (3/4/46), not the attunement. The
  attunement is the six-digit affix; tunements are seven-digit. The two namespaces
  overlap in max roll — physical penetration exists as both — so the id is what
  separates them, and each picker is constrained to its own namespace because
  crossing them would drop the line instead of importing it.
- The ten game slot ids map to our eight plus bow and ring, which are hidden —
  the bow is `Inputs.bowSet`, not a `GearPiece`.

## Identifying a stat line

`affixStatLineTable.ts` is the only authority on what a stat line means. The
reported `valueOverMax` pins each roll's ceiling, but **a ceiling is not an
identity** — 49.4 is Power, Agility and Momentum alike — so it only offers
candidates in the dialog, marked with a ✓, and never decides. An unmapped id
imports nothing until it is mapped; a choice made in the dialog is remembered per
id and the set is exportable as JSON to paste back into the table. The table ships
with 31 ids confirmed against a live build, which resolves a full set with no
clicking.

Values are clamped to our max roll but **not** rounded, so the imported figure
keeps its precision while the UI shows two decimals.

## Two bugs found on the way, split out as their own commits

- **The confirm dialog rendered behind the modal.** It sat at `z-index` 1100
  against the gear dialogs' 1200, so the "empty these slots?" confirmation was
  unreachable. Nothing had asked for confirmation from inside a dialog before.
- **The lv96 armor rows were a copy of the lv91 ones.** No real lv96 armor matched
  the table, so level and rarity fell back to a fabricated "Legendary". Corrected
  from a live build; every defense figure now traces to a reported value. With the
  rows distinct, `inferGearIdentity` recovers both level and rarity for armor as
  well as weapons.

Also: gear values displayed every digit of their real precision
(`45.568999999999996`), now two decimals for display only — the stored value is
untouched until the field is edited. The relayed max column was a per-row grid, so
`auto` sized each row to its own text and a wider figure pushed that row's border
out of line; it is one shared grid now.

## Migration

**None needed.** No field was added to `Inputs` or `GearPiece`, and an imported
piece is minted through the same helpers as a hand-created one, so
`hydrateInputs`'s existing per-piece pass already covers it.

The armor correction changes derived values only: every consumer reads through
`gearBaseStatsFor`, nothing reads the stored `hp`/`physDef`, and
`applyPieceContribution` skips both — so no saved profile's DPS moves. Raising
`relayedCapValue`'s precision only ever raises a cap, so a roll the V7 migration
clamped to 0.092 stays legal under the new 0.0921; a test pins that direction so a
future tightening cannot silently invalidate a stored profile.

## Verification

`format:check`, `lint`, the English-only grep guard, `typecheck`, `build` and the
suite all green — **816 tests across 82 files**, 43 of them new.

Driven end to end in the browser against a real capture: 8/8 slots matched, 48
stats read, 0 unmapped, level and rarity read from each piece's own base stats.
Also checked the paste → preview → Back flow, the mapping export/import
round-trip, and that the import is reversible by not pressing Save.

## Open question

`GearLevel` is still `86 | 91 | 96`, and lv86 has no table row at all, so it is
never inferred. Nothing here needed it, but a build on a newer tier would.
