### PR TITLE
fix(data): stop Splendor's Qi damage bonuses reaching Attribute DMG Boost

### DIFF
--- a/src/data/baseStats/classSkillBoosts.json
+++ b/src/data/baseStats/classSkillBoosts.json
@@ -113,13 +113,6 @@
       "maxBonus": 0.11,
       "scalesWith": "bellstrike.max",
       "scaleMax": 655
-    },
-    {
-      "skill": "Qi DMG Bonus",
-      "stat": "attributeDamage",
-      "maxBonus": 0.1,
-      "scalesWith": "momentum",
-      "scaleMax": 0
     }
   ],
   "stonesplitStrength": [

--- a/src/data/skills/bellstrike-splendor/buffs/qiImbalance.ts
+++ b/src/data/skills/bellstrike-splendor/buffs/qiImbalance.ts
@@ -2,38 +2,25 @@ import { defineClassBuff } from "../../../../definitions/skills/buffDef"
 import { BUFF } from "../../buffs/ids"
 import { damageMultiplier, stat } from "../../../../engine/effects/effect"
 
-// Two effects, both at the reference workbook's values.
+// "Increases all Qi damage taken by 10% for 15 seconds. Increases HP damage
+// taken by 10%, and Bellstrike damage taken is increased by an additional 10%
+// while in the Exhausted state" (client localization, 2026-08-15). The 25 June
+// 2026 patch note carries the latter two at 8%; the discrepancy is unresolved
+// and the localization postdates the note.
 //
-// "Spear Q now applies Qi Imbalance on Boss targets, increasing Qi Damage taken
-// by 10% for 15 seconds" (28 May 2026 patch) — unconditional, and Qi damage is
-// the attribute half of a hit, so it lands on `attributeDamageBoost` rather
-// than a target-wide vulnerability that would lift the physical half too.
+// Only the two Exhausted-state clauses are modelled: Qi damage drains the
+// target's Qi bar rather than its HP, so it reaches no damage stat here.
 //
-// "now also increases all HP Damage taken by 8% & Bellstrike damage taken by 8%
-// on exhausted targets" (25 June 2026 patch) — the workbook carries this at
-// 10%, in a column it keeps as a separate multiplicative factor rather than
-// folding into its damage-boost pool, which is why it is a `damageMultiplier`.
-// The 8-vs-10 discrepancy is unresolved; the workbook postdates the note.
-//
-// Exhausted is the qi-break window, which is what `EffectContext.phase`
-// reports, so the second effect materialises only while it is open.
-//
-// Sharing `QI_IMBALANCE_STATUS`'s value is what puts the target into the low-Qi
-// phase while this is up: a `Debuff` is tracked in the status ledger and never
-// reaches the buff history `qiPhase` reads. The id is repeated rather than
-// imported because `ids.ts` takes no imports, and the two are pinned equal by
-// `tests/engine/lowQiWindow.test.ts`.
-//
-// Mountain's Might Tier 1 widens the trigger to any Splendor martial art.
+// Returning no effects does not make this inert — sharing
+// `QI_IMBALANCE_STATUS`'s value is what holds the target in the low-Qi phase
+// for as long as it is up.
 export const qiImbalance = defineClassBuff({
   id: BUFF.qiImbalance,
   name: "Qi Imbalance",
   affectsAll: true,
   duration: 15,
   buffAppliesOnCastEnd: true,
-  summary: "Qi dmg +10%, and +10% damage taken while Exhausted",
+  summary: "+10% HP damage and +10% Bellstrike damage taken while Exhausted",
   effects: (ctx) =>
-    ctx.phase === "exhausted"
-      ? [stat("attributeDamageBoost", 0.1), damageMultiplier(1.1)]
-      : [stat("attributeDamageBoost", 0.1)],
+    ctx.phase === "exhausted" ? [damageMultiplier(1.1), stat("attributeDamageBoost", 0.1)] : [],
 })

--- a/src/data/skills/bellstrike-splendor/buffs/swordEnergyHpDamage.ts
+++ b/src/data/skills/bellstrike-splendor/buffs/swordEnergyHpDamage.ts
@@ -5,8 +5,7 @@ import { stat } from "../../../../engine/effects/effect"
 // The other half of the Nameless Sword "Qi DMG Bonus" talent: "Increases the
 // Sword Energy attack's Qi damage dealt to players and HP damage to non-player
 // units by 2% for every 100 Max Physical Attack, up to 20% increase at 1,000
-// Max Physical Attack" (client localization, 2026-08-15). Its flat +10% Qi
-// damage half is a talent row instead, having no skill scope.
+// Max Physical Attack" (client localization, 2026-08-15).
 //
 // The engine simulates a non-player target, so the HP-damage branch is the one
 // that applies, and HP damage is the physical half of a hit. Carried at the cap,

--- a/src/ui/features/talents/talents-tab/TalentsTab.tsx
+++ b/src/ui/features/talents/talents-tab/TalentsTab.tsx
@@ -195,7 +195,12 @@ const CLASS_TALENT_COLUMNS: Record<string, WeaponColumnConfig[]> = {
         {
           name: "Qi Struggle Enhancement",
           lines: [
-            { kind: "talent", skill: "Qi DMG Bonus", label: "Qi Damage Boost" },
+            {
+              kind: "static",
+              text: "+10% Qi DMG.",
+              subNote:
+                "Qi damage drains the target's Qi bar rather than its HP, so this contributes nothing to damage.",
+            },
             {
               kind: "mechanic",
               id: "swordEnergyHpDamage",

--- a/tests/engine/buffEngineEquivalence.fixture.json
+++ b/tests/engine/buffEngineEquivalence.fixture.json
@@ -33813,7 +33813,7 @@
           "duration": 15,
           "maxStacks": null,
           "effects": "[fn]",
-          "summary": "Qi dmg +10%, and +10% damage taken while Exhausted"
+          "summary": "+10% HP damage and +10% Bellstrike damage taken while Exhausted"
         },
         {
           "id": "belowSixtyEndurance",
@@ -33866,7 +33866,7 @@
       ]
     },
     "dynamic": {
-      "digest": "20fd64a53b77646a2d28a0bb3b634dbe2497fbb76f4f3655b91ee4736be1f75f"
+      "digest": "3bd0de0564a612d43d053090cba3856fc2ca670ca9fa4c8ae2e5fe5b415f57cc"
     }
   }
 }

--- a/tests/engine/lowQiWindow.test.ts
+++ b/tests/engine/lowQiWindow.test.ts
@@ -125,29 +125,25 @@ describe("Qi Imbalance as a low-Qi source", () => {
 })
 
 describe("Qi Imbalance's damage effects", () => {
-  const defs = () => buffDefsForClass("bellstrikeSplendor")
-  const module = () => defs().find((def) => def.id === BUFF.qiImbalance)!
+  const module = () =>
+    buffDefsForClass("bellstrikeSplendor").find((def) => def.id === BUFF.qiImbalance)!
 
-  it("gives Qi damage whatever the target's state", () => {
+  const effectsAt = (phase: string) => {
     const effects = module().effects
     if (typeof effects !== "function") throw new Error("expected a context-dependent effect list")
-    for (const phase of ["normal", "below30", "exhausted"] as const) {
-      expect(effects({ phase } as never)).toContainEqual({
-        kind: "stat",
-        statKey: "attributeDamageBoost",
-        amount: 0.1,
-      })
-    }
+    return effects({ phase } as never)
+  }
+
+  it("leaves its Qi damage clause out of every damage stat, in every phase", () => {
+    expect(effectsAt("normal")).toEqual([])
+    expect(effectsAt("below30")).toEqual([])
   })
 
-  it("adds its damage multiplier only inside the break window", () => {
-    const effects = module().effects
-    if (typeof effects !== "function") throw new Error("expected a context-dependent effect list")
-    const multiplierAt = (phase: string) =>
-      effects({ phase } as never).find((effect) => effect.kind === "damageMultiplier")
-    expect(multiplierAt("normal")).toBeUndefined()
-    expect(multiplierAt("below30")).toBeUndefined()
-    expect(multiplierAt("exhausted")).toEqual({ kind: "damageMultiplier", factor: 1.1 })
+  it("raises HP damage and Bellstrike damage together, only inside the break window", () => {
+    expect(effectsAt("exhausted")).toEqual([
+      { kind: "damageMultiplier", factor: 1.1 },
+      { kind: "stat", statKey: "attributeDamageBoost", amount: 0.1 },
+    ])
   })
 })
 


### PR DESCRIPTION
Bellstrike Splendor showed **21% Attribute DMG Boost** where the in-game talent grants **11%**. Two separate places routed a *Qi damage* bonus into `attributeDamageBoost`, which multiplies the Bellstrike half of a hit.

## Why they are not the same stat

Qi damage is the target's Qi bar — a channel parallel to HP damage, not a share of it. The client localization keeps them apart throughout:

- quoted in flat integers, never a share of a hit — *"deals 10 bonus Qi damage"*, *"recovers 10 Qi"*
- named **against** HP damage as a second channel — *"reduce both HP and Qi damage taken"*, *"Poisoned: Continuously deals HP and additional Qi damage"*
- it is what drives Exhaustion — *"deal Qi Damage and potentially cause Exhaustion"*

Attribute Damage has its own tooltip — *"Increases the attribute damage caused. Bellstrike DMG Bonus / Stonesplit DMG Bonus / …"* — which is exactly what `attributeDamageBoost` does at `formula.ts:258`. The engine runs no Qi economy, so a Qi damage bonus reaches no damage stat.

## The two fixes

**1. Nameless Sword talent row dropped.** Source: *"Increases Qi damage dealt by 10% **and** the Sword Energy attack's Qi damage dealt to players **and HP damage to non-player units** by 2% for every 100 Max Physical Attack."* Only the second clause carries the HP rider, and it is already modelled as `swordEnergyHpDamage`. The flat 10% is Qi-bar only. The Talents tab still lists it under Qi Struggle Enhancement, as a static line saying it contributes nothing — the same treatment Max Endurance UP gets.

**2. Qi Imbalance re-split.** It carried three clauses on two effects, mismatched:

> *"Increases all **Qi damage** taken by 10% for 15 seconds. Increases **HP damage** taken by 10%, and **Bellstrike damage** taken is increased by an additional 10% while in the Exhausted state."*

| clause | should be | was |
|---|---|---|
| Qi damage +10% | nothing | `attributeDamageBoost` 0.1, **always on** |
| HP damage taken +10%, exhausted | `damageMultiplier(1.1)` | ✅ correct |
| Bellstrike taken +10% additional, exhausted | `attributeDamageBoost` 0.1 | missing |

The permanent attribute boost was the Qi clause; the Bellstrike clause it should have been was absent. Both survivors are now gated on Exhausted. Returning `[]` outside that window leaves the buff active in the status ledger, so it still drives the low-Qi phase `swordEnergyEnhancement` reads (`buffEngine.ts:145`).

## Impact

Measured on the `42 Wave Standardized Testing` rotation over the Splendor graduation build:

| | DPS | Attribute DMG Boost |
|---|---|---|
| before | 48,921 | 21% |
| talent fix only | 48,026 | 11% |
| both fixes | **47,226** | **11%** |

Net **−3.5%**. The Qi Imbalance half is −1.7% on its own: it gives the 10% Bellstrike boost back inside the break window but stops applying it across the rest of the rotation.

Only Bellstrike Splendor is affected — Umbra and Stonesplit Strength never had either bonus.

## Tests

`lowQiWindow.test.ts` asserted the old behaviour; its two effect tests are rewritten with the constraint in the names:

- *leaves its Qi damage clause out of every damage stat, in every phase*
- *raises HP damage and Bellstrike damage together, only inside the break window*

`buffEngineEquivalence.fixture.json` regenerated with `UPDATE_BUFF_EQUIVALENCE=1` — the diff is two lines, both Splendor (summary string, dynamic digest); no other class moved.

`pnpm test` 1481 passed / 144 files · `typecheck` · `lint` · `format:check` all clean.

**No migration needed:** `storage.ts:290` strips `default-*` talent rows on load and re-seeds from `getDefaultTalentsForClass`, and buff effects are class data that is never persisted.
