### PR TITLE
fix(data): move Splendor's Sword Energy HP damage onto the whole-hit channel

### DIFF
--- a/src/data/skills/bellstrike-splendor/buffs/swordEnergyHpDamage.ts
+++ b/src/data/skills/bellstrike-splendor/buffs/swordEnergyHpDamage.ts
@@ -2,19 +2,20 @@ import { defineClassBuff } from "../../../../definitions/skills/buffDef"
 import { BUFF } from "../../buffs/ids"
 import { stat } from "../../../../engine/effects/effect"
 
-// The other half of the Nameless Sword "Qi DMG Bonus" talent: "Increases the
-// Sword Energy attack's Qi damage dealt to players and HP damage to non-player
-// units by 2% for every 100 Max Physical Attack, up to 20% increase at 1,000
-// Max Physical Attack" (client localization, 2026-08-15).
+// "Increases the Sword Energy attack's Qi damage dealt to players and HP damage
+// to non-player units by 2% for every 100 Max Physical Attack, up to 20%
+// increase at 1,000 Max Physical Attack" (client localization, 2026-08-15).
 //
-// The engine simulates a non-player target, so the HP-damage branch is the one
-// that applies, and HP damage is the physical half of a hit. Carried at the cap,
-// which a realistic build clears well before 1000 Max Physical Attack.
+// The engine simulates a non-player target, so the HP-damage branch is the live
+// one. HP damage is the whole hit rather than its physical half, and the
+// reference workbook files this family in the additive whole-hit column it
+// shares with the sibling `swordSlashDamageBoost`. Carried at the cap, which a
+// realistic build clears well before 1,000 Max Physical Attack.
 export const swordEnergyHpDamage = defineClassBuff({
   id: BUFF.swordEnergyHpDamage,
   name: "Sword Energy HP Damage",
   alwaysActive: true,
   duration: 9999,
-  summary: "physBoost +20%",
-  effects: (ctx) => (ctx.self.reachesEvent ? [stat("physBoost", 0.2)] : []),
+  summary: "HP damage +20%",
+  effects: (ctx) => (ctx.self.reachesEvent ? [stat("allDamageBoost", 0.2)] : []),
 })

--- a/tests/engine/buffEngineEquivalence.fixture.json
+++ b/tests/engine/buffEngineEquivalence.fixture.json
@@ -33791,7 +33791,7 @@
           "duration": 9999,
           "maxStacks": null,
           "effects": "[fn]",
-          "summary": "physBoost +20%"
+          "summary": "HP damage +20%"
         },
         {
           "id": "qiImbalance",
@@ -33866,7 +33866,7 @@
       ]
     },
     "dynamic": {
-      "digest": "3bd0de0564a612d43d053090cba3856fc2ca670ca9fa4c8ae2e5fe5b415f57cc"
+      "digest": "d335957b6485c3bd91c6080b2be3d067e7099a305133f650b4097c3dd5f96143"
     }
   }
 }


### PR DESCRIPTION
Follow-up to #83, same theme: a Bellstrike Splendor bonus sitting on the wrong damage channel.

`swordEnergyHpDamage` carried *"HP damage to non-player units +20%"* as `physBoost`, which multiplies only the physical and flat rows of a hit (`formula.ts:198` — `AI` appears in `AK`/`AM`/`AO`/`AQ` and `AY`/`BA`/`BC`/`BE`) and leaves the Bellstrike rows untouched.

## HP damage is the whole hit

It's the generic term for health-bar damage in the client localization — basic combos *"deal HP Damage"*, a shield *"absorbs HP damage"*, a target can be *"immune to HP damage"*. And Qi Imbalance's own text settles it:

> *"Increases **HP damage** taken by 10%, and **Bellstrike damage** taken is increased by an **additional** 10%."*

"Additional" only parses if the HP damage increase already covered the Bellstrike half.

## Which channel, from the workbook's formula

The reference workbook (h9dh.cn v1.3, lvl-110) keeps four destinations, and its damage formula fixes what each one multiplies:

```
[ (physAvg·AI + AJ)·(1+AQ)·(1+AR)      ← physical block
+ (bellAvg·AK + AL·1.5)·(1+AV)·(1+AW)  ← Bellstrike block
+ (stone…) + (silk…) + (bamboo…) ]
  · (1 + AM)          ← Universal DMG Boost, on the SUM of all blocks
  · BL · Q · (1 + chargedBonus)
  · (1 + BR)          ← Special DMG Boost, applied LAST
```

| workbook column | scope | app channel |
|---|---|---|
| `AR` Physical DMG Bonus | physical block only | `physBoost` |
| `AW` Bellstrike Bonus | Bellstrike block only | `attributeDamageBoost` |
| `AM` Universal DMG Boost | summed blocks, additive pool | `allDamageBoost` |
| `BR` Special DMG Boost | final factor, after `(1+AM)` | `damageMultiplier` |

An HP damage bonus is neither block-scoped column, so it is `AM` or `BR`. The workbook files the sibling `swordSlashDamageBoost` — same talent tree, same *"against non-player units"* wording — in **Universal DMG Boost** (rows 12-14). Hence `allDamageBoost`.

## Impact

On the graduation build over the `42 Wave Standardized Testing` rotation:

| variant | DPS |
|---|---|
| no effect at all | 41,734 |
| `allDamageBoost 0.2` (this PR) | **46,245** |
| `physBoost 0.2` (before) | 47,226 |
| `damageMultiplier(1.2)` | 49,009 |

**−2.1%**, not the gain the wider scope suggests: `H_total` is already large, so +0.2 into the additive pool is worth less than an undiluted +20% on the physical rows alone.

## Tests

`buffEngineEquivalence.fixture.json` regenerated with `UPDATE_BUFF_EQUIVALENCE=1` — the diff is two lines, both Splendor (summary string, dynamic digest); no other class moved.

`pnpm test` 1481 passed / 144 files · `typecheck` · `lint` · `format:check` all clean.

**No migration needed:** buff effects are class data that is never persisted.

---

Two things found while tracing the workbook, both left alone here:

- **`BR` is an additive pool, not a product.** `BR = SUM(picked buffs → Buffs!W) + 0.06`. Break-window row 40 reads `BR = 0.31` = 0.06 + Fearless 0.05 + Exhausted 0.10 + Qi Imbalance 0.10, applied as one `(1+0.31)`. The app composes `damageMultiplier` multiplicatively (`timeline.ts:598`), which would give ≈1.347 for the same set. Only Qi Imbalance uses that channel today, so nothing diverges yet — but a second one would start it.
- The app has no equivalent of the workbook's `Fearless` (+0.05), its `Exhausted` (+0.10) Special row, or the 0.06 constant. Whether those are genuinely missing or modelled elsewhere I haven't chased down.
