### PR TITLE
fix(timeline): a cast's chips exclude what the next cast applies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,22 @@ Whole files with no comments at all are the normal outcome, not a warning sign.
 Moving code does not move its comments with it: re-judge each one against this
 bar and drop it if it fails, even when you were told to preserve it.
 
+### The comment pass — the last step of every task
+
+**No task is finished until this has run.** When the work is otherwise done and
+before you report it, re-read your own diff and judge every comment in it again
+— the ones you just wrote included — then delete the ones that fail the bar and
+keep the ones that pass. Three questions catch most of them:
+
+1. Is the fact already visible at the call site, or in a name?
+2. Is it said twice — in another comment, or in the commit message?
+3. Could a **test name** carry it instead?
+
+"It was non-obvious while I was writing it" is not the bar: that preserves the
+author's reasoning, not something the reader cannot reconstruct. Shortening a
+comment is not the same as re-judging it, and reporting the one as the other
+misstates the work. Say in your summary that the pass ran.
+
 ## Names say what they hold at their point of use
 
 No `a`, `b`, `x`, `tmp`, no one-letter stand-in for a longer word — locals,
@@ -151,8 +167,7 @@ understood is a name to replace, and this outranks any external convention that
 prefers brevity.
 
 If you find yourself writing a comment to explain an identifier, fix the
-identifier instead. Before calling any task done, re-read your own diff and
-delete every comment a reader of the code would not miss.
+identifier instead.
 
 ## Language: English-first — no Chinese in code
 

--- a/src/engine/ledger.ts
+++ b/src/engine/ledger.ts
@@ -9,8 +9,11 @@
 export interface StatusWindow {
   start: number
   end: number
+  owner?: number
   extensions?: Array<{ frame: number; amount: number }>
 }
