### PR TITLE
Rank each gear slot's upgrade payoff on a Gear tab analysis subtab

### DIFF
--- a/src/engine/dpsWorker.ts
+++ b/src/engine/dpsWorker.ts
@@ -1,6 +1,7 @@
 import { runEngine } from "./dps"
 import { applyPieceContribution, maxRelayedClone, relayedCapValue } from "./gearStats"
 import { computeRanking, getWordSpecs } from "./itemRanking"
+import { computeGearAnalysis, type GearSlotAnalysisRow } from "./gearAnalysis"
 import { poolForClass } from "../definitions/classes/registry"
 import { annotatePoolForSlot, rerollableSlots } from "./retunement"
 import { attunementsFor } from "./attunements"
@@ -360,6 +361,21 @@ function computeRankingRequest(req: RankingWorkerRequest): RankingWorkerResponse
   return { reqId: req.reqId, rows: computeRanking(req.inputs, req.baselineDps) }
 }
 
+export interface GearAnalysisWorkerRequest {
+  reqId: number
+  inputs: Inputs
+  baselineDps: number
+}
+
+export interface GearAnalysisWorkerResponse {
+  reqId: number
+  rows: GearSlotAnalysisRow[]
+}
+
+function computeGearAnalysisRequest(req: GearAnalysisWorkerRequest): GearAnalysisWorkerResponse {
+  return { reqId: req.reqId, rows: computeGearAnalysis(req.inputs, req.baselineDps) }
+}
+
 export interface SetTilesWorkerRequest {
   reqId: number
   inputs: Inputs
@@ -465,6 +481,7 @@ export type WorkerRequest =
   | ({ kind: "reattunement" } & ReattunementWorkerRequest)
   | ({ kind: "wordMax" } & WordMaxWorkerRequest)
   | ({ kind: "ranking" } & RankingWorkerRequest)
+  | ({ kind: "gearAnalysis" } & GearAnalysisWorkerRequest)
   | ({ kind: "setTiles" } & SetTilesWorkerRequest)
   | ({ kind: "rotationDps" } & RotationDpsWorkerRequest)
   | ({ kind: "graduation" } & GraduationWorkerRequest)
@@ -475,6 +492,7 @@ export type WorkerResponse =
   | ({ kind: "reattunement" } & ReattunementWorkerResponse)
   | ({ kind: "wordMax" } & WordMaxWorkerResponse)
   | ({ kind: "ranking" } & RankingWorkerResponse)
+  | ({ kind: "gearAnalysis" } & GearAnalysisWorkerResponse)
   | ({ kind: "setTiles" } & SetTilesWorkerResponse)
   | ({ kind: "rotationDps" } & RotationDpsWorkerResponse)
   | ({ kind: "graduation" } & GraduationWorkerResponse)
@@ -496,6 +514,9 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
   } else if (req.kind === "ranking") {
     const res = computeRankingRequest(req)
     ;(self as unknown as Worker).postMessage({ kind: "ranking", ...res })
+  } else if (req.kind === "gearAnalysis") {
+    const res = computeGearAnalysisRequest(req)
+    ;(self as unknown as Worker).postMessage({ kind: "gearAnalysis", ...res })
   } else if (req.kind === "setTiles") {
     const res = computeSetTiles(req)
     ;(self as unknown as Worker).postMessage({ kind: "setTiles", ...res })
@@ -514,6 +535,7 @@ export {
   computeReattunement,
   computeWordMax,
   computeRankingRequest,
+  computeGearAnalysisRequest,
   computeSetTiles,
   computeRotationDps,
   computeGraduation,

--- a/src/engine/gearAnalysis.ts
+++ b/src/engine/gearAnalysis.ts
@@ -1,0 +1,105 @@
+import { runEngine } from "./dps"
+import { applyPieceContribution, maxRelayedClone } from "./gearStats"
+import { getWordSpecs, type WordSpec } from "./itemRanking"
+import { poolForClass } from "../definitions/classes/registry"
+import { annotatePoolForSlot, rerollableSlots } from "./retunement"
+import { attunementsFor } from "./attunements"
+import { GEAR_SLOTS } from "./types"
+import type { GearPiece, GearSlot, GearWordId, Inputs } from "./types"
+import type { RetunementPool } from "../definitions/classes/classDef"
+
+export interface GearSlotAnalysisRow {
+  slot: GearSlot
+  pieceId: string | null
+  retuneGain: number | null
+  reattuneGain: number | null
+  relayGain: number | null
+  unequipLoss: number
+}
+
+function equippedPiece(inputs: Inputs, slot: GearSlot): GearPiece | null {
+  const equippedId = inputs.equipped[slot]
+  if (!equippedId) return null
+  return inputs.inventory.find((piece) => piece.id === equippedId) ?? null
+}
+
+function dpsWithPiece(slotEmpty: Inputs, piece: GearPiece): number {
+  return runEngine(applyPieceContribution(slotEmpty, piece, +1)).dps
+}
+
+function bestRetuneDps(
+  slotEmpty: Inputs,
+  piece: GearPiece,
+  pool: RetunementPool | null,
+  specByWord: Map<GearWordId, WordSpec<GearWordId>>,
+): number | null {
+  if (piece.relayed) return null
+  if (!pool || pool.stats.length === 0) return null
+
+  let best: number | null = null
+  for (const slotIndex of rerollableSlots(piece)) {
+    for (const { word, legal, isCurrent } of annotatePoolForSlot(piece, slotIndex, pool)) {
+      if (!legal || isCurrent) continue
+      const spec = specByWord.get(word)
+      if (!spec) continue
+      const words = piece.words.map((existing, index) =>
+        index === slotIndex ? { word, value: spec.amount, retuned: true } : existing,
+      ) as GearPiece["words"]
+      const dps = dpsWithPiece(slotEmpty, { ...piece, words })
+      if (best === null || dps > best) best = dps
+    }
+  }
+  return best
+}
+
+function bestReattuneDps(slotEmpty: Inputs, piece: GearPiece, classId: string): number | null {
+  const options = attunementsFor(piece.slot, classId)
+  if (options.length === 0) return null
+
+  let best: number | null = null
+  for (const option of options) {
+    const dps = dpsWithPiece(slotEmpty, {
+      ...piece,
+      attunement: option.id,
+      attunementValue: option.max,
+    })
+    if (best === null || dps > best) best = dps
+  }
+  return best
+}
+
+function relayedDps(slotEmpty: Inputs, piece: GearPiece, inputs: Inputs): number | null {
+  if (piece.relayed) return null
+  return dpsWithPiece(slotEmpty, maxRelayedClone(piece, inputs))
+}
+
+export function computeGearAnalysis(inputs: Inputs, baselineDps: number): GearSlotAnalysisRow[] {
+  const pool = poolForClass(inputs.classId)
+  const specByWord = new Map(getWordSpecs(inputs).map((spec) => [spec.word, spec] as const))
+
+  return GEAR_SLOTS.map((slot) => {
+    const piece = equippedPiece(inputs, slot)
+    if (!piece) {
+      return {
+        slot,
+        pieceId: null,
+        retuneGain: null,
+        reattuneGain: null,
+        relayGain: null,
+        unequipLoss: 0,
+      }
+    }
+
+    const slotEmpty = applyPieceContribution(inputs, piece, -1)
+    const gainOver = (dps: number | null) => (dps === null ? null : dps - baselineDps)
+
+    return {
+      slot,
+      pieceId: piece.id,
+      retuneGain: gainOver(bestRetuneDps(slotEmpty, piece, pool, specByWord)),
+      reattuneGain: gainOver(bestReattuneDps(slotEmpty, piece, inputs.classId)),
+      relayGain: gainOver(relayedDps(slotEmpty, piece, inputs)),
+      unequipLoss: baselineDps - runEngine(slotEmpty).dps,
+    }
+  })
+}

--- a/src/ui/features/gear/gear-analysis-panel/GearAnalysisPanel.module.scss
+++ b/src/ui/features/gear/gear-analysis-panel/GearAnalysisPanel.module.scss
@@ -1,0 +1,62 @@
+.analysis {
+  transition: opacity 0.1s;
+  overflow-x: auto;
+}
+
+.analysisTable {
+  width: 100%;
+}
+
+.analysisTable th:not(:first-child),
+.analysisTable td:not(:first-child) {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.analysisTable th.rankHead,
+.analysisTable td.rankCell {
+  text-align: center;
+  width: 1%;
+}
+
+.analysisTable th.lossHead,
+.analysisTable td.loss {
+  text-align: right;
+}
+
+.analysisTable tfoot td {
+  border-bottom: none;
+  color: var(--color-text-dim);
+}
+
+.rank {
+  display: inline-block;
+  min-width: 26px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--color-surface-raised);
+  color: var(--color-accent-bright);
+  text-align: center;
+}
+
+.rank.noRank {
+  background: none;
+  color: var(--color-text-muted);
+}
+
+.loss:global(.is-negative) {
+  color: var(--color-negative);
+}
+
+.loss:global(.is-positive) {
+  color: var(--color-positive);
+}
+
+.loss:global(.is-zero) {
+  color: var(--color-text-muted);
+}
+
+.share {
+  margin-left: 6px;
+  color: var(--color-text-muted);
+}

--- a/src/ui/features/gear/gear-analysis-panel/GearAnalysisPanel.tsx
+++ b/src/ui/features/gear/gear-analysis-panel/GearAnalysisPanel.tsx
@@ -1,0 +1,144 @@
+import type { GearSlot, Inputs } from "../../../../engine/types"
+import type { GearSlotAnalysisRow } from "../../../../engine/gearAnalysis"
+import { useI18n } from "../../../../i18n/i18nContext"
+import { useGearAnalysis } from "../../../hooks/useGearAnalysis"
+import { GEAR_SLOT_LABELS } from "../shared/gearLabels"
+import { HelpHint } from "../help-hint/HelpHint"
+import styles from "./GearAnalysisPanel.module.scss"
+
+interface Props {
+  engineInputs: Inputs
+  currentDps: number
+}
+
+type GainKey = "retuneGain" | "reattuneGain" | "relayGain"
+
+const COLUMN_HINTS: Record<GainKey | "unequipLoss", string> = {
+  retuneGain:
+    "DPS this slot gains from its best legal tunement reroll. Rank 1 is the slot worth retuning first.",
+  reattuneGain:
+    "DPS this slot gains from its best attunement rolled to its maximum. Rank 1 is the slot worth re-attuning first.",
+  relayGain:
+    "DPS this slot gains once every tunement on the piece is relayed to its cap — 94 % of the maximum roll.",
+  unequipLoss:
+    "DPS the build loses if this slot is emptied, and that loss as a share of total DPS.",
+}
+
+const GAIN_EPSILON = 0.5
+
+function fmtGain(gain: number): string {
+  return `+${Math.round(gain).toLocaleString("en-US")}`
+}
+
+function fmtLoss(loss: number): string {
+  const rounded = Math.round(loss)
+  if (rounded === 0) return "0"
+  return rounded > 0
+    ? `-${rounded.toLocaleString("en-US")}`
+    : `+${(-rounded).toLocaleString("en-US")}`
+}
+
+function lossSignClass(loss: number): string {
+  const rounded = Math.round(loss)
+  if (rounded > 0) return "is-negative"
+  if (rounded < 0) return "is-positive"
+  return "is-zero"
+}
+
+function fmtShare(loss: number, totalDps: number): string {
+  if (totalDps <= 0) return "—"
+  return `${(Math.abs(loss / totalDps) * 100).toFixed(1)} %`
+}
+
+function ranksBySlot(rows: GearSlotAnalysisRow[], key: GainKey): Map<GearSlot, number> {
+  const worthwhile = rows
+    .filter((row) => (row[key] ?? 0) > GAIN_EPSILON)
+    .sort((rowA, rowB) => (rowB[key] ?? 0) - (rowA[key] ?? 0))
+  return new Map(worthwhile.map((row, index) => [row.slot, index + 1]))
+}
+
+function RankCell({ gain, rank }: { gain: number | null; rank: number | undefined }) {
+  if (rank === undefined || gain === null) {
+    return (
+      <td className={styles.rankCell}>
+        <span className={`${styles.rank} ${styles.noRank}`}>—</span>
+      </td>
+    )
+  }
+  return (
+    <td className={styles.rankCell} title={fmtGain(gain)}>
+      <span className={styles.rank}>#{rank}</span>
+    </td>
+  )
+}
+
+export function GearAnalysisPanel({ engineInputs, currentDps }: Props) {
+  const { t } = useI18n()
+  const { rows, isPending } = useGearAnalysis(engineInputs, currentDps)
+
+  if (rows.length === 0) {
+    return <div className="empty-tab">{isPending ? t("Computing…") : t("No analysis yet")}</div>
+  }
+
+  const equippedRows = rows.filter((row) => row.pieceId !== null)
+  if (equippedRows.length === 0) {
+    return <div className="empty-tab">{t("Equip gear to see where an upgrade pays off")}</div>
+  }
+
+  const retuneRanks = ranksBySlot(equippedRows, "retuneGain")
+  const reattuneRanks = ranksBySlot(equippedRows, "reattuneGain")
+  const relayRanks = ranksBySlot(equippedRows, "relayGain")
+  const sorted = [...equippedRows].sort((rowA, rowB) => rowB.unequipLoss - rowA.unequipLoss)
+  const totalLoss = equippedRows.reduce((sum, row) => sum + row.unequipLoss, 0)
+
+  return (
+    <div className={styles.analysis} style={{ opacity: isPending ? 0.6 : 1 }}>
+      <table className={`ranking-table ${styles.analysisTable}`}>
+        <thead>
+          <tr>
+            <th>{t("Slot")}</th>
+            <th className={styles.rankHead}>
+              {t("Retune")}
+              <HelpHint text={t(COLUMN_HINTS.retuneGain)} />
+            </th>
+            <th className={styles.rankHead}>
+              {t("Re-Attune")}
+              <HelpHint text={t(COLUMN_HINTS.reattuneGain)} />
+            </th>
+            <th className={styles.rankHead}>
+              {t("Relay")}
+              <HelpHint text={t(COLUMN_HINTS.relayGain)} />
+            </th>
+            <th className={styles.lossHead}>
+              {t("Tuned Stats")}
+              <HelpHint text={t(COLUMN_HINTS.unequipLoss)} />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((row) => (
+            <tr key={row.slot}>
+              <td>{t(GEAR_SLOT_LABELS[row.slot])}</td>
+              <RankCell gain={row.retuneGain} rank={retuneRanks.get(row.slot)} />
+              <RankCell gain={row.reattuneGain} rank={reattuneRanks.get(row.slot)} />
+              <RankCell gain={row.relayGain} rank={relayRanks.get(row.slot)} />
+              <td className={`${styles.loss} ${lossSignClass(row.unequipLoss)}`}>
+                {fmtLoss(row.unequipLoss)}
+                <span className={styles.share}>({fmtShare(row.unequipLoss, currentDps)})</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colSpan={4}>{t("Total tuned-stat DPS contribution")}</td>
+            <td className={`${styles.loss} ${lossSignClass(totalLoss)}`}>
+              {fmtLoss(totalLoss)}
+              <span className={styles.share}>({fmtShare(totalLoss, currentDps)})</span>
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  )
+}

--- a/src/ui/features/gear/gear-inventory-panel/GearInventoryPanel.tsx
+++ b/src/ui/features/gear/gear-inventory-panel/GearInventoryPanel.tsx
@@ -25,7 +25,6 @@ interface Props {
   showGlobal: boolean
   onToggleGlobal(): void
   onSelect(row: InventoryRow): void
-  onCreate(): void
   slotFilter: GearSlot | null
   onClearSlotFilter(): void
   dpsDeltas: DpsDeltaMap
@@ -58,7 +57,6 @@ export function GearInventoryPanel({
   showGlobal,
   onToggleGlobal,
   onSelect,
-  onCreate,
   slotFilter,
   onClearSlotFilter,
   dpsDeltas,
@@ -138,9 +136,6 @@ export function GearInventoryPanel({
   return (
     <div className={styles.gearInventory}>
       <div className="toolbar">
-        <button type="button" className="btn primary" onClick={onCreate}>
-          + {t("New piece")}
-        </button>
         {slotFilter != null && (
           <span className={styles.gearInvFilter}>
             {t(SLOT_LABEL_KEYS[slotFilter])}
@@ -165,9 +160,9 @@ export function GearInventoryPanel({
       {visibleRows.length === 0 ? (
         <div className="empty-tab">
           {slotFilter != null
-            ? t("No pieces of this type — click 'New piece' to add one")
+            ? t("No pieces of this type — click 'Create Gear' to add one")
             : rows.length === 0
-              ? t("No gear yet — click 'New piece' to add one")
+              ? t("No gear yet — click 'Create Gear' to add one")
               : t("Equipped pieces are shown above")}
         </div>
       ) : (

--- a/src/ui/features/gear/gear-tab/GearTab.tsx
+++ b/src/ui/features/gear/gear-tab/GearTab.tsx
@@ -10,7 +10,10 @@ import { GEAR_SLOTS } from "../../../../engine/types"
 import { newGearPieceId } from "../../../../storage"
 import { useI18n } from "../../../../i18n/i18nContext"
 import { useConfirm } from "../../../components/confirm-dialog/confirmContext"
+import { SubTabs } from "../../../components/sub-tabs/SubTabs"
+import { SubTabPanel } from "../../../components/sub-tabs/SubTabPanel"
 import { GearSlotTiles } from "../gear-slot-tiles/GearSlotTiles"
+import { GearAnalysisPanel } from "../gear-analysis-panel/GearAnalysisPanel"
 import { GearDetailsPanel } from "../gear-details-panel/GearDetailsPanel"
 import { GearInventoryPanel } from "../gear-inventory-panel/GearInventoryPanel"
 import type { InventoryRow } from "../gear-inventory-panel/inventoryRows"
@@ -54,6 +57,7 @@ export function GearTab({
   const [showGlobal, setShowGlobal] = useState(false)
   const [newPieceOpen, setNewPieceOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
+  const [sub, setSub] = useState<"analysis" | "inventory">("analysis")
 
   const inventory = inputs.inventory
   const equipped = inputs.equipped
@@ -212,6 +216,10 @@ export function GearTab({
           <button type="button" className="btn primary" onClick={() => setImportOpen(true)}>
             {t("Import gear")}
           </button>
+          <div className="spacer" />
+          <button type="button" className="btn primary" onClick={openCreateDialog}>
+            + {t("Create Gear")}
+          </button>
         </div>
         <GearSlotTiles
           inventory={inventory}
@@ -238,20 +246,34 @@ export function GearTab({
           wordMaxPending={wordMax.isPending || !wordMaxRowsMatch}
         />
 
-        <div className="panel">
-          <GearInventoryPanel
-            rows={visibleRows}
-            activeProfileId={activeProfileId}
-            selectedPieceId={liveSelectedPieceId}
-            showGlobal={showGlobal}
-            onToggleGlobal={() => setShowGlobal((prev) => !prev)}
-            onSelect={selectInventoryRow}
-            onCreate={openCreateDialog}
-            slotFilter={selectedSlot}
-            onClearSlotFilter={() => setSelectedSlot(null)}
-            dpsDeltas={dpsDeltas}
-            dpsDeltasPending={dpsDeltasPending}
+        <div>
+          <SubTabs
+            active={sub}
+            onSelect={setSub}
+            tabs={[
+              { key: "analysis", label: t("Analysis") },
+              { key: "inventory", label: t("Inventory") },
+            ]}
           />
+          <SubTabPanel>
+            {sub === "analysis" && (
+              <GearAnalysisPanel engineInputs={engineInputs} currentDps={currentDps} />
+            )}
+            {sub === "inventory" && (
+              <GearInventoryPanel
+                rows={visibleRows}
+                activeProfileId={activeProfileId}
+                selectedPieceId={liveSelectedPieceId}
+                showGlobal={showGlobal}
+                onToggleGlobal={() => setShowGlobal((prev) => !prev)}
+                onSelect={selectInventoryRow}
+                slotFilter={selectedSlot}
+                onClearSlotFilter={() => setSelectedSlot(null)}
+                dpsDeltas={dpsDeltas}
+                dpsDeltasPending={dpsDeltasPending}
+              />
+            )}
+          </SubTabPanel>
         </div>
       </div>
 

--- a/src/ui/hooks/useGearAnalysis.ts
+++ b/src/ui/hooks/useGearAnalysis.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react"
+import type { Inputs } from "../../engine/types"
+import type { GearSlotAnalysisRow } from "../../engine/gearAnalysis"
+import { postToDpsWorker, subscribeToDpsWorker } from "./dpsWorkerClient"
+import { useDpsWorkerPending } from "./useDpsWorkerPending"
+
+export interface GearAnalysisResult {
+  rows: GearSlotAnalysisRow[]
+  isPending: boolean
+}
+
+const NO_ROWS: GearSlotAnalysisRow[] = []
+
+export function useGearAnalysis(engineInputs: Inputs, baselineDps: number): GearAnalysisResult {
+  const [received, setReceived] = useState<GearSlotAnalysisRow[] | null>(null)
+  const isPending = useDpsWorkerPending("gearAnalysis")
+
+  useEffect(() => {
+    return subscribeToDpsWorker("gearAnalysis", ({ rows }) => setReceived(rows))
+  }, [])
+
+  useEffect(() => {
+    postToDpsWorker({ kind: "gearAnalysis", inputs: engineInputs, baselineDps })
+  }, [engineInputs, baselineDps])
+
+  return { rows: received ?? NO_ROWS, isPending }
+}

--- a/tests/engine/dpsWorkerOffload.test.ts
+++ b/tests/engine/dpsWorkerOffload.test.ts
@@ -2,10 +2,12 @@
 // `Worker` in vitest/jsdom.
 import { describe, expect, it } from "vitest"
 import {
+  computeGearAnalysisRequest,
   computeRankingRequest,
   computeRotationDps,
   computeSetTiles,
 } from "../../src/engine/dpsWorker"
+import { computeGearAnalysis } from "../../src/engine/gearAnalysis"
 import { builtinRotationsForClass, defaultRotationForClass } from "../../src/engine/builtinLibrary"
 import { computeRanking } from "../../src/engine/itemRanking"
 import { runEngine } from "../../src/engine/dps"
@@ -32,6 +34,21 @@ describe("computeRankingRequest", () => {
   it("echoes reqId", () => {
     const baselineDps = runEngine(umbraInputs).dps
     const res = computeRankingRequest({ reqId: 42, inputs: umbraInputs, baselineDps })
+    expect(res.reqId).toBe(42)
+  })
+})
+
+describe("computeGearAnalysisRequest", () => {
+  it("matches computeGearAnalysis(inputs, baselineDps) for the same inputs", () => {
+    const baselineDps = runEngine(umbraInputs).dps
+    const expected = computeGearAnalysis(umbraInputs, baselineDps)
+    const res = computeGearAnalysisRequest({ reqId: 1, inputs: umbraInputs, baselineDps })
+    expect(res.rows).toEqual(expected)
+  })
+
+  it("echoes reqId", () => {
+    const baselineDps = runEngine(umbraInputs).dps
+    const res = computeGearAnalysisRequest({ reqId: 42, inputs: umbraInputs, baselineDps })
     expect(res.reqId).toBe(42)
   })
 })

--- a/tests/engine/gearAnalysis.test.ts
+++ b/tests/engine/gearAnalysis.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest"
+import { computeGearAnalysis } from "../../src/engine/gearAnalysis"
+import { computeReattunement, computeRetunement } from "../../src/engine/dpsWorker"
+import { runEngine } from "../../src/engine/dps"
+import { applyPieceContribution, maxRelayedClone } from "../../src/engine/gearStats"
+import { defaultInputs } from "../../src/engine/defaults"
+import type { GearPiece, GearSlot, Inputs } from "../../src/engine/types"
+
+// Scoped to Bellstrike Umbra — the only implemented class (CLAUDE.md
+// § "Implemented classes").
+const umbraInputs = { ...defaultInputs, classId: "bellstrikeUmbra" }
+
+function word(name: GearPiece["words"][number]["word"], value = 0): GearPiece["words"][number] {
+  return { word: name, value, retuned: false }
+}
+const EMPTY = word("", 0)
+
+function piece(id: string, slot: GearSlot, overrides: Partial<GearPiece> = {}): GearPiece {
+  return {
+    id,
+    slot,
+    level: 91,
+    rarity: "legendary",
+    minPhys: 1000,
+    maxPhys: 2000,
+    hp: 0,
+    physDef: 0,
+    words: [word("crit", 0.03), word("power", 40), EMPTY, EMPTY, EMPTY],
+    attunement: "physPen",
+    attunementValue: 0.03,
+    relayed: false,
+    ...overrides,
+  }
+}
+
+function equip(pieces: GearPiece[]): Inputs {
+  const equipped = { ...umbraInputs.equipped }
+  for (const equippedPiece of pieces) equipped[equippedPiece.slot] = equippedPiece.id
+  return { ...umbraInputs, inventory: pieces, equipped }
+}
+
+const weapon = piece("weapon", "leftWeapon")
+const helm = piece("helm", "helm", {
+  words: [word("maxPhys", 60), word("momentum", 30), EMPTY, EMPTY, EMPTY],
+})
+const geared = equip([weapon, helm])
+const gearedDps = runEngine(geared).dps
+const rows = computeGearAnalysis(geared, gearedDps)
+
+function rowFor(slot: GearSlot) {
+  return rows.find((row) => row.slot === slot)!
+}
+
+describe("computeGearAnalysis", () => {
+  it("covers every gear slot exactly once", () => {
+    expect(rows.map((row) => row.slot)).toEqual([...new Set(rows.map((row) => row.slot))])
+    expect(rows).toHaveLength(8)
+  })
+
+  it("leaves a slot with nothing equipped without a piece or any gain", () => {
+    const empty = rowFor("bracer")
+    expect(empty.pieceId).toBeNull()
+    expect(empty.retuneGain).toBeNull()
+    expect(empty.reattuneGain).toBeNull()
+    expect(empty.relayGain).toBeNull()
+    expect(empty.unequipLoss).toBe(0)
+  })
+
+  it("scores the retune gain as the best legal reroll the per-piece analyzer offers", () => {
+    const analyzed = computeRetunement({ reqId: 1, inputs: geared, pieceId: weapon.id })
+    const best = Math.max(
+      ...analyzed.rows.filter((row) => row.legal && !row.isCurrent).map((row) => row.deltaDps),
+    )
+
+    expect(rowFor("leftWeapon").retuneGain).toBeCloseTo(best, 3)
+  })
+
+  it("scores the re-attune gain as the best attunement at its maximum roll", () => {
+    const analyzed = computeReattunement({ reqId: 1, inputs: geared, pieceId: helm.id })
+    const best = Math.max(...analyzed.options.map((option) => option.deltaDpsAtMax))
+
+    expect(rowFor("helm").reattuneGain).toBeCloseTo(best, 3)
+  })
+
+  it("scores the relay gain against the piece's max-relayed clone", () => {
+    const slotEmpty = applyPieceContribution(geared, weapon, -1)
+    const relayed = maxRelayedClone(weapon, geared)
+    const expected = runEngine(applyPieceContribution(slotEmpty, relayed, +1)).dps - gearedDps
+
+    expect(rowFor("leftWeapon").relayGain).toBeCloseTo(expected, 3)
+  })
+
+  it("scores the tuned-stat loss as the DPS the build gives up with the slot emptied", () => {
+    const expected = gearedDps - runEngine(applyPieceContribution(geared, helm, -1)).dps
+
+    expect(rowFor("helm").unequipLoss).toBeCloseTo(expected, 3)
+    expect(rowFor("helm").unequipLoss).toBeGreaterThan(0)
+  })
+
+  it("offers neither a retune nor a relay on an already relayed piece", () => {
+    const relayedWeapon = { ...weapon, relayed: true }
+    const relayedRows = computeGearAnalysis(
+      equip([relayedWeapon, helm]),
+      runEngine(equip([relayedWeapon, helm])).dps,
+    )
+    const row = relayedRows.find((candidate) => candidate.slot === "leftWeapon")!
+
+    expect(row.retuneGain).toBeNull()
+    expect(row.relayGain).toBeNull()
+    expect(row.reattuneGain).not.toBeNull()
+  })
+})

--- a/tests/ui/gearTabAnalysis.test.tsx
+++ b/tests/ui/gearTabAnalysis.test.tsx
@@ -1,0 +1,178 @@
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { defaultInputs } from "../../src/engine/defaults"
+import type { GearPiece, Inputs, StoredProfile } from "../../src/engine/types"
+import type { GearSlotAnalysisRow } from "../../src/engine/gearAnalysis"
+import { I18nProvider } from "../../src/i18n/I18nProvider"
+import { ConfirmProvider } from "../../src/ui/components/confirm-dialog/ConfirmDialog"
+import { GearTab } from "../../src/ui/features/gear/gear-tab/GearTab"
+
+const ANALYSIS_ROWS: GearSlotAnalysisRow[] = [
+  {
+    slot: "leftWeapon",
+    pieceId: "weapon",
+    retuneGain: 120,
+    reattuneGain: 40,
+    relayGain: 900,
+    unequipLoss: 3000,
+  },
+  {
+    slot: "helm",
+    pieceId: "helm",
+    retuneGain: 300,
+    reattuneGain: -10,
+    relayGain: null,
+    unequipLoss: 1000,
+  },
+  {
+    slot: "bracer",
+    pieceId: null,
+    retuneGain: null,
+    reattuneGain: null,
+    relayGain: null,
+    unequipLoss: 0,
+  },
+]
+
+vi.mock("../../src/ui/hooks/useGearAnalysis", () => ({
+  useGearAnalysis: () => ({ rows: ANALYSIS_ROWS, isPending: false }),
+}))
+
+function piece(id: string, slot: GearPiece["slot"]): GearPiece {
+  return {
+    id,
+    slot,
+    level: 91,
+    rarity: "legendary",
+    minPhys: 1000,
+    maxPhys: 2000,
+    hp: 0,
+    physDef: 0,
+    words: [
+      { word: "crit", value: 0.03, retuned: false },
+      { word: "power", value: 40, retuned: false },
+      { word: "", value: 0, retuned: false },
+      { word: "", value: 0, retuned: false },
+      { word: "", value: 0, retuned: false },
+    ],
+    attunement: "physPen",
+    attunementValue: 0.03,
+    relayed: false,
+  }
+}
+
+function renderTab() {
+  const inventory = [piece("weapon", "leftWeapon"), piece("helm", "helm"), piece("spare", "helm")]
+  const inputs: Inputs = {
+    ...defaultInputs,
+    inventory,
+    equipped: { ...defaultInputs.equipped, leftWeapon: "weapon", helm: "helm" },
+  }
+  const profiles: StoredProfile[] = [{ id: "profile", name: "Main", inputs }]
+  render(
+    <I18nProvider>
+      <ConfirmProvider>
+        <GearTab
+          inputs={inputs}
+          engineInputs={inputs}
+          onChange={() => {}}
+          profiles={profiles}
+          activeProfileId="profile"
+          currentDps={40000}
+          dpsDeltas={{}}
+          dpsDeltasPending={false}
+        />
+      </ConfirmProvider>
+    </I18nProvider>,
+  )
+}
+
+function analysisRow(slotLabel: string): HTMLElement {
+  return screen.getByRole("cell", { name: slotLabel }).closest("tr")!
+}
+
+describe("GearTab analysis subtab", () => {
+  it("opens on the analysis, not on the inventory", () => {
+    renderTab()
+
+    expect(screen.getByRole("columnheader", { name: /Tuned Stats/ })).toBeInTheDocument()
+    expect(screen.queryByRole("checkbox", { name: "Show global" })).not.toBeInTheDocument()
+  })
+
+  it("shows the inventory once its subtab is selected", () => {
+    renderTab()
+
+    fireEvent.click(screen.getByRole("tab", { name: "Inventory" }))
+
+    expect(screen.getByRole("checkbox", { name: "Show global" })).toBeInTheDocument()
+    expect(screen.queryByRole("columnheader", { name: /Tuned Stats/ })).not.toBeInTheDocument()
+  })
+
+  it("lists only the slots that carry a piece, heaviest tuned-stat contribution first", () => {
+    renderTab()
+
+    const slots = screen
+      .getAllByRole("row")
+      .map((row) => row.firstElementChild?.textContent ?? "")
+      .filter((label) => label === "Left Weapon" || label === "Helm" || label === "Bracer")
+
+    expect(slots).toEqual(["Left Weapon", "Helm"])
+  })
+
+  it("ranks each action column on its own, and dashes the slots with nothing to gain", () => {
+    renderTab()
+
+    const weaponCells = within(analysisRow("Left Weapon")).getAllByRole("cell")
+    const helmCells = within(analysisRow("Helm")).getAllByRole("cell")
+
+    expect(weaponCells[1]).toHaveTextContent("#2")
+    expect(helmCells[1]).toHaveTextContent("#1")
+    expect(weaponCells[2]).toHaveTextContent("#1")
+    expect(helmCells[2]).toHaveTextContent("—")
+    expect(weaponCells[3]).toHaveTextContent("#1")
+    expect(helmCells[3]).toHaveTextContent("—")
+  })
+
+  it("keeps the DPS gain out of the rank cell, on its hover title", () => {
+    renderTab()
+
+    const retune = within(analysisRow("Left Weapon")).getAllByRole("cell")[1]
+
+    expect(retune.textContent).toBe("#2")
+    expect(retune).toHaveAttribute("title", "+120")
+  })
+
+  it("states each slot's tuned-stat loss as a share of total DPS, and their total", () => {
+    renderTab()
+
+    expect(within(analysisRow("Left Weapon")).getAllByRole("cell")[4]).toHaveTextContent(
+      "-3,000(7.5 %)",
+    )
+    expect(screen.getByRole("cell", { name: /Total tuned-stat DPS contribution/ })).toBeVisible()
+    expect(screen.getByText("-4,000")).toBeInTheDocument()
+  })
+})
+
+describe("GearTab gear buttons", () => {
+  it("keeps import and create together in the equipped head, on either subtab", () => {
+    renderTab()
+
+    const head = screen.getByRole("heading", { name: "Equipped" }).parentElement!
+
+    expect(within(head).getByRole("button", { name: "Import gear" })).toBeInTheDocument()
+    expect(within(head).getByRole("button", { name: "+ Create Gear" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("tab", { name: "Inventory" }))
+
+    expect(within(head).getByRole("button", { name: "+ Create Gear" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "+ New piece" })).not.toBeInTheDocument()
+  })
+
+  it("opens the create dialog from the equipped head", () => {
+    renderTab()
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Create Gear" }))
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #50.

## What

The Gear tab's inventory card is now split into two subtabs — **Analysis** (default) and **Inventory** — using the shared `SubTabs`/`SubTabPanel` components.

**Analysis** lists one row per equipped slot, sorted by tuned-stat contribution:

| column | what it says |
| --- | --- |
| Slot | the gear slot |
| Retune | rank of this slot by what its best legal tunement reroll would gain |
| Re-Attune | rank by what its best attunement at max roll would gain |
| Relay | rank by what relaying every tunement to the 94 % cap would gain |
| Tuned Stats | DPS the build loses if the slot is emptied, and that loss as a share of total DPS |

Each action column ranks independently; `—` means nothing to gain there, or the action does not apply (retune/relay on an already relayed piece). A footer row totals the tuned-stat contribution. The DPS figure behind each rank is on the cell's hover title, so the column stays a ranking. Ranks and dashes share a fixed-width badge box so they line up vertically; Tuned Stats is right-aligned including its header.

## Buttons

- "New piece" is renamed **Create Gear** and moved out of the inventory toolbar into the *Equipped* panel head.
- **Import gear** now sits next to the *Equipped* title; **+ Create Gear** sits at the right of that same row.
- The inventory empty-state copy names "Create Gear".

## Engine

`src/engine/gearAnalysis.ts` computes, per equipped slot: the best legal retune, the best attunement at its max roll, the relayed clone, and the DPS lost with the slot emptied. It runs off the main thread through a new `gearAnalysis` worker kind (UI.md rule 1), and the hook is mounted inside the panel, so the sweep is only paid while the Analysis subtab is open.

## Migration

**No migration needed** — nothing about a saved profile's shape or legal values changed. The analysis is derived at runtime, and "Create Gear" / "Analysis" / "Inventory" are display labels, not ids.

## Tests

- `tests/engine/gearAnalysis.test.ts` — parity against the existing per-piece retunement and reattunement analyses, the relayed-clone and slot-empty references, and the null cases (empty slot, relayed piece).
- `tests/engine/dpsWorkerOffload.test.ts` — direct-call parity for the new worker compute function.
- `tests/ui/gearTabAnalysis.test.tsx` — subtab wiring, per-column ranking, dashes, tuned-stat shares and totals, and the button placement.

Format, lint (0 warnings), typecheck and the full suite are green (1481 tests). Also verified live in the running app.