### PR TITLE
fix(ui): the worker client numbers its own requests

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -10,30 +10,35 @@ Rules for `src/ui/**`, the app shell, and the DPS worker. An engine pass is a fu
    change (ranking sweeps, per-piece deltas, tile variants, retunement and
    word-max analyses) goes through the shared worker client: add a request kind
    and a compute function there, and drive it from a hook shaped like the
-   existing ones — a monotonic request id, subscribe on mount and unsubscribe on
-   unmount, and an empty result **derived at the hook's return** from a
-   module-level constant, never written back by a `setState` inside an effect.
-   **Never** run the engine in a render-path memo outside that one baseline pass.
-2. **Exactly one hook owns each request kind.** The client routes by kind alone,
+   existing ones — subscribe on mount and unsubscribe on unmount, and an empty
+   result **derived at the hook's return** from a module-level constant, never
+   written back by a `setState` inside an effect. **Never** run the engine in a
+   render-path memo outside that one baseline pass.
+2. **The client assigns request ids; a hook never numbers its own requests.**
+   Superseded responses are recognised by id against document-lifetime state, so
+   a counter that restarts — as any per-mount counter does on a route revisit —
+   makes the client discard live responses as stale.
+3. **Exactly one hook owns each request kind.** The client routes by kind alone,
    so a second subscriber to a kind receives the first one's results and their
-   request-id counters collide.
-3. **Never construct a worker in a hook.** The client owns a bounded, lazily
+   posts coalesce into one request.
+4. **Never construct a worker in a hook.** The client owns a bounded, lazily
    grown pool and keeps it for the life of the document. A hook that spawns its
    own pays a full module instantiation per mount — for a route-mounted tab, per
    visit.
-4. **Post through the client, never around it.** It debounces per kind with the
+5. **Post through the client, never around it.** It debounces per kind with the
    shared constant, keeps only the newest request, discards superseded responses,
-   and drops a queued request once a kind has no listeners left. Each post
-   structured-clones the full inputs, gear inventory included, on the main thread
-   — a zero-delay timeout is not a debounce.
-5. **Mount worker hooks where the results are consumed**, not in the app shell, so
+   and once a kind has no listeners left drops its queued request and voids the
+   ones already in flight, so the next mount is never handed the previous one's
+   result. Each post structured-clones the full inputs, gear inventory included,
+   on the main thread — a zero-delay timeout is not a debounce.
+6. **Mount worker hooks where the results are consumed**, not in the app shell, so
    a tab that does not show the data does not pay for the sweep.
-6. **While a recompute is in flight, show last-known values** with a subtle
+7. **While a recompute is in flight, show last-known values** with a subtle
    opacity dim. Never unmount or flash the UI. Take the flag from the client,
    which counts a kind pending from the moment a request is owed rather than when
    the debounce fires — so a sustained drag dims throughout — and never mirror it
    into hook state.
-7. **Never serialize large state per render.** Memoize on the value that actually
+8. **Never serialize large state per render.** Memoize on the value that actually
    changed.
 
 Follow the nearest existing worker hook rather than inventing a new shape.

--- a/src/ui/hooks/dpsWorkerClient.ts
+++ b/src/ui/hooks/dpsWorkerClient.ts
@@ -6,6 +6,9 @@ type RequestKind = WorkerRequest["kind"]
 type ResponseOfKind<K extends RequestKind> = Extract<WorkerResponse, { kind: K }>
 type ResponseListener = (response: WorkerResponse) => void
 