+
+export const UNOWNED = Number.NEGATIVE_INFINITY
 
 export interface StatusView {
   activeIdsAt(frame: number): string[]
@@ -30,9 +33,16 @@ export function windowEndAt(window: StatusWindow, frame: number): number {
   return end
 }
 
+function cloneWindow(window: StatusWindow): StatusWindow {
+  return window.extensions ? { ...window, extensions: [...window.extensions] } : { ...window }
+}
+
 export class StatusLedger implements StatusView {
   private readonly windows = new Map<string, StatusWindow[]>()
-  private readonly stacks = new Map<string, Array<{ frame: number; value: number }>>()
+  private readonly stacks = new Map<
+    string,
+    Array<{ frame: number; value: number; owner: number }>
+  >()
   private readonly permanentOpened = new Set<string>()
 
   constructor(
@@ -40,10 +50,11 @@ export class StatusLedger implements StatusView {
     private readonly spanEnd: number,
   ) {}
 
-  pushWindow(id: string, start: number, end: number): void {
+  pushWindow(id: string, start: number, end: number, owner: number = UNOWNED): void {
+    const window: StatusWindow = { start, end, owner }
     const existing = this.windows.get(id)
-    if (existing) existing.push({ start, end })
-    else this.windows.set(id, [{ start, end }])
+    if (existing) existing.push(window)
+    else this.windows.set(id, [window])
   }
 
   openPermanent(id: string): void {
@@ -52,10 +63,23 @@ export class StatusLedger implements StatusView {
     this.pushWindow(id, this.spanStart, this.spanEnd)
   }
 
-  recordStack(id: string, frame: number, value: number): void {
+  recordStack(id: string, frame: number, value: number, owner: number = UNOWNED): void {
     const existing = this.stacks.get(id)
-    if (existing) existing.push({ frame, value })
-    else this.stacks.set(id, [{ frame, value }])
+    if (existing) existing.push({ frame, value, owner })
+    else this.stacks.set(id, [{ frame, value, owner }])
+  }
+
+  throughOwner(ownerLimit: number): StatusLedger {
+    const view = new StatusLedger(this.spanStart, this.spanEnd)
+    for (const [id, windows] of this.windows) {
+      const kept = windows.filter((window) => (window.owner ?? UNOWNED) <= ownerLimit)
+      if (kept.length > 0) view.windows.set(id, kept.map(cloneWindow))
+    }
+    for (const [id, history] of this.stacks) {
+      const kept = history.filter((entry) => entry.owner <= ownerLimit)
+      if (kept.length > 0) view.stacks.set(id, kept)
+    }
+    return view
   }
 
   hasStackHistory(id: string): boolean {

--- a/src/engine/timeline.ts
+++ b/src/engine/timeline.ts
@@ -11,7 +11,7 @@ import type { Debuff } from "./debuff"
 import type { Skill, SkillHit, TriggerCondition } from "./skill"
 import { isPrePullSkill, hitDealsDamage, triggerConditions } from "./skill"
 import { resolveRotation, type ResolvedStep } from "./rotation"
-import { StatusLedger } from "./ledger"
+import { StatusLedger, UNOWNED } from "./ledger"
 import { collectCastBuffs } from "./castBuffs"
 import { prepareMechanics, type ContextPatch, type MechanicSetup } from "./mechanics"
 import { dotTickDamage, dotTickSkill, emitDotTicks, resolveTickDot, tickSourceSkillId } from "./dot"
@@ -52,6 +52,7 @@ interface HitEvent {
   // The frame the CAST started, which is what cast-scoped buff ids are keyed
   // by — not this hit's own frame, which may be well after it.
   castFrame: number
+  stepStart: number
 }
 
 class EventQueue {
@@ -196,10 +197,11 @@ export function simulateTimeline(inputs: Inputs): Result {
   }
 
   const ledger = new StatusLedger(spanStart, durationFrames)
-  const recordStack = (id: string, frame: number, value: number) =>
-    ledger.recordStack(id, frame, value)
+  const recordStack = (id: string, frame: number, value: number, owner = UNOWNED) =>
+    ledger.recordStack(id, frame, value, owner)
   const stacksAt = (id: string, frame: number) => ledger.stacksAt(id, frame)
-  const pushWindow = (id: string, start: number, end: number) => ledger.pushWindow(id, start, end)
+  const pushWindow = (id: string, start: number, end: number, owner = UNOWNED) =>
+    ledger.pushWindow(id, start, end, owner)
   const openPermanent = (id: string) => ledger.openPermanent(id)
 
   for (const id of rotation.permanentBuffIds) {
@@ -491,6 +493,7 @@ export function simulateTimeline(inputs: Inputs): Result {
         skill: ls.resolved.skill,
         hit,
         castFrame: ls.startFrame,
+        stepStart: ls.startFrame,
       })
     }
   }
@@ -517,7 +520,7 @@ export function simulateTimeline(inputs: Inputs): Result {
     }
     const ev = queue.pop()!
     processed++
-    const { frame, skill, hit, castFrame } = ev
+    const { frame, skill, hit, castFrame, stepStart } = ev
 
     const behavior = behaviorFor(skill)
     const hitInput = hitInputAt(skill, hit, frame)
@@ -535,8 +538,13 @@ export function simulateTimeline(inputs: Inputs): Result {
         if (!status) return
         if (permanent) openPermanent(status.id)
         else
-          pushWindow(status.id, frame, frame + Math.max(1, durationFrames ?? status.durationFrames))
-        if (stacks !== undefined) recordStack(status.id, frame, stacks)
+          pushWindow(
+            status.id,
+            frame,
+            frame + Math.max(1, durationFrames ?? status.durationFrames),
+            stepStart,
+          )
+        if (stacks !== undefined) recordStack(status.id, frame, stacks, stepStart)
       },
       applyBuff: () => {},
       consumeStacks: () => {},
@@ -600,9 +608,9 @@ export function simulateTimeline(inputs: Inputs): Result {
         if (!status || !isDebuffStatus(status)) continue
         const maxStacks = Math.max(1, status.maxStacks)
         const next = clamp(stacksAt(status.id, frame) + 1, 0, maxStacks)
-        recordStack(status.id, frame, next)
+        recordStack(status.id, frame, next, stepStart)
         if (status.activation === "permanent") openPermanent(status.id)
-        else pushWindow(status.id, frame, frame + Math.max(1, status.durationFrames))
+        else pushWindow(status.id, frame, frame + Math.max(1, status.durationFrames), stepStart)
         const det = status.detonation ?? null
         const flagged =
           det &&
@@ -614,7 +622,7 @@ export function simulateTimeline(inputs: Inputs): Result {
             buffEngine.paramTier(det.retainParam) >= (det.retainMinTier ?? 6)
               ? (det.retainParamStacks ?? det.retainStacks ?? 0)
               : (det.retainStacks ?? 0)
-          recordStack(status.id, frame, clamp(retained, 0, maxStacks))
+          recordStack(status.id, frame, clamp(retained, 0, maxStacks), stepStart)
           const sub = skillsById.get(det.skillId)
           if (sub)
             for (const subHit of sub.hits) {
@@ -624,6 +632,7 @@ export function simulateTimeline(inputs: Inputs): Result {
                 skill: sub,
                 hit: subHit,
                 castFrame: frame,
+                stepStart,
               })
             }
         }
@@ -647,17 +656,17 @@ export function simulateTimeline(inputs: Inputs): Result {
               0,
               Math.max(1, status.maxStacks),
             )
-            recordStack(status.id, frame, next)
+            recordStack(status.id, frame, next, stepStart)
             if (status.activation === "permanent") openPermanent(status.id)
-            else pushWindow(status.id, frame, frame + Math.max(1, status.durationFrames))
+            else pushWindow(status.id, frame, frame + Math.max(1, status.durationFrames), stepStart)
           }
           continue
         }
         const cur = stacksAt(status.id, frame)
         const next = clamp(cur + trigger.stacks, 0, Math.max(1, status.maxStacks))
-        recordStack(status.id, frame, next)
+        recordStack(status.id, frame, next, stepStart)
         if (status.activation === "permanent") openPermanent(status.id)
-        else pushWindow(status.id, frame, frame + Math.max(1, status.durationFrames))
+        else pushWindow(status.id, frame, frame + Math.max(1, status.durationFrames), stepStart)
       } else {
         const sub = skillsById.get(trigger.targetId)
         if (!sub) continue
@@ -668,6 +677,7 @@ export function simulateTimeline(inputs: Inputs): Result {
             skill: sub,
             hit: subHit,
             castFrame: frame,
+            stepStart,
           })
         }
       }
@@ -704,7 +714,7 @@ export function simulateTimeline(inputs: Inputs): Result {
       frame: queryFrame,
       timeSec: queryTimeSec,
       fps: FPS,
-      ledger,
+      ledger: ledger.throughOwner(ls.startFrame),
       statusById,
       buffEngine,
       // Below the display threshold there's a real chance no poison has

--- a/tests/engine/engineBaseline.fixture.json
+++ b/tests/engine/engineBaseline.fixture.json
@@ -171,7 +171,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "2be4ef9978659b6399756d0dd3adad2e43873b500d42bc23bbcd72e271b310a7"
+    "digest": "440834b0c4c8210713fe68fa2150456171f93002b2b8bd206762936ab853c6c9"
   },
   "anchor:noAttunement": {
     "dps": 66810.402809,
@@ -345,7 +345,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "6f1a36186ecba1fe775d8c6f1c514434863daf90320c7aa4637264d1eb2d7b90"
+    "digest": "74a533f871ef09d87429682d6def75b39bd442899c983cc79e313fc5e9459da1"
   },
   "anchor:dummyOff": {
     "dps": 79524.993653,
@@ -519,7 +519,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "58700b61a5faa2ab47594efad57f57fd26dd2a69acbd6b45d5856d2582774354"
+    "digest": "59ce152d9d0f690fd5486e5b803f7f86960c440079859f71311fe96df1cdd0fd"
   },
   "anchor:noQiBreak": {
     "dps": 67520.871368,
@@ -693,7 +693,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "19096e7802e0b6a7a059bc7857350b844cbdf47de654d70a3ea383970524888a"
+    "digest": "514570b0cfce8ae398e9e6fbbb82ff22ae762ddf370c3b4294cf41564fced30f"
   },
   "anchor:healerBuff": {
     "dps": 81636.609347,
@@ -867,7 +867,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "82712dbf4f2fc21cc2a18858a39d3ac4a9b008c8656fe921e09601b75da82679"
+    "digest": "de06891f619f644c07b5db807e52c35bb8f9ad8e84b677d5e4262b360e0c1ba1"
   },
   "anchor:revelryScript": {
     "dps": 84668.363721,
@@ -1041,7 +1041,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "30b7002df081579905302e84f13428477556cc594f14fa6bcaf3aa7e5d7324f7"
+    "digest": "6f5fb3e5b39e722ca571c396c8d38f13ae23b09de09c3567379a70dad25ce141"
   },
   "anchor:breakExtension": {
     "dps": 75486.57462,
@@ -1215,7 +1215,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "2b613349e629575317f1fb95626ef249a1c4ae93748092732ce1c813985eb262"
+    "digest": "bab43207a1475938282d60fbba22f106558d4dec30bec42ccd4cd9c9acffd801"
   },
   "anchor:swordHorizonT1": {
     "dps": 52367.956002,
@@ -1389,7 +1389,7 @@
       "buffWindows": 122,
       "casts": 69
     },
-    "digest": "fe83344ad9426331deed038c7bd45fdc637657fec40b383ae3fa809fe9b2ed98"
+    "digest": "0574d76da6fd4d73eea282d37c7d8e60cc370e222f5610b817111b90a8dfd920"
   },
   "anchor:noSwordHorizon": {
     "dps": 45587.912664,
@@ -1563,7 +1563,7 @@
       "buffWindows": 118,
       "casts": 69
     },
