### PR TITLE
Release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-winds-meet-dps",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/changelog/entries/v0-3-0.ts
+++ b/src/changelog/entries/v0-3-0.ts
@@ -1,0 +1,117 @@
+import type { ChangelogEntryDetails } from "../types"
+
+export const details: ChangelogEntryDetails = {
+  sections: [
+    {
+      label: "Added",
+      items: [
+        {
+          text: "Bellstrike Splendor is now selectable, with its Nameless Sword and Nameless Spear skills, talents and inner ways.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Bellstrike Splendor ships with a graduation build and three built-in rotations.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Classes with unverified numbers carry a WIP badge in the class picker.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The Rotation tab opens on a new Overview: DPS breakdown, a DPS graph and the cast timeline in one place.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The Overview lists every rotation with its DPS against the current one, and clicking an entry switches to it.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The DPS graph plots per-second DPS beside the running average and reads out time and DPS under the pointer.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The retunement analyzer scores each candidate a second time with the whole piece relayed to 94%.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The boss now enters a low-Qi window before the Qi break, drawn as its own band in the cast timeline.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Every martial art shows its path icon in the class picker.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Changed",
+      items: [
+        {
+          text: "The setup wizard walks class, gear import or manual entry, then profile name; imports take it from the capture.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "A skill's DPS is measured over the rotation instead of its own cast time, so the breakdown sums to the total.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Breakdown rows and cast-timeline lanes group under in-game skill names.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Bellstrike Umbra's skills report under the names the game gives them.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Pre-pull damage always counts toward the total, and the pre-pull checkbox in the Rotation Editor is gone.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Attunements and stat lines carry their official in-game names, and a shared weapon-art attunement is named per class.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Gear import recognizes the full official affix table, so far fewer affixes need mapping by hand.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Every dropdown is a styled, keyboard-driven select instead of the native control.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Gear tiles carry rarity as a left bar, and gear details gains an identity strip, read-only base stats and hover hints.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The gear import screen reads as a numbered step rail with a draggable bookmarklet seal and a parsed-gear banner.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Text and number fields, sub-tab panels and focus styles share one consistent look across the app.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Fixed",
+      items: [
+        {
+          text: "The final affinity rate is now calculated correctly.",
+          authors: ["KelvinJin"],
+        },
+        {
+          text: "Jadeware's 4-piece bonus only pays out against a target in a low-Qi state, as the set describes.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Class Buffs no longer lists the buffs a slotted inner way owns.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Imported stat lines show their display name instead of an internal id, and no longer report phantom clamp corrections.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+  ],
+}

--- a/src/changelog/registry.ts
+++ b/src/changelog/registry.ts
@@ -2,6 +2,12 @@ import type { ChangelogEntry } from "./types"
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: "0.3.0",
+    date: "2026-08-16",
+    headline: "Bellstrike Splendor, and a rotation Overview",
+    loadDetails: () => import("./entries/v0-3-0").then((module) => module.details),
+  },
+  {
     version: "0.2.1",
     date: "2026-08-13",
     headline: "Attune effects on import, and panels that stay filled",

--- a/src/ui/layout/output-panel/OutputPanel.tsx
+++ b/src/ui/layout/output-panel/OutputPanel.tsx
@@ -79,7 +79,7 @@ export function MetricsCard({
         aria-live="polite"
         onClick={onGraduationClick}
       >
-        {result.graduationRate !== null && result.graduationRate > 0.91 && (
+        {result.graduationRate !== null && result.graduationRate > 0.94 && (
           <GraduationFire rate={result.graduationRate} />
         )}
         <span className={styles.stat}>

--- a/src/ui/layout/output-panel/graduation-fire/GraduationFire.tsx
+++ b/src/ui/layout/output-panel/graduation-fire/GraduationFire.tsx
@@ -176,7 +176,7 @@ export function GraduationFire({ rate }: { rate: number }) {
       }
       const dt = Math.min((now - last) / 1000, MAX_DT)
       last = now
-      const intensity = Math.min(1, Math.max(0, (rateRef.current - 0.91) / 0.09))
+      const intensity = Math.min(1, Math.max(0, (rateRef.current - 0.94) / 0.06))
       spawnCarry += (SPAWN_BASE + SPAWN_PER_INTENSITY * intensity) * dt
       while (spawnCarry >= 1) {
         spawnCarry -= 1

--- a/tests/ui/outputPanel.test.tsx
+++ b/tests/ui/outputPanel.test.tsx
@@ -53,7 +53,7 @@ describe("MetricsCard", () => {
     expect(button.querySelector("svg")).toHaveAttribute("aria-hidden", "true")
   })
 
-  it("sets the graduation button on fire above a 91% rate", () => {
+  it("sets the graduation button on fire above a 94% rate", () => {
     render(
       <I18nProvider>
         <MetricsCard result={{ ...result, graduationRate: 0.95 }} />
@@ -65,14 +65,14 @@ describe("MetricsCard", () => {
     expect(button.querySelector("svg")).toHaveAttribute("aria-hidden", "true")
   })
 
-  it("keeps the graduation button unlit at a 91% rate", () => {
+  it("keeps the graduation button unlit at a 94% rate", () => {
     render(
       <I18nProvider>
-        <MetricsCard result={{ ...result, graduationRate: 0.91 }} />
+        <MetricsCard result={{ ...result, graduationRate: 0.94 }} />
       </I18nProvider>,
     )
 
-    const button = screen.getByRole("button", { name: "Graduation: 91.0%" })
+    const button = screen.getByRole("button", { name: "Graduation: 94.0%" })
     expect(button.querySelector("canvas")).toBeNull()
   })
 


### PR DESCRIPTION
Bumps the app version to 0.3.0 and adds the in-app changelog entry for everything since 0.2.1.

Headline: Bellstrike Splendor, and a rotation Overview

- Added: Bellstrike Splendor (skills, talents, inner ways, graduation build, three rotations), the WIP class badge, the Rotation Overview subtab with rotation list and per-second DPS graph, the relayed retunement score, the low-Qi window band, and martial-art path icons.
- Changed: the setup wizard, rotation-based skill DPS, in-game-name grouping in breakdown and timeline, always-counted pre-pull damage, official attunement and stat-line names, the regenerated affix table, styled selects, and the gear tab, gear import and field styling reworks.
- Fixed: the final affinity rate calculation, Jadeware 4-piece gating, inner-way buff attribution, and imported stat-line labels and phantom clamp corrections.

Gates: format, lint, typecheck and the full test suite pass, including the changelog format test.

No migration needed: the changelog is display-only and no stored shape changed in this commit.