### PR TITLE
chore(release): 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-winds-meet-dps",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/changelog/entries/v0-2-1.ts
+++ b/src/changelog/entries/v0-2-1.ts
@@ -1,0 +1,32 @@
+import type { ChangelogEntryDetails } from "../types"
+
+export const details: ChangelogEntryDetails = {
+  sections: [
+    {
+      label: "Changed",
+      items: [
+        {
+          text: "A saved affix mapping no longer overrides the built-in table; it only fills in ids the table does not carry.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Fixed",
+      items: [
+        {
+          text: "Imported gear now maps every Bellstrike Umbra and Stonesplit Strength attune effect to the right attunement.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Stonesplit Strength no longer shows an attunement that could never be rolled and always read zero.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The analysis panels no longer stay blank after you leave a page and come back to it.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+  ],
+}

--- a/src/changelog/registry.ts
+++ b/src/changelog/registry.ts
@@ -2,6 +2,12 @@ import type { ChangelogEntry } from "./types"
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: "0.2.1",
+    date: "2026-08-13",
+    headline: "Attune effects on import, and panels that stay filled",
+    loadDetails: () => import("./entries/v0-2-1").then((module) => module.details),
+  },
+  {
     version: "0.2.0",
     date: "2026-08-13",
     headline: "Graduation builds, and a changelog",


### PR DESCRIPTION
Bumps the app version to **0.2.1** and writes the in-app changelog entry for everything shipped since 0.2.0.

### Changelog as written

**Headline:** Attune effects on import, and panels that stay filled

**Changed**

- A saved affix mapping no longer overrides the built-in table; it only fills in ids the table does not carry.

**Fixed**

- Imported gear now maps every Bellstrike Umbra and Stonesplit Strength attune effect to the right attunement.
- Stonesplit Strength no longer shows an attunement that could never be rolled and always read zero.
- The analysis panels no longer stay blank after you leave a page and come back to it.

The one docs-only commit in the range is not an item — nothing a player can see changed.

### Files touched

- `package.json` — the `version` field
- `src/changelog/entries/v0-2-1.ts` — new entry module
- `src/changelog/registry.ts` — prepended row with a dynamic import

### Migration

No migration needed: the changelog is display-only and no stored shape changed. Both fixes in the range also shipped without one — `classSpecificAttunement` is derived and stripped on every save, and the worker request ids are in-memory only.

### Gates

`pnpm format`, `pnpm lint`, `pnpm typecheck` clean. `pnpm test` — 120 files, 1230 tests passed, including `tests/data/changelogFormat.test.ts`.