-    "digest": "0645271799ed32b8483e8f3ba7831c111cdd15844f47dcc5e070442c6350bc3c"
+    "digest": "f684e1373c4e2174bfaced951ce0b24533e7e75a2f7e56d00979341826867a6d"
   },
   "anchor:noInsightfulStrike": {
     "dps": 63589.275013,
@@ -1737,7 +1737,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "e3fafec6d1b27aab56f41115fba2bf70b142fa99de9966ad45fc79b8f9841141"
+    "digest": "0dc60d66a19c884e39ce94b9594a8ee3e8425777647d903b86f93253a29bbda7"
   },
   "anchor:noMoraleChant": {
     "dps": 68114.100368,
@@ -1903,7 +1903,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "46f0dd9a752fcba41fcd63be1f4b573f2361c601601f0f3a192d4ff3a4df3c73"
+    "digest": "8bde0855dca930846e21f21aebaec7d64280d500bcf68dfbd3c0b50079a3dbb9"
   },
   "anchor:spearHeavyNoWolfchasersArt": {
     "dps": 43140.113258,
@@ -2085,7 +2085,7 @@
       "buffWindows": 140,
       "casts": 80
     },
-    "digest": "3e79c6bb67da18632605e477234bf88d3fa25b68f0ddfc05cef0f2966a66c128"
+    "digest": "65f9aba93abff699f1fc40b3225700c76bb7d16173a072db439bc3681c01c14c"
   },
   "anchor:bitterSeasonT6": {
     "dps": 54082.23041,
@@ -2267,7 +2267,7 @@
       "buffWindows": 126,
       "casts": 69
     },