+type WithoutReqId<Request> = Request extends unknown ? Omit<Request, "reqId"> : never
+export type UnsentRequest = WithoutReqId<WorkerRequest>
+
 const MAX_POOL_SIZE = 4
 
 interface KindState {
@@ -21,6 +24,7 @@ interface KindState {
 const stateByKind = new Map<RequestKind, KindState>()
 const pool: Worker[] = []
 const workerByKind = new Map<RequestKind, Worker>()
+let lastAssignedReqId = 0
 
 function stateFor(kind: RequestKind): KindState {
   const existing = stateByKind.get(kind)
@@ -65,19 +69,21 @@ function setPending(state: KindState, isPending: boolean): void {
 function deliver(response: WorkerResponse): void {
   const state = stateFor(response.kind)
   if (response.reqId === state.latestReqId) setPending(state, false)
-  if (response.reqId < state.lastDeliveredReqId) return
+  if (response.reqId <= state.lastDeliveredReqId) return
   state.lastDeliveredReqId = response.reqId
   for (const listener of state.responseListeners) listener(response)
 }
 
-function cancelQueued(state: KindState): void {
+function abandonRequests(state: KindState): void {
   if (state.debounceHandle !== null) clearTimeout(state.debounceHandle)
   state.debounceHandle = null
   state.queued = null
+  state.lastDeliveredReqId = state.latestReqId
   setPending(state, false)
 }
 
-export function postToDpsWorker(request: WorkerRequest): void {
+export function postToDpsWorker(unsent: UnsentRequest): void {
+  const request = { ...unsent, reqId: ++lastAssignedReqId } as WorkerRequest
   const state = stateFor(request.kind)
   state.queued = request
   state.latestReqId = request.reqId
@@ -100,7 +106,7 @@ export function subscribeToDpsWorker<K extends RequestKind>(
   state.responseListeners.add(typedListener)
   return () => {
     state.responseListeners.delete(typedListener)
-    if (state.responseListeners.size === 0) cancelQueued(state)
+    if (state.responseListeners.size === 0) abandonRequests(state)
   }
 }
 

--- a/src/ui/hooks/useDpsDeltas.ts
+++ b/src/ui/hooks/useDpsDeltas.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type { GearPiece, Inputs } from "../../engine/types"
 import type { DpsDelta } from "../../engine/dpsWorker"
 import { postToDpsWorker, subscribeToDpsWorker } from "./dpsWorkerClient"
@@ -20,7 +20,6 @@ export function useDpsDeltas(
   baselineDps: number,
   extraCandidates: readonly GearPiece[] = NO_EXTRAS,
 ): DpsDeltasResult {
-  const reqIdRef = useRef(0)
   const [deltas, setDeltas] = useState<DpsDeltaMap>({})
   const isPending = useDpsWorkerPending("dpsDeltas")
 
@@ -34,7 +33,6 @@ export function useDpsDeltas(
     if (!hasCandidates) return
     postToDpsWorker({
       kind: "dpsDeltas",
-      reqId: ++reqIdRef.current,
       inputs,
       baselineDps,
       pieceIds: [...inputs.inventory.map((p) => p.id), ...extraCandidates.map((p) => p.id)],

--- a/src/ui/hooks/useGraduationRate.ts
+++ b/src/ui/hooks/useGraduationRate.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type { Inputs } from "../../engine/types"
 import { postToDpsWorker, subscribeToDpsWorker } from "./dpsWorkerClient"
 import { useDpsWorkerPending } from "./useDpsWorkerPending"
@@ -19,7 +19,6 @@ export function useGraduationRate(
   inputs: Inputs,
   currentDps: number,
 ): GraduationRateData & { isPending: boolean } {
-  const reqIdRef = useRef(0)
   const [data, setData] = useState<GraduationRateData | null>(null)
   const isPending = useDpsWorkerPending("graduation")
 
@@ -32,7 +31,7 @@ export function useGraduationRate(
   }, [])
 
   useEffect(() => {
-    postToDpsWorker({ kind: "graduation", reqId: ++reqIdRef.current, inputs, currentDps })
+    postToDpsWorker({ kind: "graduation", inputs, currentDps })
   }, [inputs, currentDps])
 
   return { ...(data ?? EMPTY_DATA), isPending }

--- a/src/ui/hooks/useItemRanking.ts
+++ b/src/ui/hooks/useItemRanking.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type { Inputs, ItemRankingRow } from "../../engine/types"
 import { postToDpsWorker, subscribeToDpsWorker } from "./dpsWorkerClient"
 import { useDpsWorkerPending } from "./useDpsWorkerPending"
@@ -9,7 +9,6 @@ export interface ItemRankingResult {
 }
 
 export function useItemRanking(engineInputs: Inputs, baselineDps: number): ItemRankingResult {
-  const reqIdRef = useRef(0)
   const [rows, setRows] = useState<ItemRankingRow[]>([])
   const isPending = useDpsWorkerPending("ranking")
 
@@ -18,12 +17,7 @@ export function useItemRanking(engineInputs: Inputs, baselineDps: number): ItemR
   }, [])
 
   useEffect(() => {
-    postToDpsWorker({
-      kind: "ranking",
-      reqId: ++reqIdRef.current,
-      inputs: engineInputs,
-      baselineDps,
-    })
+    postToDpsWorker({ kind: "ranking", inputs: engineInputs, baselineDps })
   }, [engineInputs, baselineDps])
 
   return { rows, isPending }

--- a/src/ui/hooks/useReattunementAnalysis.ts
+++ b/src/ui/hooks/useReattunementAnalysis.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type { Inputs } from "../../engine/types"
 import type { ReattunementOption } from "../../engine/dpsWorker"
 import { postToDpsWorker, subscribeToDpsWorker } from "./dpsWorkerClient"
@@ -35,7 +35,6 @@ export function useReattunementAnalysis(
   inputs: Inputs,
   selectedPieceId: string | null,
 ): ReattunementAnalysisResult {
-  const reqIdRef = useRef(0)
   const [received, setReceived] = useState<ReceivedReattunement | null>(null)
   const isPending = useDpsWorkerPending("reattunement")
 
@@ -49,12 +48,7 @@ export function useReattunementAnalysis(
 
   useEffect(() => {
     if (!selectedPieceId) return
-    postToDpsWorker({
-      kind: "reattunement",
-      reqId: ++reqIdRef.current,
-      inputs,
-      pieceId: selectedPieceId,
-    })
+    postToDpsWorker({ kind: "reattunement", inputs, pieceId: selectedPieceId })
   }, [inputs, selectedPieceId])
 
   if (!selectedPieceId) return NO_SELECTION_RESULT

--- a/src/ui/hooks/useRetunementAnalysis.ts
+++ b/src/ui/hooks/useRetunementAnalysis.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type { Inputs } from "../../engine/types"
 import type { RetunementRow } from "../../engine/dpsWorker"
 import { postToDpsWorker, subscribeToDpsWorker } from "./dpsWorkerClient"
@@ -32,7 +32,6 @@ export function useRetunementAnalysis(
   inputs: Inputs,
   selectedPieceId: string | null,
 ): RetunementAnalysisResult {
-  const reqIdRef = useRef(0)
   const [received, setReceived] = useState<ReceivedRetunement | null>(null)
   const isPending = useDpsWorkerPending("retunement")
 
@@ -44,12 +43,7 @@ export function useRetunementAnalysis(
 
   useEffect(() => {
     if (!selectedPieceId) return
-    postToDpsWorker({
-      kind: "retunement",
-      reqId: ++reqIdRef.current,
-      inputs,
-      pieceId: selectedPieceId,
-    })
+    postToDpsWorker({ kind: "retunement", inputs, pieceId: selectedPieceId })
   }, [inputs, selectedPieceId])
 
   if (!selectedPieceId) return NO_SELECTION_RESULT

--- a/src/ui/hooks/useSetTileDps.ts
+++ b/src/ui/hooks/useSetTileDps.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type { Inputs } from "../../engine/types"
 import type { SetTilesWorkerResponse } from "../../engine/dpsWorker"
 import { postToDpsWorker, subscribeToDpsWorker } from "./dpsWorkerClient"
@@ -15,7 +15,6 @@ export interface SetTileDpsResult {
 }
 
 export function useSetTileDps(inputs: Inputs): SetTileDpsResult {
-  const reqIdRef = useRef(0)
   const [data, setData] = useState<SetTileDps | null>(null)
   const isPending = useDpsWorkerPending("setTiles")
 
@@ -28,7 +27,7 @@ export function useSetTileDps(inputs: Inputs): SetTileDpsResult {
   }, [])
 
   useEffect(() => {
-    postToDpsWorker({ kind: "setTiles", reqId: ++reqIdRef.current, inputs })
+    postToDpsWorker({ kind: "setTiles", inputs })
   }, [inputs])
 
   return { data, isPending }

--- a/src/ui/hooks/useWordMaxAnalysis.ts
+++ b/src/ui/hooks/useWordMaxAnalysis.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type { GearPiece, Inputs } from "../../engine/types"
 import type { WordMaxRow } from "../../engine/dpsWorker"
 import { postToDpsWorker, subscribeToDpsWorker } from "./dpsWorkerClient"
@@ -19,7 +19,6 @@ const NO_SELECTION_RESULT: WordMaxAnalysisResult = {
 }
 
 export function useWordMaxAnalysis(inputs: Inputs, piece: GearPiece | null): WordMaxAnalysisResult {
-  const reqIdRef = useRef(0)
   const [received, setReceived] = useState<{ rows: WordMaxRow[]; pieceId: string } | null>(null)
   const isPending = useDpsWorkerPending("wordMax")
 
@@ -29,7 +28,7 @@ export function useWordMaxAnalysis(inputs: Inputs, piece: GearPiece | null): Wor
 
   useEffect(() => {
     if (!piece) return
-    postToDpsWorker({ kind: "wordMax", reqId: ++reqIdRef.current, inputs, piece })
+    postToDpsWorker({ kind: "wordMax", inputs, piece })
   }, [inputs, piece])
 
   if (!piece) return NO_SELECTION_RESULT

--- a/tests/ui/dpsWorkerClient.test.ts
+++ b/tests/ui/dpsWorkerClient.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { WorkerRequest, WorkerResponse } from "../../src/engine/dpsWorker"
+import type { UnsentRequest } from "../../src/ui/hooks/dpsWorkerClient"
 import { defaultInputs } from "../../src/engine/defaults"
 
 const { created, MockWorker } = vi.hoisted(() => {
@@ -32,8 +33,8 @@ async function freshClient(cores = 8): Promise<Client> {
   return import("../../src/ui/hooks/dpsWorkerClient")
 }
 
-function rankingRequest(reqId: number): WorkerRequest {
-  return { kind: "ranking", reqId, inputs: defaultInputs, baselineDps: 1000 }
+function rankingRequest(): UnsentRequest {
+  return { kind: "ranking", inputs: defaultInputs, baselineDps: 1000 }
 }
 
 function rankingResponse(reqId: number): WorkerResponse {
@@ -42,6 +43,11 @@ function rankingResponse(reqId: number): WorkerResponse {
 
 function respond(workerIndex: number, response: WorkerResponse): void {
   created[workerIndex].onmessage?.({ data: response })
+}
+
+function reqIdOfLastPost(workerIndex: number): number {
+  const posted = created[workerIndex].posted
+  return (posted[posted.length - 1] as WorkerRequest).reqId
 }
 
 beforeEach(() => {
@@ -57,13 +63,13 @@ describe("dpsWorkerClient", () => {
     const client = await freshClient()
     client.subscribeToDpsWorker("ranking", () => {})
 
-    client.postToDpsWorker(rankingRequest(1))
-    client.postToDpsWorker(rankingRequest(2))
-    client.postToDpsWorker(rankingRequest(3))
+    client.postToDpsWorker(rankingRequest())
+    client.postToDpsWorker(rankingRequest())
+    client.postToDpsWorker(rankingRequest())
     await vi.runAllTimersAsync()
 
     expect(created).toHaveLength(1)
-    expect(created[0].posted).toEqual([rankingRequest(3)])
+    expect(created[0].posted).toEqual([{ ...rankingRequest(), reqId: 3 }])
   })
 
   it("reports pending from the first post until the matching response", async () => {
@@ -71,13 +77,13 @@ describe("dpsWorkerClient", () => {
     client.subscribeToDpsWorker("ranking", () => {})
 
     expect(client.isDpsWorkerPending("ranking")).toBe(false)
-    client.postToDpsWorker(rankingRequest(1))
+    client.postToDpsWorker(rankingRequest())
     expect(client.isDpsWorkerPending("ranking")).toBe(true)
 
     await vi.runAllTimersAsync()
     expect(client.isDpsWorkerPending("ranking")).toBe(true)
 
-    respond(0, rankingResponse(1))
+    respond(0, rankingResponse(reqIdOfLastPost(0)))
     expect(client.isDpsWorkerPending("ranking")).toBe(false)
   })
 
@@ -85,15 +91,16 @@ describe("dpsWorkerClient", () => {
     const client = await freshClient()
     client.subscribeToDpsWorker("ranking", () => {})
 
-    client.postToDpsWorker(rankingRequest(1))
+    client.postToDpsWorker(rankingRequest())
     await vi.runAllTimersAsync()
-    client.postToDpsWorker(rankingRequest(2))
+    const supersededReqId = reqIdOfLastPost(0)
+    client.postToDpsWorker(rankingRequest())
     await vi.runAllTimersAsync()
 
-    respond(0, rankingResponse(1))
+    respond(0, rankingResponse(supersededReqId))
     expect(client.isDpsWorkerPending("ranking")).toBe(true)
 
-    respond(0, rankingResponse(2))
+    respond(0, rankingResponse(reqIdOfLastPost(0)))
     expect(client.isDpsWorkerPending("ranking")).toBe(false)
   })
 
@@ -104,11 +111,12 @@ describe("dpsWorkerClient", () => {
     client.subscribeToDpsWorker("ranking", ({ reqId }) => rankingSeen.push(reqId))
     client.subscribeToDpsWorker("setTiles", ({ reqId }) => setTilesSeen.push(reqId))
 
-    client.postToDpsWorker(rankingRequest(1))
+    client.postToDpsWorker(rankingRequest())
     await vi.runAllTimersAsync()
-    respond(0, rankingResponse(1))
+    const reqId = reqIdOfLastPost(0)
+    respond(0, rankingResponse(reqId))
 
-    expect(rankingSeen).toEqual([1])
+    expect(rankingSeen).toEqual([reqId])
     expect(setTilesSeen).toEqual([])
   })
 
@@ -117,12 +125,49 @@ describe("dpsWorkerClient", () => {
     const seen: number[] = []
     client.subscribeToDpsWorker("ranking", ({ reqId }) => seen.push(reqId))
 
-    client.postToDpsWorker(rankingRequest(2))
+    client.postToDpsWorker(rankingRequest())
     await vi.runAllTimersAsync()
-    respond(0, rankingResponse(2))
-    respond(0, rankingResponse(1))
+    const newest = reqIdOfLastPost(0)
+    respond(0, rankingResponse(newest))
+    respond(0, rankingResponse(newest - 1))
 
-    expect(seen).toEqual([2])
+    expect(seen).toEqual([newest])
+  })
+
+  it("numbers requests itself so a remounted listener still gets its results", async () => {
+    const client = await freshClient()
+
+    const firstVisit = client.subscribeToDpsWorker("ranking", () => {})
+    for (const _change of [0, 1, 2]) {
+      client.postToDpsWorker(rankingRequest())
+      await vi.runAllTimersAsync()
+      respond(0, rankingResponse(reqIdOfLastPost(0)))
+    }
+    firstVisit()
+
+    const seen: number[] = []
+    client.subscribeToDpsWorker("ranking", ({ reqId }) => seen.push(reqId))
+    client.postToDpsWorker(rankingRequest())
+    await vi.runAllTimersAsync()
+    respond(0, rankingResponse(reqIdOfLastPost(0)))
+
+    expect(seen).toEqual([reqIdOfLastPost(0)])
+  })
+
+  it("withholds a response the previous listener abandoned from the next one", async () => {
+    const client = await freshClient()
+
+    const firstVisit = client.subscribeToDpsWorker("ranking", () => {})
+    client.postToDpsWorker(rankingRequest())
+    await vi.runAllTimersAsync()
+    const abandonedReqId = reqIdOfLastPost(0)
+    firstVisit()
+
+    const seen: number[] = []
+    client.subscribeToDpsWorker("ranking", ({ reqId }) => seen.push(reqId))
+    respond(0, rankingResponse(abandonedReqId))
+
+    expect(seen).toEqual([])
   })
 
   it("reuses one worker across resubscribe cycles", async () => {
@@ -130,7 +175,7 @@ describe("dpsWorkerClient", () => {
 
     for (const _visit of [0, 1, 2]) {
       const unsubscribe = client.subscribeToDpsWorker("ranking", () => {})
-      client.postToDpsWorker(rankingRequest(1))
+      client.postToDpsWorker(rankingRequest())
       await vi.runAllTimersAsync()
       unsubscribe()
     }
@@ -142,7 +187,7 @@ describe("dpsWorkerClient", () => {
     const client = await freshClient()
     const unsubscribe = client.subscribeToDpsWorker("ranking", () => {})
 
-    client.postToDpsWorker(rankingRequest(1))
+    client.postToDpsWorker(rankingRequest())
     unsubscribe()
     await vi.runAllTimersAsync()
 
@@ -163,7 +208,7 @@ describe("dpsWorkerClient", () => {
     ]
     for (const kind of kinds) {
       client.subscribeToDpsWorker(kind, () => {})
-      client.postToDpsWorker({ ...rankingRequest(1), kind } as WorkerRequest)
+      client.postToDpsWorker({ ...rankingRequest(), kind } as UnsentRequest)
       await vi.runAllTimersAsync()
     }
 


### PR DESCRIPTION
## The bug

Retunement and reattunement in the gear overview, and the DPS values in the overview tab, sometimes never computed — a settled panel with no data, for the rest of the visit.

## Root cause

The client tracks `lastDeliveredReqId` per request kind in module state that lives for the whole document, and discards any response below that watermark as superseded. The ids themselves came from a per-hook `useRef(0)`, which resets on every mount — and both tabs are route elements, so they remount on every tab switch.

So: visit Gear, change inputs three times (watermark 3), leave, come back — the counter restarts at 1, and responses 1 and 2 are dropped as stale. The pending flag still clears, because that check runs before the staleness guard, which is why it looks settled rather than loading. A response still in flight from the previous mount could bump the watermark too, poisoning a fresh visit on its first request.

## Fix

- The client owns a single monotonic counter and stamps `reqId` itself; `postToDpsWorker` takes a request without one. All seven hooks lost their `reqIdRef`, so no hook can reintroduce a restarting counter.
- Losing the last listener of a kind now also voids its in-flight requests, so a stale result from the previous mount is never handed to the next one.
- `docs/UI.md`: new rule that the client assigns request ids and a hook never numbers its own (with the why); the one-hook-per-kind rule no longer claims counters collide; the post-through-the-client rule states the in-flight voiding.
- Tests: the existing client tests read ids from the posted messages instead of supplying them, plus `numbers requests itself so a remounted listener still gets its results` and `withholds a response the previous listener abandoned from the next one`.

**No migration needed** — nothing about saved profiles or their shape is touched, this is in-memory request routing only.

Gates: `pnpm lint`, `pnpm typecheck`, `pnpm test` (1209 passed), prettier — all green.
