### PR TITLE
chore: release 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-winds-meet-dps",
   "private": true,
-  "version": "0.1.13",
+  "version": "0.2.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/changelog/README.md
+++ b/src/changelog/README.md
@@ -30,6 +30,19 @@ stated in `docs/UI.md`.
    player-facing sentence. Be thorough — a release that shipped a lot should read
    as though it did, so do not compress ten visible changes into three lines.
 
+   Each item is the **end state against the previous release**, not the path the
+   commits took to reach it. The reader upgraded from one published version to
+   this one, so everything in between is invisible to them. A commit that fixed,
+   refined or reverted something introduced earlier in the same range is not its
+   own item — it folds into the item for the thing itself, or it disappears; a
+   feature and the fix that corrected it before release are one line, describing
+   what actually ships. A `Changed` item needs a prior published state to have
+   changed from: if the thing it changes is new in this release, it belongs in
+   that `Added` line or nowhere. Read the drafted sections against each other
+   before writing and strike any two lines a player would experience as one
+   change — thoroughness means covering every visible change once, not counting
+   one twice because two commits touched it.
+
    The author column is not optional context: every item names at least one
    GitHub login, so map each sentence back to the commit it came from rather than
    crediting a whole release to one person. When several commits by different

--- a/src/changelog/entries/v0-2-0.ts
+++ b/src/changelog/entries/v0-2-0.ts
@@ -1,0 +1,110 @@
+import type { ChangelogEntryDetails } from "../types"
+
+export const details: ChangelogEntryDetails = {
+  sections: [
+    {
+      label: "Added",
+      items: [
+        {
+          text: "A graduation percentage in the metrics row, showing how close your build is to a benchmark build.",
+          authors: ["KelvinJin", "M1zuke"],
+        },
+        {
+          text: "The graduation popup shows the benchmark build's gear, and its panel stats on a second tab.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "A toggle switches the graduation build between max rolls and relayed caps.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "This changelog, behind the version next to the title, crediting the people who shipped each change.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The gear import brings the inner ways your capture carries, in the order it reports them.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The gear import names the inner ways it cannot model and warns that the calculation will differ.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The gear import marks a stat line that belongs to another class instead of calling it unknown.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The Spear Special's Defense Down debuff, reducing target physical defense by 5% while River Flow is up.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Changed",
+      items: [
+        {
+          text: "Stonesplit Strength is validated — its output is checked against a measured build.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The inner-way list keeps the five modelled ways; the 23 unimplemented entries are gone.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The default build starts with no inner ways slotted, because the ones it filled were removed.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Analyses share one pool of background workers, so opening a tab no longer spins up its own.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The app downloads a far smaller attribute table on first load.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Fixed",
+      items: [
+        {
+          text: "The selected breakthrough now drives your own attributes, not just the target's defense and resistance.",
+          authors: ["M1zuke"],
+        },
+        { text: "Concentration is applied once instead of twice.", authors: ["M1zuke"] },
+        {
+          text: "A cast's buff chips no longer include what the next cast applies.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Every defined class is selectable, not only the validated ones.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Switching class keeps your inner ways where you put them, with no slot reserved for the signature.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "An imported attunement reads its own units, so an 8.9% penetration roll no longer arrives as 890%.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "A low attunement roll from an older piece is no longer raised to the minimum this app models.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Opening a dialog no longer quarters the frame rate; the backdrop darkens instead of blurring.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Escape now closes only the dialog on top, instead of the one behind it as well.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "A key a combobox already handled no longer closes the dialog as well.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+  ],
+}

--- a/src/changelog/registry.ts
+++ b/src/changelog/registry.ts
@@ -2,6 +2,12 @@ import type { ChangelogEntry } from "./types"
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: "0.2.0",
+    date: "2026-08-13",
+    headline: "Graduation builds, and a changelog",
+    loadDetails: () => import("./entries/v0-2-0").then((module) => module.details),
+  },
+  {
     version: "0.1.13",
     date: "2026-08-12",
     headline: "Gear import from the official dashboard",


### PR DESCRIPTION
Bumps the app to 0.2.0 and writes the in-app changelog entry for everything
since 0.1.13.

Minor rather than patch: the Graduation Build panel and its analysis are new
surfaces, which is the bar `src/changelog/README.md` sets for `x.Y.0`.

The range is `fce8eb5..HEAD`. The 0.1.14 bump that shipped alongside the
changelog feature was reverted in `c7b1b69` before it reached a release, so
nothing between the two was ever published and it does not split the range.

## Contents

23 items - 8 Added, 5 Changed, 10 Fixed. Graduation builds and the changelog
lead; the rest is the gear import gaining inner ways, the Spear Special's
Defense Down debuff, the inner-way list trimmed to the five modelled ways, and
a run of fixes across breakthroughs, buff chips, class switching, attunement
import units and dialog behaviour.

Every item names the GitHub login that shipped it. Mizuke's commits carry no
GitHub-linked email, so `.author.login` is empty on all of them and the logins
come from the PR fallback the README prescribes.

## Second commit

`docs(changelog): an item is the end state, not the commit path` is a procedure
fix, not part of the release. The first draft of this entry had three items
that were one visible change written twice - a feature and the pre-release fix
that corrected it, and a Changed line for a build that was itself new here. The
rule now sits next to the be-thorough rule that pushed toward that padding. The
same wording went into the bumpVersion command, which lives outside both clones
and so is not in this PR.

## Gates

`pnpm format`, `pnpm lint`, `pnpm typecheck` clean; `pnpm test` 1207 passing
across 120 files, including `tests/data/changelogFormat.test.ts`.

No migration needed: the changelog is display-only and no stored shape changed.
Commits in this release that did change a stored shape shipped their repair at
the time.