-    "digest": "37418b8ade56497b77a6c43801a9fb549c2d85c8901ded4b34d79d6a0b3cc2e5"
+    "digest": "cb50c751b35ca4f30809c2e57cd3b75f26568d1d5d72e3e54806603bd5776f39"
   },
   "anchor:bitterSeasonT4": {
     "dps": 53073.676393,
@@ -2449,7 +2449,7 @@
       "buffWindows": 126,
       "casts": 69
     },
-    "digest": "5f7b190f75a1604d10b573162d21fd0549e5c4fd34f2fcf704c9a5559087663b"
+    "digest": "985154ccab91933e280b7a08320ca665ad9125bf19dac2180a5efe37371c5c09"
   },
   "anchor:bitterSeasonT1": {
     "dps": 52619.642715,
@@ -2631,7 +2631,7 @@
       "buffWindows": 126,
       "casts": 69
     },
-    "digest": "fcbdbe78b1e92a98716b03b6c21a82d5b86a9a9e2453aec2514d14735d2f6008"
+    "digest": "f62eba437d163482371fe958341f70a7bda6d6a04c268a7435f4132e32ace099"
   },
   "anchor:noSet": {
     "dps": 67945.115374,
@@ -2805,7 +2805,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "8c8efc5506150d24eb65ccf114c3984c91e4e3a8863195482a35ac7b46018ec3"
+    "digest": "fcc92cd331035d102795642d63ec94baa0bc58c0ddb3191e559c5d634b5d925c"
   },
   "anchor:set-Jadeware": {
     "dps": 74219.190657,
@@ -2979,7 +2979,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "e0aeb2e8697cf7cfa77fe3398810fb8d9bc9464f7e02ec7e7e0eca8b3b412f02"
+    "digest": "abc0fdbca9510ed4f3e9301c8158649a9ffb210021b873a3a10178346c0af37d"
   },
   "anchor:set-Mistwillow": {
     "dps": 67945.115374,
@@ -3153,7 +3153,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "6c3c9eac156d49dfd8a636de53a641778ea054798b0f93656a82af43b9a08e38"
+    "digest": "ce3c707d38c63fe39b4a249c430388614de2df5e43a9ab60ebd9d555c94d5800"
   },
   "anchor:set-StarsAlign": {
     "dps": 67945.115374,
@@ -3327,7 +3327,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "8c8efc5506150d24eb65ccf114c3984c91e4e3a8863195482a35ac7b46018ec3"
+    "digest": "fcc92cd331035d102795642d63ec94baa0bc58c0ddb3191e559c5d634b5d925c"
   },
   "anchor:set-ShatteredRidge": {
     "dps": 69872.746274,
@@ -3501,7 +3501,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "ac843f5269bbb083afef091513e0146b666d36a49bc4b5bcc38e8e71caad268e"
+    "digest": "bc84aefba10c8fb3d3e74d027563dbf011895ab36b23d8ab8cbe7f73103c26db"
   },
   "anchor:set-Swallowcall": {
     "dps": 67945.115374,
@@ -3675,7 +3675,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "8c8efc5506150d24eb65ccf114c3984c91e4e3a8863195482a35ac7b46018ec3"
+    "digest": "fcc92cd331035d102795642d63ec94baa0bc58c0ddb3191e559c5d634b5d925c"
   },
   "anchor:set-SwayingHeights": {
     "dps": 69119.858999,
@@ -3849,7 +3849,7 @@
       "buffWindows": 125,
       "casts": 69
     },
-    "digest": "da96dd2aa0fbfe9c87b93fb9a535e9f23a4a4be94140dff75eab5acf9b18e9c5"
+    "digest": "e51cccb9382e336cb05f23fe301787b82ef2f9f6275be68e77a293f4a9013127"
   },
   "defaults:umbra": {
     "dps": 11066.747036,

--- a/tests/engine/ledger.test.ts
+++ b/tests/engine/ledger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { StatusLedger, windowEndAt } from "../../src/engine/ledger"
+import { StatusLedger, UNOWNED, windowEndAt } from "../../src/engine/ledger"
 
 const SPAN_START = -120
 const SPAN_END = 3600
@@ -48,7 +48,7 @@ describe("StatusLedger — windows", () => {
     const led = ledger()
     led.openPermanent("aura")
     led.openPermanent("aura")
-    expect(led.windowsOf("aura")).toEqual([{ start: SPAN_START, end: SPAN_END }])
+    expect(led.windowsOf("aura")).toEqual([{ start: SPAN_START, end: SPAN_END, owner: UNOWNED }])
   })
 
   it("gates stacks on the window — the question a trigger condition asks", () => {

--- a/tests/engine/timeline.test.ts
+++ b/tests/engine/timeline.test.ts
@@ -724,4 +724,36 @@ describe("timeline — cast chips sample once the cast has fully resolved", () =
     expect(markerOn(second)).toBeTruthy()
     expect(markerOn(first)!.remainingSec!).toBeGreaterThan(markerOn(second)!.remainingSec!)
   })
+
+  it("leaves out what the next cast applies on that same closing frame", () => {
+    const buff = makeBuff(CLASS, { name: "Marker", durationFrames: 600, maxStacks: 5 })
+    const opener = makeSkill(CLASS, {
+      name: "Opener",
+      castFrames: 30,
+      hits: [
+        makeHit({
+          frame: 0,
+          triggers: [makeTrigger({ kind: "applyBuff", targetId: buff.id, stacks: 1 })],
+        }),
+      ],
+    })
+    const silent = makeSkill(CLASS, {
+      name: "Silent",
+      castFrames: 100,
+      hits: [makeHit({ frame: 100, physMultiplier: 1 })],
+    })
+    const rotation = makeRotation(CLASS, {
+      steps: [
+        makeStep({ skillId: opener.id, hitCount: 1 }),
+        makeStep({ skillId: silent.id, hitCount: 1 }),
+        makeStep({ skillId: opener.id, hitCount: 1 }),
+      ],
+    })
+    const r = simulateTimeline(timelineInputs(rotation, [opener, silent], [buff]))
+
+    const silentCast = r.casts!.find((c) => c.skillName === "Silent")!
+    const lastCast = r.casts![r.casts!.length - 1]
+    expect(silentCast.buffs.find((b) => b.name === "Marker")!.stacks).toBe(1)
+    expect(lastCast.buffs.find((b) => b.name === "Marker")!.stacks).toBe(2)
+  })
 })


### PR DESCRIPTION
Closes #37.

## The bug

Dragon Head - Plus showed the Bleed Tick debuff at one stack more than it should, with a freshly-refreshed duration. On the `Nox - 1m DH` rotation from the profile attached to the issue, the row read `Bleed Tick 3/5 @9.53s` where the cast before it read `2/5`.

## Root cause

Dragon Head - Plus applies no bleed. Its hit is authored at `frame: 246` with `castFrames: 246`, so the hit lands on the frame the **next** rotation step starts — a supported authoring pattern, blessed by the existing `timeline — a hit landing on the rotation's closing frame` tests.

The cast-chip snapshot is taken on that same frame. The next step, `Sword Martial Q`, applies a bleed stack on its own hit at frame 0, and `stacksAt`/`remainingFramesAt` returned that application as Dragon Head's state.

## The fix

Ledger entries now record which rotation step wrote them, as that step's start frame. A triggered sub-skill inherits its parent's, so a whole trigger chain stays attributed to the step that set it off. The chip snapshot reads `ledger.throughOwner(step.startFrame)` — everything up to and including its own step, nothing a later one wrote.

The existing contract that a cast *does* show its own closing-frame hit still holds; verified against Dragon's Breath: Smolder, whose Smolder application on that same closing frame still appears on its own row.

## Verification

- Reproduced from the profile attached to the issue. Dragon Head - Plus now reads `Bleed Tick 2/5 @5.67s`, matching the preceding cast and decaying correctly across the 4-second cast.
- New regression guard: `leaves out what the next cast applies on that same closing frame`. Confirmed it fails without the fix.
- Full suite 1069 passed; typecheck, lint and Prettier clean.
- `runEngine` cost 4.43ms → 4.62ms per pass (+4%), measured over 20 iterations on the default Bellstrike Umbra rotation.

## Notes for review

- **No migration needed.** Nothing about saved-profile shape, defaults or allowlists changes; this is a read-path fix inside one simulation pass.
- **The baseline fixture was regenerated, and only its `digest` values moved.** `dps`, `totalDamage`, `rotationDuration` and every `perSkill` row are byte-identical across all 22 anchor cases — the bug was display-only, so no build's numbers change.

## Second commit

`docs(conventions)` promotes the comment pass into CLAUDE.md § "Comments" as a named gate on finishing a task. The rule already existed as the trailing sentence of the "Names" section, where nothing routed a reader to it; the buried copy is deleted so there is one source. Unrelated to the fix — happy to split it out if you would rather review it separately.

The matching updates to the `developer` and `reviewer` agents are not in this PR: `.gitignore:10` excludes `.claude/`, so they live on my working tree only.
