### PR TITLE
Simulation tab

### DIFF
--- a/docs/CALCULATION.md
+++ b/docs/CALCULATION.md
@@ -143,7 +143,11 @@ stochastic per-hit roll, a stacking-and-decaying reduction, a stateful counter.
   addition is not associative. The memo signature is derived from what a
   mechanic returns, never hand-appended.
 - **A stochastic effect is a seeded whole-rotation schedule**, not a buff def —
-  a def cannot express a per-hit roll. Say so in the module when you add one.
+  a def cannot express a per-hit roll. Say so in the module when you add one. It
+  must **accept the run's generator when the engine supplies one** and realise a
+  single trajectory instead of averaging its own fixed-seed sweep; without one it
+  averages as before. A schedule that ignores the generator keeps reporting an
+  expectation on a run that has none, and understates the spread.
 - **Only hits laid by the rotation roll a proc.** DoT ticks and
   trigger-enqueued hits do not. This is structural; do not work around it per
   mechanic.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -26,11 +26,13 @@ Rules for `src/ui/**`, the app shell, and the DPS worker. An engine pass is a fu
    own pays a full module instantiation per mount — for a route-mounted tab, per
    visit.
 5. **Post through the client, never around it.** It debounces per kind with the
-   shared constant, keeps only the newest request, discards superseded responses,
-   and once a kind has no listeners left drops its queued request and voids the
-   ones already in flight, so the next mount is never handed the previous one's
-   result. Each post structured-clones the full inputs, gear inventory included,
-   on the main thread — a zero-delay timeout is not a debounce.
+   shared table, keeps only the newest request, discards superseded responses,
+   and once a kind has no listeners left drops its queued request and **aborts**
+   the ones already in flight, so the next mount is never handed the previous
+   one's result and no worker keeps computing for a tab that is gone. Each post
+   structured-clones the full inputs, gear inventory included, on the main thread
+   — a zero-delay timeout is not a debounce, so a kind that must fire at once
+   takes a zero entry in that table and posts synchronously.
 6. **Mount worker hooks where the results are consumed**, not in the app shell, so
    a tab that does not show the data does not pay for the sweep.
 7. **While a recompute is in flight, show last-known values** with a subtle
@@ -40,6 +42,13 @@ Rules for `src/ui/**`, the app shell, and the DPS worker. An engine pass is a fu
    into hook state.
 8. **Never serialize large state per render.** Memoize on the value that actually
    changed.
+9. **A kind that reports progress reports it on its own message kind**, routed
+   ahead of the response channel and never through it — that channel retires a
+   request id on first delivery, so progress sent down it swallows both the later
+   progress and the real result. Progress never clears the pending flag, and
+   progress for anything but the newest request id is dropped. A kind that can
+   run long must also be interruptible between chunks, and yield between them so
+   its cancel message can be read at all.
 
 Follow the nearest existing worker hook rather than inventing a new shape.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-winds-meet-dps",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import { MetricsCard, WarningsList } from "../ui/layout/output-panel/OutputPanel
 import { GithubLink } from "../ui/layout/github-link/GithubLink"
 import { ChangelogButton } from "../ui/layout/changelog-button/ChangelogButton"
 import { RotationTab } from "../ui/features/rotation/rotation-tab/RotationTab"
+import { SimulationTab } from "../ui/features/simulation/simulation-tab/SimulationTab"
 import { ProfilePanel } from "../ui/features/profile/profile-panel/ProfilePanel"
 import { GearTab } from "../ui/features/gear/gear-tab/GearTab"
 import { TalentsOdditiesTab } from "../ui/features/talents/talents-oddities-tab/TalentsOdditiesTab"
@@ -228,6 +229,7 @@ function AppInner() {
     { path: "/overview", label: t("Overview") },
     { path: "/gear", label: t("Gear") },
     { path: "/rotation", label: t("Rotation") },
+    { path: "/simulation", label: t("Simulation") },
     { path: "/skills", label: t("Skill Editor") },
     { path: "/talents", label: t("Talents & Oddities") },
     { path: "/profile", label: t("Profiles"), align: "right" },
@@ -345,6 +347,16 @@ function AppInner() {
                 engineInputs={engineInputs}
                 onChange={setInputs}
                 result={result}
+              />
+            }
+          />
+          <Route
+            path="/simulation"
+            element={
+              <SimulationTab
+                inputs={inputs}
+                engineInputs={engineInputs}
+                expectedTotalDamage={result.totalDamage}
               />
             }
           />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -353,11 +353,7 @@ function AppInner() {
           <Route
             path="/simulation"
             element={
-              <SimulationTab
-                inputs={inputs}
-                engineInputs={engineInputs}
-                expectedTotalDamage={result.totalDamage}
-              />
+              <SimulationTab inputs={inputs} engineInputs={engineInputs} expectedDps={result.dps} />
             }
           />
           <Route

--- a/src/changelog/entries/v0-3-1.ts
+++ b/src/changelog/entries/v0-3-1.ts
@@ -1,0 +1,65 @@
+import type { ChangelogEntryDetails } from "../types"
+
+export const details: ChangelogEntryDetails = {
+  sections: [
+    {
+      label: "Added",
+      items: [
+        {
+          text: "A new Simulation tab rolls a chosen rotation up to 10,000 times and reports the spread of parses it produced.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The simulation summary averages DPS and total damage, the best and worst parse, and the hits of each outcome.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Simulation results show a DPS distribution, a parse ladder from top-1 to top-99, and the observed outcome mix.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "A running simulation reports its progress and can be cancelled, keeping the runs it already finished.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The Gear tab has an Analysis subtab that ranks each equipped slot by its upgrade payoff and the DPS it contributes.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Changed",
+      items: [
+        {
+          text: "The graduation flame now appears above 94 % rather than 91 %.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Creating a gear piece is now Create Gear, beside Import gear above the equipped slots.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The Talents tab now marks Qi damage talents as contributing nothing to damage.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Fixed",
+      items: [
+        {
+          text: "Bellstrike Splendor no longer counts Qi damage bonuses as Attribute DMG Boost, which overstated its damage.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Bellstrike Splendor's Sword Energy HP damage bonus now applies to the whole hit rather than only its physical part.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Bellstrike Splendor's Qi Imbalance now raises Bellstrike damage taken only inside the break window.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+  ],
+}

--- a/src/changelog/registry.ts
+++ b/src/changelog/registry.ts
@@ -2,6 +2,12 @@ import type { ChangelogEntry } from "./types"
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: "0.3.1",
+    date: "2026-08-16",
+    headline: "Simulate parses, and rank every gear slot's payoff",
+    loadDetails: () => import("./entries/v0-3-1").then((module) => module.details),
+  },
+  {
     version: "0.3.0",
     date: "2026-08-16",
     headline: "Bellstrike Splendor, and a rotation Overview",

--- a/src/data/innerWays/bitterSeasonMechanic.ts
+++ b/src/data/innerWays/bitterSeasonMechanic.ts
@@ -100,6 +100,7 @@ export function bitterSeasonMechanic(): TimelineMechanic<State> {
           setup.hitTimesSec,
           tuning.procChance,
           setup.rotationDurationSec,
+          setup.rng,
         ),
         baseTargetDefense: getBreakthrough(setup.inputs.breakthrough).defense,
         suppressed: henZhiActive(setup.inputs),
@@ -133,6 +134,7 @@ export function bitterSeasonMechanic(): TimelineMechanic<State> {
         setup.rotationDurationSec,
         extensionTimesSec,
         maxRemainingSec,
+        setup.rng,
       )
       for (const envelope of bitterSeasonEnvelopeWindows(
         setup.hitTimesSec,

--- a/src/data/innerWays/insightfulStrikeMechanic.ts
+++ b/src/data/innerWays/insightfulStrikeMechanic.ts
@@ -56,6 +56,7 @@ export function insightfulStrikeMechanic(): TimelineMechanic<State> {
           setup.weaponHitTimesSec,
           proc,
           setup.rotationDurationSec,
+          setup.rng,
         ),
         tier6: innerWayHasNode(insightfulStrike, tier, INNER_WAY_NODE.concentrationDotMultiplier),
       }

--- a/src/data/sets/hawkwingMechanic.ts
+++ b/src/data/sets/hawkwingMechanic.ts
@@ -22,7 +22,12 @@ export function hawkwingMechanic(setId: string, setName: string): TimelineMechan
       if (setup.inputs.set !== setId) return null
       const proc = Math.min(setup.effectiveRates.affinityRate, AFFINITY_PROC_CAP)
       return {
-        schedule: hawkwingStacksSchedule(setup.hitTimesSec, proc, setup.rotationDurationSec),
+        schedule: hawkwingStacksSchedule(
+          setup.hitTimesSec,
+          proc,
+          setup.rotationDurationSec,
+          setup.rng,
+        ),
       }
     },
 

--- a/src/engine/buffs/bitterSeason.ts
+++ b/src/engine/buffs/bitterSeason.ts
@@ -1,4 +1,4 @@
-import { mulberry32 } from "./hawkwing"
+import { mulberry32 } from "../rng"
 
 const STEP_SEC = 0.05
 const SIM_RUNS = 500
@@ -35,6 +35,7 @@ export function bitterSeasonStackSchedule(
   hitTimesSec: readonly number[],
   procChance: number,
   rotationDurationSec: number,
+  runRng?: () => number,
 ): BitterSeasonStackSchedule {
   if (hitTimesSec.length === 0 || rotationDurationSec <= 0 || procChance <= 0) {
     return ZERO_STACK_SCHEDULE
@@ -43,9 +44,10 @@ export function bitterSeasonStackSchedule(
   const steps = Math.ceil(rotationDurationSec / STEP_SEC) + 1
   const stackAccum = new Float64Array(steps)
   const maxStackAccum = new Float64Array(steps)
+  const simRuns = runRng ? 1 : SIM_RUNS
 
-  for (let sim = 0; sim < SIM_RUNS; sim++) {
-    const rng = mulberry32(STACK_SEED_OFFSET + sim)
+  for (let sim = 0; sim < simRuns; sim++) {
+    const rng = runRng ?? mulberry32(STACK_SEED_OFFSET + sim)
     let stacks = 0
     let windowEnd = -Infinity
     let hitIdx = 0
@@ -69,8 +71,8 @@ export function bitterSeasonStackSchedule(
   const expectedStacks = new Float64Array(steps)
   const maxStackProb = new Float64Array(steps)
   for (let step = 0; step < steps; step++) {
-    expectedStacks[step] = stackAccum[step] / SIM_RUNS
-    maxStackProb[step] = maxStackAccum[step] / SIM_RUNS
+    expectedStacks[step] = stackAccum[step] / simRuns
+    maxStackProb[step] = maxStackAccum[step] / simRuns
   }
 
   return {
@@ -106,6 +108,7 @@ export function bitterSeasonPoisonSchedule(
   // The ceiling an extension may leave on the REMAINING duration, from the
   // extending moment. `Infinity` when the build has no extension source.
   maxRemainingSec: number,
+  runRng?: () => number,
 ): BitterSeasonPoisonSchedule {
   if (
     hitTimesSec.length === 0 ||
@@ -124,9 +127,10 @@ export function bitterSeasonPoisonSchedule(
   // through a dense rotation), this decays to 0 the moment hits actually
   // stop landing — the number the "Remaining" display wants.
   const remainingAccum = new Float64Array(steps)
+  const simRuns = runRng ? 1 : SIM_RUNS
 
-  for (let sim = 0; sim < SIM_RUNS; sim++) {
-    const rng = mulberry32(POISON_SEED_OFFSET + sim)
+  for (let sim = 0; sim < simRuns; sim++) {
+    const rng = runRng ?? mulberry32(POISON_SEED_OFFSET + sim)
     let poisonEnd = -Infinity
     let hitIdx = 0
     let extIdx = 0
@@ -161,8 +165,8 @@ export function bitterSeasonPoisonSchedule(
   const activeProb = new Float64Array(steps)
   const expectedRemaining = new Float64Array(steps)
   for (let step = 0; step < steps; step++) {
-    activeProb[step] = accum[step] / SIM_RUNS
-    expectedRemaining[step] = remainingAccum[step] / SIM_RUNS
+    activeProb[step] = accum[step] / simRuns
+    expectedRemaining[step] = remainingAccum[step] / simRuns
   }
 
   const indexAt = (tSec: number): number =>

--- a/src/engine/buffs/concentration.ts
+++ b/src/engine/buffs/concentration.ts
@@ -3,7 +3,7 @@
 // always-on once the inner way is selected — its `counterMechanic` is present
 // in the def's data but never actually evaluated at runtime in the extracted
 // bundle. Here it's modeled as a game-accurate 4-hit ramp/10s window.
-import { mulberry32 } from "./hawkwing"
+import { mulberry32 } from "../rng"
 
 const STEP_SEC = 0.05
 const WINDOW_SEC = 10
@@ -21,14 +21,16 @@ export function concentrationActiveProbSchedule(
   weaponHitTimesSec: readonly number[],
   p: number,
   rotationDurationSec: number,
+  runRng?: () => number,
 ): ConcentrationSchedule {
   if (weaponHitTimesSec.length === 0 || rotationDurationSec <= 0 || p <= 0) return INACTIVE_SCHEDULE
 
   const steps = Math.ceil(rotationDurationSec / STEP_SEC) + 1
   const accum = new Float64Array(steps)
+  const simRuns = runRng ? 1 : SIM_RUNS
 
-  for (let sim = 0; sim < SIM_RUNS; sim++) {
-    const rng = mulberry32(SEED_OFFSET + sim)
+  for (let sim = 0; sim < simRuns; sim++) {
+    const rng = runRng ?? mulberry32(SEED_OFFSET + sim)
     let counter = 0
     let active = false
     let lastAffinityHitTime = -Infinity
@@ -59,7 +61,7 @@ export function concentrationActiveProbSchedule(
   }
 
   const activeProb = new Float64Array(steps)
-  for (let step = 0; step < steps; step++) activeProb[step] = accum[step] / SIM_RUNS
+  for (let step = 0; step < steps; step++) activeProb[step] = accum[step] / simRuns
 
   return {
     getActiveProbAtTime(tSec: number): number {

--- a/src/engine/buffs/hawkwing.ts
+++ b/src/engine/buffs/hawkwing.ts
@@ -5,15 +5,7 @@
 // multiplier for the whole fight. This engine deliberately diverges: it
 // samples the same simulation's per-step expectation every frame instead
 // (`hawkwingStacksSchedule` below), rather than collapsing it to one average.
-export function mulberry32(seed: number): () => number {
-  let a = seed | 0
-  return function next(): number {
-    a = (a + 1831565813) | 0
-    let t = Math.imul(a ^ (a >>> 15), a | 1)
-    t = (t + Math.imul(t ^ (t >>> 7), t | 61)) ^ t
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-  }
-}
+import { mulberry32 } from "../rng"
 
 const STEP_SEC = 0.05
 const DECAY_SEC = 5
@@ -35,14 +27,16 @@ export function hawkwingStacksSchedule(
   hitTimesSec: readonly number[],
   p: number,
   rotationDurationSec: number,
+  runRng?: () => number,
 ): HawkwingStacksSchedule {
   if (hitTimesSec.length === 0 || rotationDurationSec <= 0 || p <= 0) return ZERO_HAWKWING_SCHEDULE
 
   const steps = Math.ceil(rotationDurationSec / STEP_SEC) + 1
   const accum = new Float64Array(steps)
+  const simRuns = runRng ? 1 : SIM_RUNS
 
-  for (let sim = 0; sim < SIM_RUNS; sim++) {
-    const rng = mulberry32(314 + sim)
+  for (let sim = 0; sim < simRuns; sim++) {
+    const rng = runRng ?? mulberry32(314 + sim)
     let stacks = 0
     let lastStackTime = -Infinity
     let hitIdx = 0
@@ -63,7 +57,7 @@ export function hawkwingStacksSchedule(
   }
 
   const expected = new Float64Array(steps)
-  for (let step = 0; step < steps; step++) expected[step] = accum[step] / SIM_RUNS
+  for (let step = 0; step < steps; step++) expected[step] = accum[step] / simRuns
 
   return {
     getExpectedStacksAtTime(tSec: number): number {

--- a/src/engine/dot.ts
+++ b/src/engine/dot.ts
@@ -1,7 +1,7 @@
 import type { Debuff, DebuffDotSpec, DotStackShape } from "./debuff"
 import type { Skill } from "./skill"
 import type { StatusWindow } from "./ledger"
-import type { computeSkillDamage, FormulaContext } from "./formula"
+import type { computeSkillDamage, FormulaContext, RolledHit } from "./formula"
 import { attuneTagOf, mysticCategoryOf } from "./buffs/tags"
 
 type ArtRow = Parameters<typeof computeSkillDamage>[0]
@@ -91,9 +91,10 @@ export function dotTickDamage(
   compute: typeof computeSkillDamage,
   forceCrit = false,
   shape?: DotStackShape,
-): number {
+  rng?: () => number,
+): { damage: number; rolled?: RolledHit } {
   const dot = debuff.dot
-  if (!dot) return 0
+  if (!dot) return { damage: 0 }
   const resolved = shape ?? {
     physMultiplier: dot.physMultiplier,
     physFixed: dot.physFixed,
@@ -101,7 +102,8 @@ export function dotTickDamage(
     attributeFixed: dot.attributeFixed,
   }
   const art = tickArt(dot, debuff.name, resolved, forceCrit)
-  return compute(art, ctx, Math.max(1, dot.count)).expectedDamage
+  const { expectedDamage, rolled } = compute(art, ctx, Math.max(1, dot.count), rng)
+  return { damage: rolled?.damage ?? expectedDamage, rolled }
 }
 
 // Overlapping windows are one continuous episode: a DoT refreshed mid-window

--- a/src/engine/dps.ts
+++ b/src/engine/dps.ts
@@ -1,4 +1,4 @@
-import type { Inputs, Result } from "./types"
+import type { EngineRunOptions, Inputs, Result } from "./types"
 import type { Rotation } from "./rotation"
 import { simulateTimeline } from "./timeline"
 import { defaultRotationForClass, builtinRotationsForClass } from "./builtinLibrary"
@@ -15,7 +15,7 @@ export function activeRotationForInputs(inputs: Inputs): Rotation | null {
   return defaultRotationForClass(inputs.classId)
 }
 
-export function runEngine(inputs: Inputs): Result {
+export function runEngine(inputs: Inputs, options?: EngineRunOptions): Result {
   const rotation = activeRotationForInputs(inputs)
   if (!rotation) {
     return {
@@ -28,5 +28,5 @@ export function runEngine(inputs: Inputs): Result {
       warnings: [`No default rotation for ${inputs.classId}.`],
     }
   }
-  return simulateTimeline({ ...inputs, activeCustomRotation: rotation })
+  return simulateTimeline({ ...inputs, activeCustomRotation: rotation }, options)
 }

--- a/src/engine/dpsWorker.ts
+++ b/src/engine/dpsWorker.ts
@@ -10,6 +10,8 @@ import { withDerivedStats } from "./derivedInputs"
 import { applyArmorSet, applyBowSet, ARMOR_SET_OPTIONS, swapArsenal } from "./panel"
 import { graduationInputs } from "./graduation"
 import type { Rotation } from "./rotation"
+import { RUN_SEED_STRIDE } from "./rng"
+import type { HitOutcome } from "./formula"
 import type {
   Arsenal,
   BowSet,
@@ -18,7 +20,10 @@ import type {
   GearWordId,
   Inputs,
   ItemRankingRow,
+  OutcomeCounts,
 } from "./types"
+
+const OUTCOME_KEYS: readonly HitOutcome[] = ["abrasion", "normal", "crit", "affinity"]
 
 export interface DpsDelta {
   current: number
@@ -411,6 +416,124 @@ function computeRotationDps(req: RotationDpsWorkerRequest): RotationDpsWorkerRes
   return { reqId: req.reqId, dpsByOptionId }
 }
 
+export const PARSE_RUN_CAP = 10_000
+const PARSE_TARGET_CHUNK_MS = 60
+const MAX_CHUNK_RUNS = 200
+
+export interface ParseRun {
+  totalDamage: number
+  dps: number
+  abrasionHits: number
+  normalHits: number
+  criticalHits: number
+  affinityHits: number
+}
+
+export type ExpectedOutcomeRates = OutcomeCounts
+
+export interface ParseSimulationWorkerRequest {
+  reqId: number
+  inputs: Inputs
+  rotation: Rotation | null
+  runs: number
+  seed: number
+}
+
+export interface ParseSimulationWorkerResponse {
+  reqId: number
+  runs: ParseRun[]
+  expectedRates: ExpectedOutcomeRates | null
+  rotationDuration: number
+  requestedRuns: number
+  completedRuns: number
+  cancelled: boolean
+  warnings: string[]
+}
+
+export interface ParseSimulationProgressResponse {
+  reqId: number
+  done: number
+  total: number
+}
+
+export interface ParseSimulationCancelRequest {
+  reqId: number
+}
+
+const NO_OUTCOMES: OutcomeCounts = { abrasion: 0, normal: 0, crit: 0, affinity: 0 }
+
+async function computeParseSimulation(
+  req: ParseSimulationWorkerRequest,
+  onProgress?: (done: number, total: number) => void,
+  isCancelled?: () => boolean,
+): Promise<ParseSimulationWorkerResponse> {
+  const total = Math.max(1, Math.min(Math.round(req.runs), PARSE_RUN_CAP))
+  const runInputs: Inputs = {
+    ...req.inputs,
+    activeCustomRotation: req.rotation,
+    selectedBuiltinRotationId: null,
+  }
+
+  const runs: ParseRun[] = []
+  const shareTotals: OutcomeCounts = { abrasion: 0, normal: 0, crit: 0, affinity: 0 }
+  let warnings: string[] = []
+  let rotationDuration = 0
+
+  const runOnce = (index: number): void => {
+    const result = runEngine(runInputs, {
+      seed: (req.seed + index * RUN_SEED_STRIDE) | 0,
+      collect: "totals",
+    })
+    const counts = result.outcomeCounts ?? NO_OUTCOMES
+    const share = result.expectedOutcomeShare ?? NO_OUTCOMES
+    for (const outcome of OUTCOME_KEYS) shareTotals[outcome] += share[outcome]
+    if (index === 0) {
+      warnings = result.warnings
+      rotationDuration = result.rotationDuration
+    }
+    runs.push({
+      totalDamage: result.totalDamage,
+      dps: result.dps,
+      abrasionHits: counts.abrasion,
+      normalHits: counts.normal,
+      criticalHits: counts.crit,
+      affinityHits: counts.affinity,
+    })
+  }
+
+  const startedAt = performance.now()
+  runOnce(0)
+  const msPerRun = Math.max(performance.now() - startedAt, 0.01)
+  const chunkRuns = Math.max(
+    1,
+    Math.min(Math.round(PARSE_TARGET_CHUNK_MS / msPerRun), MAX_CHUNK_RUNS),
+  )
+
+  while (runs.length < total) {
+    if (isCancelled?.()) break
+    const chunkEnd = Math.min(runs.length + chunkRuns, total)
+    for (let index = runs.length; index < chunkEnd; index++) runOnce(index)
+    onProgress?.(runs.length, total)
+    // A synchronous loop never lets `onmessage` fire, so without this yield no
+    // cancel is ever read.
+    if (runs.length < total) await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  const expectedRates: ExpectedOutcomeRates = { abrasion: 0, normal: 0, crit: 0, affinity: 0 }
+  for (const outcome of OUTCOME_KEYS) expectedRates[outcome] = shareTotals[outcome] / runs.length
+
+  return {
+    reqId: req.reqId,
+    runs,
+    expectedRates: runs.length > 0 ? expectedRates : null,
+    rotationDuration,
+    requestedRuns: total,
+    completedRuns: runs.length,
+    cancelled: runs.length < total,
+    warnings,
+  }
+}
+
 export interface GraduationWorkerRequest {
   reqId: number
   inputs: Inputs
@@ -484,6 +607,8 @@ export type WorkerRequest =
   | ({ kind: "gearAnalysis" } & GearAnalysisWorkerRequest)
   | ({ kind: "setTiles" } & SetTilesWorkerRequest)
   | ({ kind: "rotationDps" } & RotationDpsWorkerRequest)
+  | ({ kind: "parseSimulation" } & ParseSimulationWorkerRequest)
+  | ({ kind: "parseSimulationCancel" } & ParseSimulationCancelRequest)
   | ({ kind: "graduation" } & GraduationWorkerRequest)
 
 export type WorkerResponse =
@@ -495,7 +620,11 @@ export type WorkerResponse =
   | ({ kind: "gearAnalysis" } & GearAnalysisWorkerResponse)
   | ({ kind: "setTiles" } & SetTilesWorkerResponse)
   | ({ kind: "rotationDps" } & RotationDpsWorkerResponse)
+  | ({ kind: "parseSimulation" } & ParseSimulationWorkerResponse)
+  | ({ kind: "parseSimulationProgress" } & ParseSimulationProgressResponse)
   | ({ kind: "graduation" } & GraduationWorkerResponse)
+
+const cancelledReqIds = new Set<number>()
 
 self.onmessage = (e: MessageEvent<WorkerRequest>) => {
   const req = e.data
@@ -523,6 +652,23 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
   } else if (req.kind === "rotationDps") {
     const res = computeRotationDps(req)
     ;(self as unknown as Worker).postMessage({ kind: "rotationDps", ...res })
+  } else if (req.kind === "parseSimulationCancel") {
+    cancelledReqIds.add(req.reqId)
+  } else if (req.kind === "parseSimulation") {
+    void computeParseSimulation(
+      req,
+      (done, total) =>
+        (self as unknown as Worker).postMessage({
+          kind: "parseSimulationProgress",
+          reqId: req.reqId,
+          done,
+          total,
+        }),
+      () => cancelledReqIds.has(req.reqId),
+    ).then((res) => {
+      cancelledReqIds.delete(req.reqId)
+      ;(self as unknown as Worker).postMessage({ kind: "parseSimulation", ...res })
+    })
   } else {
     const res = computeGraduation(req)
     ;(self as unknown as Worker).postMessage({ kind: "graduation", ...res })
@@ -538,5 +684,6 @@ export {
   computeGearAnalysisRequest,
   computeSetTiles,
   computeRotationDps,
+  computeParseSimulation,
   computeGraduation,
 }

--- a/src/engine/formula.ts
+++ b/src/engine/formula.ts
@@ -116,12 +116,26 @@ function setFormulaBonus(setId: string | null, field: keyof SetFormulaBonus): nu
   return typeof value === "number" ? value : 0
 }
 
+export type HitOutcome = "abrasion" | "normal" | "crit" | "affinity"
+
+export interface RolledHit {
+  outcome: HitOutcome
+  damage: number
+  chance: Record<HitOutcome, number>
+}
+
 interface SkillResult {
   expectedDamage: number
   cells: Record<string, number>
+  rolled?: RolledHit
 }
 
-export function computeSkillDamage(art: ArtRow, ctx: FormulaContext, count: number): SkillResult {
+export function computeSkillDamage(
+  art: ArtRow,
+  ctx: FormulaContext,
+  count: number,
+  rng?: () => number,
+): SkillResult {
   const num = (v: number | undefined) => v ?? 0
   const N = num(art.physMultiplier)
   const O = num(art.attributeMultiplier)
@@ -321,10 +335,38 @@ export function computeSkillDamage(art: ArtRow, ctx: FormulaContext, count: numb
   // Fixed-damage skills (e.g. Dragon Head) can trigger neither crit, affinity
   // nor abrasion — they always deal the normal row.
   const F_base = guaranteedNormal ? EF : guaranteedCrit ? EB : EH
-  const F = F_base * (1 + H_total) * count * I_corr * (1 + E_attuneBoost) * dotMult
+  // Written as a call rather than a precomputed factor so every branch below
+  // evaluates the identical expression tree: reassociating the product moves
+  // the last ULP, which `engineBaseline.fixture.json` hashes.
+  const withTail = (base: number) =>
+    base * (1 + H_total) * count * I_corr * (1 + E_attuneBoost) * dotMult
+  const F = withTail(F_base)
+
+  function rollHit(draw: () => number): RolledHit {
+    // Both draws are taken on every hit so the stream position never depends
+    // on which track won — otherwise adding a track reshuffles later hits.
+    const outcomeDraw = draw()
+    const magnitudeDraw = draw()
+    const between = (low: number, high: number) => low + magnitudeDraw * (high - low)
+    const chance: Record<HitOutcome, number> = guaranteedNormal
+      ? { abrasion: 0, normal: 1, crit: 0, affinity: 0 }
+      : guaranteedCrit
+        ? { abrasion: 0, normal: 0, crit: 1, affinity: 0 }
+        : { abrasion: AL, normal: AR, crit: AN, affinity: AP }
+    if (guaranteedNormal)
+      return { outcome: "normal", damage: withTail(between(normalMin, normalMax)), chance }
+    if (guaranteedCrit)
+      return { outcome: "crit", damage: withTail(between(critMin, critMax)), chance }
+    if (outcomeDraw < AL) return { outcome: "abrasion", damage: withTail(DZ), chance }
+    if (outcomeDraw < AL + AN)
+      return { outcome: "crit", damage: withTail(between(critMin, critMax)), chance }
+    if (outcomeDraw < AL + AN + AP) return { outcome: "affinity", damage: withTail(ED), chance }
+    return { outcome: "normal", damage: withTail(between(normalMin, normalMax)), chance }
+  }
 
   return {
     expectedDamage: F,
+    rolled: rng ? rollHit(rng) : undefined,
     cells: {
       X,
       Y,

--- a/src/engine/mechanics/types.ts
+++ b/src/engine/mechanics/types.ts
@@ -31,6 +31,9 @@ export interface MechanicSetup {
   // once in `timeline.ts` — see CLAUDE.md § "White vs Yellow rates". A
   // mechanic reads this rather than re-deriving it from `inputs`.
   effectiveRates: { precision: number; critRate: number; affinityRate: number }
+  // A stochastic schedule that receives this must honour it — docs/CALCULATION.md
+  // § "Mechanic rules".
+  rng?: () => number
 }
 
 // Two of the formula's inputs are not `{statKey, amount}` deltas and so cannot

--- a/src/engine/rng.ts
+++ b/src/engine/rng.ts
@@ -1,0 +1,12 @@
+export function mulberry32(seed: number): () => number {
+  let a = seed | 0
+  return function next(): number {
+    a = (a + 1831565813) | 0
+    let t = Math.imul(a ^ (a >>> 15), a | 1)
+    t = (t + Math.imul(t ^ (t >>> 7), t | 61)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export const RUN_SEED_STRIDE = 0x9e3779b1
+export const MECHANIC_STREAM_OFFSET = 0x5bf03635

--- a/src/engine/timeline.ts
+++ b/src/engine/timeline.ts
@@ -1,6 +1,8 @@
 import type {
   BuffWindow,
+  EngineRunOptions,
   Inputs,
+  OutcomeCounts,
   Result,
   RotationCast,
   SkillTickResult,
@@ -27,7 +29,8 @@ import { buildBehaviors, type BuildView, type HitContext, type HitInput } from "
 import { applyEffect, type EffectSink } from "./effects/apply"
 import { grantsMinPhysCritBoostFor } from "../definitions/classes/registry"
 import { buildContext, effectiveRates } from "./panel"
-import { computeSkillDamage } from "./formula"
+import { computeSkillDamage, type HitOutcome, type RolledHit } from "./formula"
+import { MECHANIC_STREAM_OFFSET, mulberry32 } from "./rng"
 import { applyBuffEffects } from "./statRegistry"
 import { builtinSkillsForClass, builtinDebuffsForClass } from "./builtinLibrary"
 import { builtinBuffsForClass } from "./builtinBuffs"
@@ -42,6 +45,8 @@ import { innerWayTier } from "../definitions/innerWays/registry"
 import { PROP } from "../data/skills/ids"
 
 export const FPS = 60
+
+const OUTCOME_KEYS: readonly HitOutcome[] = ["abrasion", "normal", "crit", "affinity"]
 
 // Guards against a runaway cast-skill trigger chain.
 const EVENT_CAP = 100_000
@@ -109,7 +114,13 @@ class EventQueue {
   }
 }
 
-export function simulateTimeline(inputs: Inputs): Result {
+export function simulateTimeline(inputs: Inputs, options?: EngineRunOptions): Result {
+  const collectDetail = options?.collect !== "totals"
+  const hitRng = options?.seed === undefined ? undefined : mulberry32(options.seed)
+  const mechanicRng =
+    options?.seed === undefined
+      ? undefined
+      : mulberry32((options.seed ^ MECHANIC_STREAM_OFFSET) | 0)
   const rotation = inputs.activeCustomRotation
   if (!rotation || rotation.classId !== inputs.classId) {
     return emptyResult(["Timeline rotation not available for this class."])
@@ -362,6 +373,7 @@ export function simulateTimeline(inputs: Inputs): Result {
     paramTier: (name) => buffEngine?.paramTier(name) ?? 0,
     hasBuffEngine: !!buffEngine,
     effectiveRates: { precision, critRate, affinityRate },
+    rng: mechanicRng,
   }
   const mechanics = prepareMechanics(mechanicSetup)
 
@@ -517,6 +529,7 @@ export function simulateTimeline(inputs: Inputs): Result {
     damage: number,
     breakdownName: string,
   ): void {
+    if (!collectDetail) return
     const e = byName.get(name)
     if (e) {
       e.count += count
@@ -525,8 +538,17 @@ export function simulateTimeline(inputs: Inputs): Result {
   }
 
   const timeline: TimelineEvent[] = []
+  const pushEvent = (event: TimelineEvent): void => {
+    if (collectDetail) timeline.push(event)
+  }
 
   let totalDamage = 0
+  const outcomeTally: OutcomeCounts = { abrasion: 0, normal: 0, crit: 0, affinity: 0 }
+  const expectedShareTally: OutcomeCounts = { abrasion: 0, normal: 0, crit: 0, affinity: 0 }
+  const tallyRoll = (rolled: RolledHit): void => {
+    outcomeTally[rolled.outcome] += 1
+    for (const outcome of OUTCOME_KEYS) expectedShareTally[outcome] += rolled.chance[outcome]
+  }
   let processed = 0
   while (queue.size > 0) {
     if (processed >= EVENT_CAP) {
@@ -601,25 +623,21 @@ export function simulateTimeline(inputs: Inputs): Result {
     for (const effect of behavior.patchArt(hitInput, hitContext)) applyEffect(artSink, effect)
     if (st.damageFactor !== 1) art.correction = (art.correction ?? 1) * st.damageFactor
     if (st.conditionalFinalCrit) art.conditionalFinalCrit = st.conditionalFinalCrit
-    const { expectedDamage } = computeSkillDamage(art, st.ctx, 1)
+    const { expectedDamage, rolled } = computeSkillDamage(art, st.ctx, 1, hitRng)
+    const damage = rolled?.damage ?? expectedDamage
     const hitInWindow = inWindow(frame)
     if (hitInWindow) {
-      totalDamage += expectedDamage
-      add(
-        skill.name,
-        skill.skillType,
-        1,
-        expectedDamage,
-        breakdownNameOf(skill.breakdownName, skill.name),
-      )
+      totalDamage += damage
+      if (rolled) tallyRoll(rolled)
+      add(skill.name, skill.skillType, 1, damage, breakdownNameOf(skill.breakdownName, skill.name))
     }
-    timeline.push({
+    pushEvent({
       frame,
       timeSec: frame / FPS,
       skillName: skill.name,
       type: skill.skillType,
       kind: "hit",
-      damage: expectedDamage,
+      damage,
       inWindow: hitInWindow,
     })
 
@@ -724,65 +742,74 @@ export function simulateTimeline(inputs: Inputs): Result {
 
   ledger.sortWindows()
 
-  const castsUnsorted: RotationCast[] = laidSteps.map((ls, i) => {
-    const lastHitFrame =
-      ls.performedHits.length > 0 ? Math.max(...ls.performedHits.map((h) => h.frame)) : 0
-    const queryFrame = Math.max(
-      ls.startFrame,
-      ls.startFrame + castLens[i] - 1,
-      ls.startFrame + lastHitFrame,
-    )
-    const queryTimeSec = queryFrame / FPS
-    const { buffs, seen: seenBuffIds } = collectCastBuffs({
-      frame: queryFrame,
-      timeSec: queryTimeSec,
-      fps: FPS,
-      ledger: ledger.throughOwner(ls.startFrame),
-      statusById,
-      buffEngine,
-      // Below the display threshold there's a real chance no poison has
-      // procced yet at all (e.g. right after the very first eligible hits),
-      // so the expected-remaining number alone would understate that and
-      // read as an oddly short "duration" — withhold it until more likely
-      // than not to be up, same convention as Concentration's own gate.
-      overrideRemainingSec: (id, timeSec) => {
-        for (const { mechanic, state } of mechanics) {
-          const override = mechanic.remainingSecAt?.(state, id, timeSec)
-          if (override) return override
+  function buildCasts(): RotationCast[] {
+    const castsUnsorted: RotationCast[] = laidSteps.map((ls, i) => {
+      const lastHitFrame =
+        ls.performedHits.length > 0 ? Math.max(...ls.performedHits.map((h) => h.frame)) : 0
+      const queryFrame = Math.max(
+        ls.startFrame,
+        ls.startFrame + castLens[i] - 1,
+        ls.startFrame + lastHitFrame,
+      )
+      const queryTimeSec = queryFrame / FPS
+      const { buffs, seen: seenBuffIds } = collectCastBuffs({
+        frame: queryFrame,
+        timeSec: queryTimeSec,
+        fps: FPS,
+        ledger: ledger.throughOwner(ls.startFrame),
+        statusById,
+        buffEngine,
+        // Below the display threshold there's a real chance no poison has
+        // procced yet at all (e.g. right after the very first eligible hits),
+        // so the expected-remaining number alone would understate that and
+        // read as an oddly short "duration" — withhold it until more likely
+        // than not to be up, same convention as Concentration's own gate.
+        overrideRemainingSec: (id, timeSec) => {
+          for (const { mechanic, state } of mechanics) {
+            const override = mechanic.remainingSecAt?.(state, id, timeSec)
+            if (override) return override
+          }
+          return null
+        },
+      })
+      for (const { mechanic, state } of mechanics) {
+        for (const chip of mechanic.display?.(state, queryTimeSec, ls.prePull, mechanicSetup) ??
+          []) {
+          if (seenBuffIds.has(chip.id)) continue
+          seenBuffIds.add(chip.id)
+          buffs.push(chip)
         }
-        return null
-      },
+      }
+
+      return {
+        index: 0,
+        stepId: ls.resolved.step.id,
+        stepIndex: i,
+        skillName: ls.resolved.skill.name,
+        timeSec: ls.startFrame / FPS,
+        inWindow: inWindow(ls.startFrame),
+        prePull: ls.prePull,
+        buffs,
+      }
     })
-    for (const { mechanic, state } of mechanics) {
-      for (const chip of mechanic.display?.(state, queryTimeSec, ls.prePull, mechanicSetup) ?? []) {
-        if (seenBuffIds.has(chip.id)) continue
-        seenBuffIds.add(chip.id)
-        buffs.push(chip)
+    castsUnsorted.sort((a, b) => a.timeSec - b.timeSec)
+    return castsUnsorted.map((c, i) => ({ ...c, index: i + 1 }))
+  }
+
+  function buildBuffWindows(): BuffWindow[] {
+    const windows: BuffWindow[] = []
+    for (const [id, arr] of ledger.entries()) {
+      const status = statusById.get(id)
+      if (!status) continue
+      for (const w of arr) {
+        windows.push({ id, name: status.name, startSec: w.start / FPS, endSec: w.end / FPS })
       }
     }
-
-    return {
-      index: 0,
-      stepId: ls.resolved.step.id,
-      stepIndex: i,
-      skillName: ls.resolved.skill.name,
-      timeSec: ls.startFrame / FPS,
-      inWindow: inWindow(ls.startFrame),
-      prePull: ls.prePull,
-      buffs,
-    }
-  })
-  castsUnsorted.sort((a, b) => a.timeSec - b.timeSec)
-  const casts: RotationCast[] = castsUnsorted.map((c, i) => ({ ...c, index: i + 1 }))
-
-  const buffWindows: BuffWindow[] = []
-  for (const [id, arr] of ledger.entries()) {
-    const status = statusById.get(id)
-    if (!status) continue
-    for (const w of arr) {
-      buffWindows.push({ id, name: status.name, startSec: w.start / FPS, endSec: w.end / FPS })
-    }
+    return windows
   }
+
+  const casts: RotationCast[] = collectDetail ? buildCasts() : []
+  const buffWindows: BuffWindow[] = collectDetail ? buildBuffWindows() : []
 
   interface DotTickEntry extends DotTickPlan {
     seq: number
@@ -857,13 +884,19 @@ export function simulateTimeline(inputs: Inputs): Result {
 
   for (const entry of dotTickEntries) {
     const st = resolveState(entry.frame, entry.dotSkill)
-    const damage =
-      dotTickDamage(entry.debuffForTick, st.ctx, computeSkillDamage, st.forceCrit, entry.shape) *
-      (entry.scale ?? 1) *
-      entry.weight
+    const tick = dotTickDamage(
+      entry.debuffForTick,
+      st.ctx,
+      computeSkillDamage,
+      st.forceCrit,
+      entry.shape,
+      hitRng,
+    )
+    const damage = tick.damage * (entry.scale ?? 1) * entry.weight
     totalDamage += damage
+    if (tick.rolled) tallyRoll(tick.rolled)
     add(entry.dotName, entry.dotType, 1, damage, entry.dotBreakdownName)
-    timeline.push({
+    pushEvent({
       frame: entry.frame,
       timeSec: entry.frame / FPS,
       skillName: entry.dotName,
@@ -879,22 +912,18 @@ export function simulateTimeline(inputs: Inputs): Result {
       const st = resolveState(event.frame, event.skill)
       const art = { ...event.art } as Parameters<typeof computeSkillDamage>[0]
       if (st.forceCrit) art.guaranteedCrit = 1
-      const { expectedDamage } = computeSkillDamage(art, st.ctx, 1)
-      totalDamage += expectedDamage
-      add(
-        event.name,
-        event.type,
-        1,
-        expectedDamage,
-        breakdownNameOf(event.skill.breakdownName, event.name),
-      )
-      timeline.push({
+      const { expectedDamage, rolled } = computeSkillDamage(art, st.ctx, 1, hitRng)
+      const damage = rolled?.damage ?? expectedDamage
+      totalDamage += damage
+      if (rolled) tallyRoll(rolled)
+      add(event.name, event.type, 1, damage, breakdownNameOf(event.skill.breakdownName, event.name))
+      pushEvent({
         frame: event.frame,
         timeSec: event.frame / FPS,
         skillName: event.name,
         type: event.type,
         kind: "hit",
-        damage: expectedDamage,
+        damage,
         inWindow: true,
       })
     }
@@ -917,6 +946,18 @@ export function simulateTimeline(inputs: Inputs): Result {
   if (durationFrames <= 0)
     warnings.push("Timeline has no in-window skills — duration and DPS are 0.")
 
+  const rolledHits = OUTCOME_KEYS.reduce((sum, outcome) => sum + outcomeTally[outcome], 0)
+  const expectedOutcomeShare: OutcomeCounts = {
+    abrasion: 0,
+    normal: 0,
+    crit: 0,
+    affinity: 0,
+  }
+  if (rolledHits > 0) {
+    for (const outcome of OUTCOME_KEYS)
+      expectedOutcomeShare[outcome] = expectedShareTally[outcome] / rolledHits
+  }
+
   return {
     dps,
     totalDamage,
@@ -930,6 +971,8 @@ export function simulateTimeline(inputs: Inputs): Result {
     qiBreakWindow,
     lowQiWindow,
     casts,
+    outcomeCounts: hitRng ? outcomeTally : undefined,
+    expectedOutcomeShare: hitRng ? expectedOutcomeShare : undefined,
   }
 }
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -2,6 +2,7 @@ import type { GearWordId } from "../data/stats/statLines"
 import type { Rotation } from "./rotation"
 
 export type { GearWordId } from "../data/stats/statLines"
+import type { HitOutcome } from "./formula"
 import type { Skill } from "./skill"
 import type { Buff, BuffStatEffect } from "./buff"
 import type { Debuff } from "./debuff"
@@ -292,6 +293,13 @@ export interface StoredProfile {
   inputs: Inputs
 }
 
+export type OutcomeCounts = Record<HitOutcome, number>
+
+export interface EngineRunOptions {
+  seed?: number
+  collect?: "full" | "totals"
+}
+
 export interface Result {
   dps: number
   totalDamage: number
@@ -305,6 +313,10 @@ export interface Result {
   qiBreakWindow?: { startSec: number; endSec: number } | null
   lowQiWindow?: { startSec: number; endSec: number } | null
   casts?: RotationCast[]
+  // Optional so `JSON.stringify` drops the keys on an unseeded run and the
+  // locked baseline digest stays byte-identical.
+  outcomeCounts?: OutcomeCounts
+  expectedOutcomeShare?: OutcomeCounts
 }
 
 export interface CastBuffTag {

--- a/src/ui/features/simulation/damageFormat.ts
+++ b/src/ui/features/simulation/damageFormat.ts
@@ -15,6 +15,15 @@ export function fixed(value: number, digits: number): string {
   return Number.isFinite(value) ? value.toFixed(digits) : "—"
 }
 
+export function decimalNumber(value: number, digits: number): string {
+  return Number.isFinite(value)
+    ? value.toLocaleString("en-US", {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      })
+    : "—"
+}
+
 export function signedPercent(fraction: number): string {
   if (!Number.isFinite(fraction)) return "—"
   const percent = fraction * 100

--- a/src/ui/features/simulation/damageFormat.ts
+++ b/src/ui/features/simulation/damageFormat.ts
@@ -1,0 +1,23 @@
+export function fullNumber(value: number): string {
+  return Number.isFinite(value) ? Math.round(value).toLocaleString("en-US") : "—"
+}
+
+export function compactDamage(value: number): string {
+  if (!Number.isFinite(value)) return "—"
+  const magnitude = Math.abs(value)
+  if (magnitude >= 1_000_000) return (value / 1_000_000).toFixed(2) + "M"
+  if (magnitude >= 10_000) return (value / 1000).toFixed(0) + "k"
+  if (magnitude >= 1000) return (value / 1000).toFixed(1) + "k"
+  return value.toFixed(0)
+}
+
+export function fixed(value: number, digits: number): string {
+  return Number.isFinite(value) ? value.toFixed(digits) : "—"
+}
+
+export function signedPercent(fraction: number): string {
+  if (!Number.isFinite(fraction)) return "—"
+  const percent = fraction * 100
+  const sign = percent > 0.005 ? "+" : percent < -0.005 ? "−" : "±"
+  return `${sign}${Math.abs(percent).toFixed(1)} %`
+}

--- a/src/ui/features/simulation/simulation-controls-panel/SimulationControlsPanel.module.scss
+++ b/src/ui/features/simulation/simulation-controls-panel/SimulationControlsPanel.module.scss
@@ -1,0 +1,16 @@
+@use "breakpoints";
+
+.rotationField {
+  flex: 0 1 280px;
+  min-width: 0;
+}
+
+.runCountField {
+  flex: 0 0 96px;
+}
+
+@include breakpoints.below(breakpoints.$bp-700) {
+  .rotationField {
+    flex: 1 1 100%;
+  }
+}

--- a/src/ui/features/simulation/simulation-controls-panel/SimulationControlsPanel.tsx
+++ b/src/ui/features/simulation/simulation-controls-panel/SimulationControlsPanel.tsx
@@ -1,0 +1,90 @@
+import { useI18n } from "../../../../i18n/i18nContext"
+import { NumInput } from "../../../components/number-inputs/NumberInputs"
+import { Select } from "../../../components/select/Select"
+import type { RotationOption } from "../../rotation/rotationOptions"
+import type { SimulationStatus } from "../../../hooks/useParseSimulation"
+import { SimulationProgressBar } from "../simulation-progress-bar/SimulationProgressBar"
+import { MAX_RUN_COUNT, MIN_RUN_COUNT, RUN_COUNT_STEP } from "../simulationRunSettings"
+import styles from "./SimulationControlsPanel.module.scss"
+
+const GROUP_LABELS: Record<RotationOption["group"], string> = {
+  builtin: "Built-in rotations",
+  custom: "Custom Rotation",
+}
+
+export function SimulationControlsPanel({
+  options,
+  selectedOptionId,
+  onSelectOption,
+  runCount,
+  onRunCountChange,
+  status,
+  progress,
+  isStale,
+  onRun,
+  onCancel,
+}: {
+  options: RotationOption[]
+  selectedOptionId: string
+  onSelectOption: (optionId: string) => void
+  runCount: number
+  onRunCountChange: (next: number) => void
+  status: SimulationStatus
+  progress: { done: number; total: number }
+  isStale: boolean
+  onRun: () => void
+  onCancel: () => void
+}) {
+  const { t } = useI18n()
+  const isRunning = status === "running"
+
+  return (
+    <div className="panel">
+      <div className="toolbar">
+        <span className="toolbar-label">{t("Rotation")}</span>
+        <div className={styles.rotationField}>
+          <Select
+            ariaLabel={t("Rotation")}
+            value={selectedOptionId}
+            disabled={isRunning || options.length === 0}
+            onChange={onSelectOption}
+            options={options.map((option) => ({
+              value: option.id,
+              label: option.name,
+              group: t(GROUP_LABELS[option.group]),
+              meta: option.isClassDefault ? t("default") : undefined,
+            }))}
+          />
+        </div>
+        <span className="toolbar-label">{t("Runs")}</span>
+        <div className={styles.runCountField}>
+          <NumInput
+            value={runCount}
+            onChange={onRunCountChange}
+            min={MIN_RUN_COUNT}
+            max={MAX_RUN_COUNT}
+            step={RUN_COUNT_STEP}
+            aria-label={t("Runs")}
+            disabled={isRunning}
+          />
+        </div>
+        <span className="spacer" />
+        <button
+          type="button"
+          className="btn primary"
+          onClick={onRun}
+          disabled={isRunning || options.length === 0}
+        >
+          {t("Run")}
+        </button>
+        <button type="button" className="btn" onClick={onCancel} disabled={!isRunning}>
+          {t("Cancel")}
+        </button>
+      </div>
+      <SimulationProgressBar done={progress.done} total={progress.total} status={status} />
+      {isStale && !isRunning && (
+        <p className="hint">{t("Your build changed since this simulation — run it again")}</p>
+      )}
+    </div>
+  )
+}

--- a/src/ui/features/simulation/simulation-distribution-panel/SimulationDistributionPanel.module.scss
+++ b/src/ui/features/simulation/simulation-distribution-panel/SimulationDistributionPanel.module.scss
@@ -1,0 +1,204 @@
+$y-axis-width: 40px;
+$axis-gap: 8px;
+$plot-height: 220px;
+
+.graphPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.plotRow {
+  display: grid;
+  grid-template-columns: $y-axis-width 1fr;
+  gap: $axis-gap;
+}
+
+.yAxis {
+  position: relative;
+  height: $plot-height;
+}
+
+.yAxisLabel {
+  position: absolute;
+  right: 0;
+  transform: translateY(-50%);
+  font-size: 0.7em;
+  color: var(--color-text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.plot {
+  position: relative;
+  height: $plot-height;
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-raised);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.chart {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.gridLine {
+  stroke: var(--color-surface-raised);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.band {
+  fill: rgba(192, 160, 96, 0.1);
+}
+
+.bar {
+  fill: rgba(192, 160, 96, 0.55);
+}
+
+.barHovered {
+  fill: var(--color-accent-bright);
+}
+
+.medianLine {
+  stroke: var(--color-accent-bright);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+
+.meanLine {
+  stroke: #6a9bd8;
+  stroke-width: 1;
+  stroke-dasharray: 5 4;
+  vector-effect: non-scaling-stroke;
+}
+
+.expectedLine {
+  stroke: #6ad8c4;
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+  vector-effect: non-scaling-stroke;
+}
+
+.hoverGuide {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--color-border-hover);
+  pointer-events: none;
+}
+
+.hoverTooltip {
+  position: absolute;
+  top: 12px;
+  transform: translateX(10px);
+  padding: 4px 8px;
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.hoverTooltip.flipped {
+  transform: translateX(calc(-100% - 10px));
+}
+
+.hoverRange {
+  font-size: 0.7em;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.hoverCount {
+  font-size: 0.78em;
+  color: var(--color-accent-bright);
+  font-variant-numeric: tabular-nums;
+}
+
+.hoverShare {
+  font-size: 0.7em;
+  color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.xAxis {
+  display: grid;
+  grid-template-columns: $y-axis-width 1fr;
+  gap: $axis-gap;
+}
+
+.xAxisTrack {
+  grid-column: 2;
+  position: relative;
+  height: 16px;
+}
+
+.xAxisTick {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 0.7em;
+  color: var(--color-text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.alignStart {
+  transform: none;
+}
+
+.alignEnd {
+  transform: translateX(-100%);
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  padding-left: $y-axis-width + $axis-gap;
+  font-size: 0.75em;
+  color: var(--color-text-muted);
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.swatch {
+  width: 14px;
+  height: 0;
+  border-top-width: 2px;
+  border-top-style: solid;
+}
+
+.swatchMedian {
+  border-top-color: var(--color-accent-bright);
+}
+
+.swatchMean {
+  border-top-width: 1px;
+  border-top-style: dashed;
+  border-top-color: #6a9bd8;
+}
+
+.swatchExpected {
+  border-top-width: 1px;
+  border-top-style: dotted;
+  border-top-color: #6ad8c4;
+}
+
+.swatchBand {
+  height: 10px;
+  border: none;
+  border-radius: 2px;
+  background: rgba(192, 160, 96, 0.28);
+}
+
+.legendValue {
+  color: var(--color-accent-bright);
+  font-variant-numeric: tabular-nums;
+}

--- a/src/ui/features/simulation/simulation-distribution-panel/SimulationDistributionPanel.tsx
+++ b/src/ui/features/simulation/simulation-distribution-panel/SimulationDistributionPanel.tsx
@@ -1,8 +1,9 @@
 import { useRef, useState } from "react"
 import { useI18n } from "../../../../i18n/i18nContext"
-import { compactDamage, fixed, fullNumber } from "../damageFormat"
+import type { ParseRun } from "../../../../engine/dpsWorker"
+import { compactDamage, decimalNumber, fixed, fullNumber } from "../damageFormat"
 import { parseAtRank } from "../simulation-parse-ladder-panel/parseLadder"
-import { damageHistogram } from "./damageHistogram"
+import { parseHistogram } from "./parseHistogram"
 import styles from "./SimulationDistributionPanel.module.scss"
 
 const GRID_FRACTIONS = [1, 0.75, 0.5, 0.25, 0]
@@ -19,19 +20,21 @@ function niceCeiling(value: number): number {
 }
 
 export function SimulationDistributionPanel({
-  sortedTotals,
-  meanTotalDamage,
-  expectedTotalDamage,
+  sorted,
+  meanDps,
+  expectedDps,
+  rotationDuration,
 }: {
-  sortedTotals: readonly number[]
-  meanTotalDamage: number
-  expectedTotalDamage: number
+  sorted: readonly ParseRun[]
+  meanDps: number
+  expectedDps: number
+  rotationDuration: number
 }) {
   const { t } = useI18n()
   const plotRef = useRef<HTMLDivElement>(null)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
 
-  const histogram = damageHistogram(sortedTotals)
+  const histogram = parseHistogram(sorted.map((run) => run.dps))
   if (histogram.bins.length === 0) return <div className="empty-tab">{t("(none)")}</div>
 
   const { bins, min, max, maxCount } = histogram
@@ -40,15 +43,15 @@ export function SimulationDistributionPanel({
   const binSpan = 100 / bins.length
   const barGap = binSpan * BAR_GAP_FRACTION
 
-  const median = parseAtRank(sortedTotals, 50)
-  const lowBand = parseAtRank(sortedTotals, 20)
-  const highBand = parseAtRank(sortedTotals, 80)
+  const median = parseAtRank(sorted, 50)!.dps
+  const lowBand = parseAtRank(sorted, 20)!.dps
+  const highBand = parseAtRank(sorted, 80)!.dps
 
-  const xOf = (damage: number) => (span > 0 ? ((damage - min) / span) * 100 : 50)
+  const xOf = (dps: number) => (span > 0 ? ((dps - min) / span) * 100 : 50)
   const yOf = (count: number) => 100 - (count / axisTop) * 100
+  const damageOf = (dps: number) => dps * rotationDuration
 
-  const showExpected =
-    Number.isFinite(expectedTotalDamage) && expectedTotalDamage >= min && expectedTotalDamage <= max
+  const showExpected = Number.isFinite(expectedDps) && expectedDps >= min && expectedDps <= max
 
   const hovered = hoveredIndex === null ? null : bins[hoveredIndex]
 
@@ -85,7 +88,7 @@ export function SimulationDistributionPanel({
             viewBox="0 0 100 100"
             preserveAspectRatio="none"
             role="img"
-            aria-label={`${t("Damage Distribution")} — ${t("median")} ${fullNumber(median)}, ${fullNumber(min)} ${t("to")} ${fullNumber(max)}`}
+            aria-label={`${t("DPS Distribution")} — ${t("median")} ${decimalNumber(median, 2)} ${t("DPS")}, ${decimalNumber(min, 2)} ${t("to")} ${decimalNumber(max, 2)}`}
           >
             {GRID_FRACTIONS.map((fraction) => (
               <line
@@ -117,19 +120,13 @@ export function SimulationDistributionPanel({
             {showExpected && (
               <line
                 className={styles.expectedLine}
-                x1={xOf(expectedTotalDamage)}
-                x2={xOf(expectedTotalDamage)}
+                x1={xOf(expectedDps)}
+                x2={xOf(expectedDps)}
                 y1="0"
                 y2="100"
               />
             )}
-            <line
-              className={styles.meanLine}
-              x1={xOf(meanTotalDamage)}
-              x2={xOf(meanTotalDamage)}
-              y1="0"
-              y2="100"
-            />
+            <line className={styles.meanLine} x1={xOf(meanDps)} x2={xOf(meanDps)} y1="0" y2="100" />
             <line className={styles.medianLine} x1={xOf(median)} x2={xOf(median)} y1="0" y2="100" />
           </svg>
           {hovered && (
@@ -145,14 +142,16 @@ export function SimulationDistributionPanel({
                 }
                 style={{ left: (hoveredIndex! + 0.5) * binSpan + "%" }}
               >
-                <div className={styles.hoverRange}>
-                  {compactDamage(hovered.start)} – {compactDamage(hovered.end)}
-                </div>
                 <div className={styles.hoverCount}>
-                  {fullNumber(hovered.count)} {t("runs")}
+                  {decimalNumber(hovered.start, 0)} – {decimalNumber(hovered.end, 0)} {t("DPS")}
+                </div>
+                <div className={styles.hoverRange}>
+                  {compactDamage(damageOf(hovered.start))} – {compactDamage(damageOf(hovered.end))}{" "}
+                  {t("dmg")}
                 </div>
                 <div className={styles.hoverShare}>
-                  {fixed((hovered.count / sortedTotals.length) * 100, 1)} %
+                  {fullNumber(hovered.count)} {t("runs")} ·{" "}
+                  {fixed((hovered.count / sorted.length) * 100, 1)} %
                 </div>
               </div>
             </>
@@ -174,7 +173,7 @@ export function SimulationDistributionPanel({
                 className={styles.xAxisTick + alignment}
                 style={{ left: fraction * 100 + "%" }}
               >
-                {compactDamage(min + span * fraction)}
+                {decimalNumber(min + span * fraction, 0)}
               </span>
             )
           })}
@@ -184,18 +183,18 @@ export function SimulationDistributionPanel({
         <span className={styles.legendItem}>
           <span className={`${styles.swatch} ${styles.swatchMedian}`} />
           {t("Median")}
-          <span className={styles.legendValue}>{fullNumber(median)}</span>
+          <span className={styles.legendValue}>{decimalNumber(median, 2)}</span>
         </span>
         <span className={styles.legendItem}>
           <span className={`${styles.swatch} ${styles.swatchMean}`} />
           {t("Mean")}
-          <span className={styles.legendValue}>{fullNumber(meanTotalDamage)}</span>
+          <span className={styles.legendValue}>{decimalNumber(meanDps, 2)}</span>
         </span>
         {showExpected && (
           <span className={styles.legendItem}>
             <span className={`${styles.swatch} ${styles.swatchExpected}`} />
             {t("Expected")}
-            <span className={styles.legendValue}>{fullNumber(expectedTotalDamage)}</span>
+            <span className={styles.legendValue}>{decimalNumber(expectedDps, 2)}</span>
           </span>
         )}
         <span className={styles.legendItem}>

--- a/src/ui/features/simulation/simulation-distribution-panel/SimulationDistributionPanel.tsx
+++ b/src/ui/features/simulation/simulation-distribution-panel/SimulationDistributionPanel.tsx
@@ -1,0 +1,208 @@
+import { useRef, useState } from "react"
+import { useI18n } from "../../../../i18n/i18nContext"
+import { compactDamage, fixed, fullNumber } from "../damageFormat"
+import { parseAtRank } from "../simulation-parse-ladder-panel/parseLadder"
+import { damageHistogram } from "./damageHistogram"
+import styles from "./SimulationDistributionPanel.module.scss"
+
+const GRID_FRACTIONS = [1, 0.75, 0.5, 0.25, 0]
+const AXIS_TICK_FRACTIONS = [0, 0.25, 0.5, 0.75, 1]
+const NICE_STEPS = [1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10]
+const TOOLTIP_FLIP_AT = 60
+const BAR_GAP_FRACTION = 0.12
+
+function niceCeiling(value: number): number {
+  if (!(value > 0)) return 1
+  const magnitude = 10 ** Math.floor(Math.log10(value))
+  const step = NICE_STEPS.find((candidate) => candidate * magnitude >= value)
+  return (step ?? 10) * magnitude
+}
+
+export function SimulationDistributionPanel({
+  sortedTotals,
+  meanTotalDamage,
+  expectedTotalDamage,
+}: {
+  sortedTotals: readonly number[]
+  meanTotalDamage: number
+  expectedTotalDamage: number
+}) {
+  const { t } = useI18n()
+  const plotRef = useRef<HTMLDivElement>(null)
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+
+  const histogram = damageHistogram(sortedTotals)
+  if (histogram.bins.length === 0) return <div className="empty-tab">{t("(none)")}</div>
+
+  const { bins, min, max, maxCount } = histogram
+  const span = max - min
+  const axisTop = niceCeiling(maxCount)
+  const binSpan = 100 / bins.length
+  const barGap = binSpan * BAR_GAP_FRACTION
+
+  const median = parseAtRank(sortedTotals, 50)
+  const lowBand = parseAtRank(sortedTotals, 20)
+  const highBand = parseAtRank(sortedTotals, 80)
+
+  const xOf = (damage: number) => (span > 0 ? ((damage - min) / span) * 100 : 50)
+  const yOf = (count: number) => 100 - (count / axisTop) * 100
+
+  const showExpected =
+    Number.isFinite(expectedTotalDamage) && expectedTotalDamage >= min && expectedTotalDamage <= max
+
+  const hovered = hoveredIndex === null ? null : bins[hoveredIndex]
+
+  function trackPointer(clientX: number) {
+    const rect = plotRef.current?.getBoundingClientRect()
+    if (!rect || rect.width === 0) return
+    const fraction = (clientX - rect.left) / rect.width
+    const index = Math.floor(fraction * bins.length)
+    setHoveredIndex(Math.min(bins.length - 1, Math.max(0, index)))
+  }
+
+  return (
+    <div className={styles.graphPanel}>
+      <div className={styles.plotRow}>
+        <div className={styles.yAxis}>
+          {GRID_FRACTIONS.map((fraction) => (
+            <span
+              key={fraction}
+              className={styles.yAxisLabel}
+              style={{ top: (1 - fraction) * 100 + "%" }}
+            >
+              {Math.round(axisTop * fraction)}
+            </span>
+          ))}
+        </div>
+        <div
+          ref={plotRef}
+          className={styles.plot}
+          onMouseMove={(event) => trackPointer(event.clientX)}
+          onMouseLeave={() => setHoveredIndex(null)}
+        >
+          <svg
+            className={styles.chart}
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            role="img"
+            aria-label={`${t("Damage Distribution")} — ${t("median")} ${fullNumber(median)}, ${fullNumber(min)} ${t("to")} ${fullNumber(max)}`}
+          >
+            {GRID_FRACTIONS.map((fraction) => (
+              <line
+                key={fraction}
+                className={styles.gridLine}
+                x1="0"
+                x2="100"
+                y1={(1 - fraction) * 100}
+                y2={(1 - fraction) * 100}
+              />
+            ))}
+            <rect
+              className={styles.band}
+              x={xOf(lowBand)}
+              width={Math.max(0, xOf(highBand) - xOf(lowBand))}
+              y="0"
+              height="100"
+            />
+            {bins.map((bin, index) => (
+              <rect
+                key={bin.start}
+                className={styles.bar + (index === hoveredIndex ? ` ${styles.barHovered}` : "")}
+                x={index * binSpan + barGap / 2}
+                width={Math.max(binSpan - barGap, 0.2)}
+                y={yOf(bin.count)}
+                height={100 - yOf(bin.count)}
+              />
+            ))}
+            {showExpected && (
+              <line
+                className={styles.expectedLine}
+                x1={xOf(expectedTotalDamage)}
+                x2={xOf(expectedTotalDamage)}
+                y1="0"
+                y2="100"
+              />
+            )}
+            <line
+              className={styles.meanLine}
+              x1={xOf(meanTotalDamage)}
+              x2={xOf(meanTotalDamage)}
+              y1="0"
+              y2="100"
+            />
+            <line className={styles.medianLine} x1={xOf(median)} x2={xOf(median)} y1="0" y2="100" />
+          </svg>
+          {hovered && (
+            <>
+              <div
+                className={styles.hoverGuide}
+                style={{ left: (hoveredIndex! + 0.5) * binSpan + "%" }}
+              />
+              <div
+                className={
+                  styles.hoverTooltip +
+                  ((hoveredIndex! + 0.5) * binSpan > TOOLTIP_FLIP_AT ? ` ${styles.flipped}` : "")
+                }
+                style={{ left: (hoveredIndex! + 0.5) * binSpan + "%" }}
+              >
+                <div className={styles.hoverRange}>
+                  {compactDamage(hovered.start)} – {compactDamage(hovered.end)}
+                </div>
+                <div className={styles.hoverCount}>
+                  {fullNumber(hovered.count)} {t("runs")}
+                </div>
+                <div className={styles.hoverShare}>
+                  {fixed((hovered.count / sortedTotals.length) * 100, 1)} %
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+      <div className={styles.xAxis}>
+        <div className={styles.xAxisTrack}>
+          {AXIS_TICK_FRACTIONS.map((fraction, index) => {
+            const alignment =
+              index === 0
+                ? ` ${styles.alignStart}`
+                : index === AXIS_TICK_FRACTIONS.length - 1
+                  ? ` ${styles.alignEnd}`
+                  : ""
+            return (
+              <span
+                key={fraction}
+                className={styles.xAxisTick + alignment}
+                style={{ left: fraction * 100 + "%" }}
+              >
+                {compactDamage(min + span * fraction)}
+              </span>
+            )
+          })}
+        </div>
+      </div>
+      <div className={styles.legend}>
+        <span className={styles.legendItem}>
+          <span className={`${styles.swatch} ${styles.swatchMedian}`} />
+          {t("Median")}
+          <span className={styles.legendValue}>{fullNumber(median)}</span>
+        </span>
+        <span className={styles.legendItem}>
+          <span className={`${styles.swatch} ${styles.swatchMean}`} />
+          {t("Mean")}
+          <span className={styles.legendValue}>{fullNumber(meanTotalDamage)}</span>
+        </span>
+        {showExpected && (
+          <span className={styles.legendItem}>
+            <span className={`${styles.swatch} ${styles.swatchExpected}`} />
+            {t("Expected")}
+            <span className={styles.legendValue}>{fullNumber(expectedTotalDamage)}</span>
+          </span>
+        )}
+        <span className={styles.legendItem}>
+          <span className={`${styles.swatch} ${styles.swatchBand}`} />
+          {t("p20–p80")}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/features/simulation/simulation-distribution-panel/damageHistogram.ts
+++ b/src/ui/features/simulation/simulation-distribution-panel/damageHistogram.ts
@@ -1,0 +1,55 @@
+const MIN_BINS = 12
+const MAX_BINS = 40
+
+export interface HistogramBin {
+  start: number
+  end: number
+  count: number
+}
+
+export interface DamageHistogram {
+  bins: HistogramBin[]
+  min: number
+  max: number
+  binWidth: number
+  maxCount: number
+}
+
+export function binCountFor(runCount: number): number {
+  return Math.min(MAX_BINS, Math.max(MIN_BINS, Math.round(Math.sqrt(runCount))))
+}
+
+export function damageHistogram(sortedTotals: readonly number[]): DamageHistogram {
+  if (sortedTotals.length === 0) {
+    return { bins: [], min: 0, max: 0, binWidth: 0, maxCount: 0 }
+  }
+
+  const min = sortedTotals[0]
+  const max = sortedTotals[sortedTotals.length - 1]
+  if (max === min) {
+    return {
+      bins: [{ start: min, end: min, count: sortedTotals.length }],
+      min,
+      max,
+      binWidth: 0,
+      maxCount: sortedTotals.length,
+    }
+  }
+
+  const binCount = binCountFor(sortedTotals.length)
+  const binWidth = (max - min) / binCount
+  const bins: HistogramBin[] = Array.from({ length: binCount }, (_unused, index) => ({
+    start: min + index * binWidth,
+    end: min + (index + 1) * binWidth,
+    count: 0,
+  }))
+
+  for (const total of sortedTotals) {
+    const index = Math.min(binCount - 1, Math.floor((total - min) / binWidth))
+    bins[index].count += 1
+  }
+
+  let maxCount = 0
+  for (const bin of bins) maxCount = Math.max(maxCount, bin.count)
+  return { bins, min, max, binWidth, maxCount }
+}

--- a/src/ui/features/simulation/simulation-distribution-panel/parseHistogram.ts
+++ b/src/ui/features/simulation/simulation-distribution-panel/parseHistogram.ts
@@ -7,7 +7,7 @@ export interface HistogramBin {
   count: number
 }
 
-export interface DamageHistogram {
+export interface ParseHistogram {
   bins: HistogramBin[]
   min: number
   max: number
@@ -19,7 +19,7 @@ export function binCountFor(runCount: number): number {
   return Math.min(MAX_BINS, Math.max(MIN_BINS, Math.round(Math.sqrt(runCount))))
 }
 
-export function damageHistogram(sortedTotals: readonly number[]): DamageHistogram {
+export function parseHistogram(sortedTotals: readonly number[]): ParseHistogram {
   if (sortedTotals.length === 0) {
     return { bins: [], min: 0, max: 0, binWidth: 0, maxCount: 0 }
   }

--- a/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.module.scss
+++ b/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.module.scss
@@ -1,0 +1,50 @@
+.mixBar {
+  display: flex;
+  gap: 2px;
+  height: 14px;
+  margin-bottom: 12px;
+}
+
+.segment {
+  flex-grow: 0;
+  flex-shrink: 1;
+  min-width: 0;
+  border-radius: 3px;
+}
+
+.swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  margin-right: 7px;
+  vertical-align: baseline;
+}
+
+.critical {
+  background: var(--color-accent-bright);
+}
+
+.normal {
+  background: #6a9bd8;
+}
+
+.affinity {
+  background: var(--color-rarity-epic);
+}
+
+.abrasion {
+  background: var(--color-text-muted);
+}
+
+.categoryCell {
+  text-align: left;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.numeric {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}

--- a/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.module.scss
+++ b/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.module.scss
@@ -48,3 +48,8 @@
   text-align: right;
   white-space: nowrap;
 }
+
+.mixTable th.centered,
+.mixTable td.centered {
+  text-align: center;
+}

--- a/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.module.scss
+++ b/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.module.scss
@@ -22,19 +22,19 @@
 }
 
 .critical {
-  background: var(--color-accent-bright);
+  background: #e8c84a;
 }
 
 .normal {
-  background: #6a9bd8;
+  background: var(--color-text);
 }
 
 .affinity {
-  background: var(--color-rarity-epic);
+  background: #e08a3c;
 }
 
 .abrasion {
-  background: var(--color-text-muted);
+  background: var(--color-text-faint);
 }
 
 .categoryCell {

--- a/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.tsx
+++ b/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.tsx
@@ -39,14 +39,14 @@ export function SimulationOutcomeMixPanel({
           />
         ))}
       </div>
-      <table className="ranking-table ranking-table-spaced">
+      <table className={`ranking-table ranking-table-spaced ${styles.mixTable}`}>
         <thead>
           <tr>
             <th>{t("Outcome")}</th>
-            <th>{t("Hits")}</th>
-            <th>{t("Share")}</th>
-            <th>{t("Expected")}</th>
-            <th>{t("Gap (pp)")}</th>
+            <th className={styles.centered}>{t("Hits")}</th>
+            <th className={styles.centered}>{t("Share")}</th>
+            <th className={styles.centered}>{t("Expected")}</th>
+            <th className={styles.centered}>{t("Gap (pp)")}</th>
           </tr>
         </thead>
         <tbody>
@@ -56,12 +56,14 @@ export function SimulationOutcomeMixPanel({
                 <span className={`${styles.swatch} ${styles[row.category]}`} />
                 {t(CATEGORY_LABELS[row.category])}
               </th>
-              <td className={styles.numeric}>{fixed(row.meanHits, 2)}</td>
-              <td className={styles.numeric}>{fixed(row.observedShare * 100, 1)} %</td>
-              <td className={styles.numeric}>
+              <td className={`${styles.numeric} ${styles.centered}`}>{fixed(row.meanHits, 2)}</td>
+              <td className={`${styles.numeric} ${styles.centered}`}>
+                {fixed(row.observedShare * 100, 1)} %
+              </td>
+              <td className={`${styles.numeric} ${styles.centered}`}>
                 {row.expectedShare === null ? "—" : `${fixed(row.expectedShare * 100, 1)} %`}
               </td>
-              <td className={styles.numeric}>
+              <td className={`${styles.numeric} ${styles.centered}`}>
                 {row.deltaPoints === null ? "—" : fixed(row.deltaPoints, 2)}
               </td>
             </tr>

--- a/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.tsx
+++ b/src/ui/features/simulation/simulation-outcome-mix-panel/SimulationOutcomeMixPanel.tsx
@@ -1,0 +1,76 @@
+import { useI18n } from "../../../../i18n/i18nContext"
+import type { ExpectedOutcomeRates } from "../../../../engine/dpsWorker"
+import { fixed } from "../damageFormat"
+import type { ParseSummary } from "../simulation-summary-bar/summaryStats"
+import { outcomeMix, totalMeanHits, type OutcomeCategory } from "./outcomeMix"
+import styles from "./SimulationOutcomeMixPanel.module.scss"
+
+const CATEGORY_LABELS: Record<OutcomeCategory, string> = {
+  critical: "Critical",
+  normal: "Normal",
+  affinity: "Affinity",
+  abrasion: "Abrasion",
+}
+
+export function SimulationOutcomeMixPanel({
+  summary,
+  expectedRates,
+}: {
+  summary: ParseSummary
+  expectedRates: ExpectedOutcomeRates | null
+}) {
+  const { t } = useI18n()
+  const rows = outcomeMix(summary, expectedRates)
+  const total = totalMeanHits(summary)
+  if (total <= 0) return <div className="empty-tab">{t("(none)")}</div>
+
+  const mixLabel = rows
+    .map((row) => `${t(CATEGORY_LABELS[row.category])} ${fixed(row.observedShare * 100, 1)} %`)
+    .join(", ")
+
+  return (
+    <>
+      <div className={styles.mixBar} role="img" aria-label={`${t("Outcome Mix")} — ${mixLabel}`}>
+        {rows.map((row) => (
+          <div
+            key={row.category}
+            className={`${styles.segment} ${styles[row.category]}`}
+            style={{ flexBasis: (row.observedShare * 100).toFixed(2) + "%" }}
+          />
+        ))}
+      </div>
+      <table className="ranking-table ranking-table-spaced">
+        <thead>
+          <tr>
+            <th>{t("Outcome")}</th>
+            <th>{t("Hits")}</th>
+            <th>{t("Share")}</th>
+            <th>{t("Expected")}</th>
+            <th>{t("Gap (pp)")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.category}>
+              <th scope="row" className={styles.categoryCell}>
+                <span className={`${styles.swatch} ${styles[row.category]}`} />
+                {t(CATEGORY_LABELS[row.category])}
+              </th>
+              <td className={styles.numeric}>{fixed(row.meanHits, 2)}</td>
+              <td className={styles.numeric}>{fixed(row.observedShare * 100, 1)} %</td>
+              <td className={styles.numeric}>
+                {row.expectedShare === null ? "—" : `${fixed(row.expectedShare * 100, 1)} %`}
+              </td>
+              <td className={styles.numeric}>
+                {row.deltaPoints === null ? "—" : fixed(row.deltaPoints, 2)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="hint">
+        {t("Observed share should track the expected rate — a wide gap means too few runs.")}
+      </p>
+    </>
+  )
+}

--- a/src/ui/features/simulation/simulation-outcome-mix-panel/outcomeMix.ts
+++ b/src/ui/features/simulation/simulation-outcome-mix-panel/outcomeMix.ts
@@ -1,0 +1,56 @@
+import type { ExpectedOutcomeRates } from "../../../../engine/dpsWorker"
+import type { ParseSummary } from "../simulation-summary-bar/summaryStats"
+
+export type OutcomeCategory = "critical" | "normal" | "affinity" | "abrasion"
+
+export const OUTCOME_ORDER: readonly OutcomeCategory[] = [
+  "critical",
+  "normal",
+  "affinity",
+  "abrasion",
+]
+
+export interface OutcomeRow {
+  category: OutcomeCategory
+  meanHits: number
+  observedShare: number
+  expectedShare: number | null
+  deltaPoints: number | null
+}
+
+const MEAN_HITS_BY_CATEGORY: Record<OutcomeCategory, (summary: ParseSummary) => number> = {
+  critical: (summary) => summary.meanCriticalHits,
+  normal: (summary) => summary.meanNormalHits,
+  affinity: (summary) => summary.meanAffinityHits,
+  abrasion: (summary) => summary.meanAbrasionHits,
+}
+
+const EXPECTED_BY_CATEGORY: Record<OutcomeCategory, keyof ExpectedOutcomeRates> = {
+  critical: "crit",
+  normal: "normal",
+  affinity: "affinity",
+  abrasion: "abrasion",
+}
+
+export function totalMeanHits(summary: ParseSummary): number {
+  return OUTCOME_ORDER.reduce((sum, category) => sum + MEAN_HITS_BY_CATEGORY[category](summary), 0)
+}
+
+export function outcomeMix(
+  summary: ParseSummary,
+  expectedRates: ExpectedOutcomeRates | null,
+): OutcomeRow[] {
+  const total = totalMeanHits(summary)
+  return OUTCOME_ORDER.map((category) => {
+    const meanHits = MEAN_HITS_BY_CATEGORY[category](summary)
+    const observedShare = total > 0 ? meanHits / total : 0
+    const expectedShare = expectedRates ? expectedRates[EXPECTED_BY_CATEGORY[category]] : null
+    return {
+      category,
+      meanHits,
+      observedShare,
+      expectedShare,
+      deltaPoints: expectedShare === null ? null : (observedShare - expectedShare) * 100,
+    }
+  })
+}

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.module.scss
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.module.scss
@@ -1,0 +1,77 @@
+.rank {
+  text-align: left;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.rank.tierHigh {
+  color: var(--color-rarity-legendary);
+}
+
+.rank.tierMid {
+  color: var(--color-rarity-epic);
+}
+
+.rank.tierBase {
+  color: var(--color-text-dim);
+}
+
+.damage {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.delta {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.delta:global(.is-positive) {
+  color: var(--color-positive);
+}
+
+.delta:global(.is-negative) {
+  color: var(--color-negative);
+}
+
+.delta:global(.is-zero) {
+  color: var(--color-text-muted);
+}
+
+.divergingFill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  transition: width 0.15s ease;
+}
+
+.divergingFill:global(.is-positive) {
+  background: var(--color-positive);
+}
+
+.divergingFill:global(.is-negative) {
+  background: var(--color-negative);
+}
+
+.divergingFill:global(.is-zero) {
+  background: transparent;
+}
+
+.centreTick {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: var(--color-border-strong);
+}
+
+.medianRow {
+  background: var(--color-surface-selected);
+}
+
+.medianRow .rank {
+  color: var(--color-text);
+}

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.module.scss
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.module.scss
@@ -17,9 +17,16 @@
   color: var(--color-text-dim);
 }
 
+.dps {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: var(--color-accent-bright);
+}
+
 .damage {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+  color: var(--color-text-faint);
 }
 
 .delta {

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.module.scss
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.module.scss
@@ -1,3 +1,8 @@
+.ladder th.centered,
+.ladder td.centered {
+  text-align: center;
+}
+
 .rank {
   text-align: left;
   font-weight: 600;

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.tsx
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.tsx
@@ -1,5 +1,6 @@
+import type { ParseRun } from "../../../../engine/dpsWorker"
 import { useI18n } from "../../../../i18n/i18nContext"
-import { fixed, fullNumber, signedPercent } from "../damageFormat"
+import { decimalNumber, fixed, fullNumber, signedPercent } from "../damageFormat"
 import { ladderAxisSpan, MEDIAN_RANK, parseLadder, type ParseLadderRow } from "./parseLadder"
 import styles from "./SimulationParseLadderPanel.module.scss"
 
@@ -15,9 +16,9 @@ function signClassOf(delta: number): string {
   return "is-zero"
 }
 
-export function SimulationParseLadderPanel({ sortedTotals }: { sortedTotals: readonly number[] }) {
+export function SimulationParseLadderPanel({ sorted }: { sorted: readonly ParseRun[] }) {
   const { t } = useI18n()
-  const rows = parseLadder(sortedTotals)
+  const rows = parseLadder(sorted)
   if (rows.length === 0) return <div className="empty-tab">{t("(none)")}</div>
 
   const axisSpan = ladderAxisSpan(rows) || 1
@@ -37,6 +38,7 @@ export function SimulationParseLadderPanel({ sortedTotals }: { sortedTotals: rea
         <thead>
           <tr>
             <th>{t("Rank")}</th>
+            <th>{t("DPS")}</th>
             <th>{t("Damage")}</th>
             <th className="bar-col">
               {t("vs Median")} (±{fixed(axisSpan * 100, 1)} %)
@@ -52,6 +54,7 @@ export function SimulationParseLadderPanel({ sortedTotals }: { sortedTotals: rea
                 <th scope="row" className={`${styles.rank} ${tierClassOf(row.rank)}`}>
                   {rankLabel(row.rank)}
                 </th>
+                <td className={styles.dps}>{decimalNumber(row.dps, 2)}</td>
                 <td className={styles.damage}>{fullNumber(row.totalDamage)}</td>
                 <td className="bar-col">
                   <div className="skill-bar-track">

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.tsx
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.tsx
@@ -1,0 +1,73 @@
+import { useI18n } from "../../../../i18n/i18nContext"
+import { fixed, fullNumber, signedPercent } from "../damageFormat"
+import { ladderAxisSpan, MEDIAN_RANK, parseLadder, type ParseLadderRow } from "./parseLadder"
+import styles from "./SimulationParseLadderPanel.module.scss"
+
+function tierClassOf(rank: number): string {
+  if (rank >= 99) return styles.tierHigh
+  if (rank >= 80) return styles.tierMid
+  return styles.tierBase
+}
+
+function signClassOf(delta: number): string {
+  if (delta > 0.00005) return "is-positive"
+  if (delta < -0.00005) return "is-negative"
+  return "is-zero"
+}
+
+export function SimulationParseLadderPanel({ sortedTotals }: { sortedTotals: readonly number[] }) {
+  const { t } = useI18n()
+  const rows = parseLadder(sortedTotals)
+  if (rows.length === 0) return <div className="empty-tab">{t("(none)")}</div>
+
+  const axisSpan = ladderAxisSpan(rows) || 1
+  const rankLabel = (rank: number) =>
+    rank === 100 ? t("MAX") : rank === 0 ? t("MIN") : rank === MEDIAN_RANK ? t("MEDIAN") : `${rank}`
+
+  const barFor = (row: ParseLadderRow) => {
+    const halfWidth = Math.min(50, (Math.abs(row.deltaFromMedian) / axisSpan) * 50)
+    return row.deltaFromMedian >= 0
+      ? { left: "50%", width: halfWidth + "%" }
+      : { right: "50%", width: halfWidth + "%" }
+  }
+
+  return (
+    <>
+      <table className="ranking-table skill-table">
+        <thead>
+          <tr>
+            <th>{t("Rank")}</th>
+            <th>{t("Damage")}</th>
+            <th className="bar-col">
+              {t("vs Median")} (±{fixed(axisSpan * 100, 1)} %)
+            </th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const sign = signClassOf(row.deltaFromMedian)
+            return (
+              <tr key={row.rank} className={row.rank === MEDIAN_RANK ? styles.medianRow : ""}>
+                <th scope="row" className={`${styles.rank} ${tierClassOf(row.rank)}`}>
+                  {rankLabel(row.rank)}
+                </th>
+                <td className={styles.damage}>{fullNumber(row.totalDamage)}</td>
+                <td className="bar-col">
+                  <div className="skill-bar-track">
+                    <div className={`${styles.divergingFill} ${sign}`} style={barFor(row)} />
+                    <div className={styles.centreTick} />
+                  </div>
+                </td>
+                <td className={`${styles.delta} ${sign}`}>{signedPercent(row.deltaFromMedian)}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <p className="hint">
+        {t("A Top-99 parse beats 99 % of the simulated runs. Every value is a run that happened.")}
+      </p>
+    </>
+  )
+}

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.tsx
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.tsx
@@ -33,12 +33,12 @@ export function SimulationParseLadderPanel({ sorted }: { sorted: readonly ParseR
   }
 
   return (
-    <table className="ranking-table skill-table">
+    <table className={`ranking-table skill-table ${styles.ladder}`}>
       <thead>
         <tr>
           <th>{t("Rank")}</th>
-          <th>{t("DPS")}</th>
-          <th>{t("Damage")}</th>
+          <th className={styles.centered}>{t("DPS")}</th>
+          <th className={styles.centered}>{t("Damage")}</th>
           <th className="bar-col">
             {t("vs Median")} (±{fixed(axisSpan * 100, 1)} %)
           </th>
@@ -53,8 +53,10 @@ export function SimulationParseLadderPanel({ sorted }: { sorted: readonly ParseR
               <th scope="row" className={`${styles.rank} ${tierClassOf(row.rank)}`}>
                 {rankLabel(row.rank)}
               </th>
-              <td className={styles.dps}>{decimalNumber(row.dps, 2)}</td>
-              <td className={styles.damage}>{fullNumber(row.totalDamage)}</td>
+              <td className={`${styles.dps} ${styles.centered}`}>{decimalNumber(row.dps, 2)}</td>
+              <td className={`${styles.damage} ${styles.centered}`}>
+                {fullNumber(row.totalDamage)}
+              </td>
               <td className="bar-col">
                 <div className="skill-bar-track">
                   <div className={`${styles.divergingFill} ${sign}`} style={barFor(row)} />

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.tsx
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/SimulationParseLadderPanel.tsx
@@ -33,44 +33,39 @@ export function SimulationParseLadderPanel({ sorted }: { sorted: readonly ParseR
   }
 
   return (
-    <>
-      <table className="ranking-table skill-table">
-        <thead>
-          <tr>
-            <th>{t("Rank")}</th>
-            <th>{t("DPS")}</th>
-            <th>{t("Damage")}</th>
-            <th className="bar-col">
-              {t("vs Median")} (±{fixed(axisSpan * 100, 1)} %)
-            </th>
-            <th />
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => {
-            const sign = signClassOf(row.deltaFromMedian)
-            return (
-              <tr key={row.rank} className={row.rank === MEDIAN_RANK ? styles.medianRow : ""}>
-                <th scope="row" className={`${styles.rank} ${tierClassOf(row.rank)}`}>
-                  {rankLabel(row.rank)}
-                </th>
-                <td className={styles.dps}>{decimalNumber(row.dps, 2)}</td>
-                <td className={styles.damage}>{fullNumber(row.totalDamage)}</td>
-                <td className="bar-col">
-                  <div className="skill-bar-track">
-                    <div className={`${styles.divergingFill} ${sign}`} style={barFor(row)} />
-                    <div className={styles.centreTick} />
-                  </div>
-                </td>
-                <td className={`${styles.delta} ${sign}`}>{signedPercent(row.deltaFromMedian)}</td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
-      <p className="hint">
-        {t("A Top-99 parse beats 99 % of the simulated runs. Every value is a run that happened.")}
-      </p>
-    </>
+    <table className="ranking-table skill-table">
+      <thead>
+        <tr>
+          <th>{t("Rank")}</th>
+          <th>{t("DPS")}</th>
+          <th>{t("Damage")}</th>
+          <th className="bar-col">
+            {t("vs Median")} (±{fixed(axisSpan * 100, 1)} %)
+          </th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const sign = signClassOf(row.deltaFromMedian)
+          return (
+            <tr key={row.rank} className={row.rank === MEDIAN_RANK ? styles.medianRow : ""}>
+              <th scope="row" className={`${styles.rank} ${tierClassOf(row.rank)}`}>
+                {rankLabel(row.rank)}
+              </th>
+              <td className={styles.dps}>{decimalNumber(row.dps, 2)}</td>
+              <td className={styles.damage}>{fullNumber(row.totalDamage)}</td>
+              <td className="bar-col">
+                <div className="skill-bar-track">
+                  <div className={`${styles.divergingFill} ${sign}`} style={barFor(row)} />
+                  <div className={styles.centreTick} />
+                </div>
+              </td>
+              <td className={`${styles.delta} ${sign}`}>{signedPercent(row.deltaFromMedian)}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
   )
 }

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/parseLadder.ts
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/parseLadder.ts
@@ -1,0 +1,33 @@
+export const PARSE_RANKS = [100, 99, 95, 80, 50, 20, 5, 1, 0] as const
+export const MEDIAN_RANK = 50
+
+export interface ParseLadderRow {
+  rank: number
+  totalDamage: number
+  deltaFromMedian: number
+}
+
+export function parseAtRank(sortedTotals: readonly number[], rank: number): number {
+  if (sortedTotals.length === 0) return 0
+  const index = Math.ceil((rank / 100) * sortedTotals.length) - 1
+  return sortedTotals[Math.min(sortedTotals.length - 1, Math.max(0, index))]
+}
+
+export function parseLadder(sortedTotals: readonly number[]): ParseLadderRow[] {
+  if (sortedTotals.length === 0) return []
+  const median = parseAtRank(sortedTotals, MEDIAN_RANK)
+  return PARSE_RANKS.map((rank) => {
+    const totalDamage = parseAtRank(sortedTotals, rank)
+    return {
+      rank,
+      totalDamage,
+      deltaFromMedian: median > 0 ? (totalDamage - median) / median : 0,
+    }
+  })
+}
+
+export function ladderAxisSpan(rows: readonly ParseLadderRow[]): number {
+  let span = 0
+  for (const row of rows) span = Math.max(span, Math.abs(row.deltaFromMedian))
+  return span
+}

--- a/src/ui/features/simulation/simulation-parse-ladder-panel/parseLadder.ts
+++ b/src/ui/features/simulation/simulation-parse-ladder-panel/parseLadder.ts
@@ -1,27 +1,31 @@
+import type { ParseRun } from "../../../../engine/dpsWorker"
+
 export const PARSE_RANKS = [100, 99, 95, 80, 50, 20, 5, 1, 0] as const
 export const MEDIAN_RANK = 50
 
 export interface ParseLadderRow {
   rank: number
+  dps: number
   totalDamage: number
   deltaFromMedian: number
 }
 
-export function parseAtRank(sortedTotals: readonly number[], rank: number): number {
-  if (sortedTotals.length === 0) return 0
-  const index = Math.ceil((rank / 100) * sortedTotals.length) - 1
-  return sortedTotals[Math.min(sortedTotals.length - 1, Math.max(0, index))]
+export function parseAtRank(sorted: readonly ParseRun[], rank: number): ParseRun | null {
+  if (sorted.length === 0) return null
+  const index = Math.ceil((rank / 100) * sorted.length) - 1
+  return sorted[Math.min(sorted.length - 1, Math.max(0, index))]
 }
 
-export function parseLadder(sortedTotals: readonly number[]): ParseLadderRow[] {
-  if (sortedTotals.length === 0) return []
-  const median = parseAtRank(sortedTotals, MEDIAN_RANK)
+export function parseLadder(sorted: readonly ParseRun[]): ParseLadderRow[] {
+  const median = parseAtRank(sorted, MEDIAN_RANK)
+  if (!median) return []
   return PARSE_RANKS.map((rank) => {
-    const totalDamage = parseAtRank(sortedTotals, rank)
+    const run = parseAtRank(sorted, rank)!
     return {
       rank,
-      totalDamage,
-      deltaFromMedian: median > 0 ? (totalDamage - median) / median : 0,
+      dps: run.dps,
+      totalDamage: run.totalDamage,
+      deltaFromMedian: median.dps > 0 ? (run.dps - median.dps) / median.dps : 0,
     }
   })
 }

--- a/src/ui/features/simulation/simulation-progress-bar/SimulationProgressBar.module.scss
+++ b/src/ui/features/simulation/simulation-progress-bar/SimulationProgressBar.module.scss
@@ -1,0 +1,20 @@
+.progressRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.progressCount {
+  font-size: 0.78em;
+  color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.progressStatus {
+  margin: 4px 0 0;
+  font-size: 0.78em;
+  color: var(--color-text-muted);
+}

--- a/src/ui/features/simulation/simulation-progress-bar/SimulationProgressBar.tsx
+++ b/src/ui/features/simulation/simulation-progress-bar/SimulationProgressBar.tsx
@@ -1,0 +1,48 @@
+import { useI18n } from "../../../../i18n/i18nContext"
+import type { SimulationStatus } from "../../../hooks/useParseSimulation"
+import { fullNumber } from "../damageFormat"
+import styles from "./SimulationProgressBar.module.scss"
+
+export function SimulationProgressBar({
+  done,
+  total,
+  status,
+}: {
+  done: number
+  total: number
+  status: SimulationStatus
+}) {
+  const { t } = useI18n()
+  if (status === "idle") return null
+
+  const percent = total > 0 ? Math.min(100, (done / total) * 100) : 0
+  const statusText =
+    status === "running"
+      ? `${t("Simulating")} ${fullNumber(total)} ${t("runs")}…`
+      : status === "cancelled"
+        ? `${t("Simulation cancelled at")} ${fullNumber(done)} ${t("runs")}`
+        : `${t("Simulation complete")} — ${fullNumber(done)} ${t("runs")}`
+
+  return (
+    <>
+      <div className={styles.progressRow}>
+        <div
+          className="skill-bar-track"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={total}
+          aria-valuenow={done}
+          aria-valuetext={`${fullNumber(done)} ${t("of")} ${fullNumber(total)} ${t("runs")}`}
+        >
+          <div className="skill-bar-fill" style={{ width: percent.toFixed(2) + "%" }} />
+        </div>
+        <span className={styles.progressCount}>
+          {fullNumber(done)} / {fullNumber(total)}
+        </span>
+      </div>
+      <p className={styles.progressStatus} role="status">
+        {statusText}
+      </p>
+    </>
+  )
+}

--- a/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.module.scss
+++ b/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.module.scss
@@ -1,0 +1,70 @@
+@use "breakpoints";
+
+.summaryPanel {
+  transition: opacity 120ms ease;
+}
+
+.stale {
+  opacity: 0.75;
+}
+
+.statStrip {
+  display: grid;
+  grid-template-columns: 1.4fr repeat(7, minmax(0, 1fr));
+  gap: 4px 20px;
+  align-items: end;
+  transition: opacity 120ms ease;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.label {
+  font-size: 0.7em;
+  color: var(--color-text-muted);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.value {
+  font-size: 1em;
+  color: var(--color-accent-bright);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.lead .value {
+  font-size: 1.9em;
+  color: var(--color-accent);
+  line-height: 1.1;
+}
+
+.groupStart {
+  border-left: 1px solid var(--color-surface-raised);
+  padding-left: 20px;
+  min-width: 0;
+}
+
+@include breakpoints.below(breakpoints.$bp-900) {
+  .statStrip {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px 16px;
+  }
+
+  .groupStart {
+    border-left: none;
+    padding-left: 0;
+  }
+}
+
+@include breakpoints.below(breakpoints.$bp-560) {
+  .statStrip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.module.scss
+++ b/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.module.scss
@@ -10,7 +10,7 @@
 
 .statStrip {
   display: grid;
-  grid-template-columns: 1.4fr repeat(8, minmax(0, 1fr));
+  grid-template-columns: 1.4fr repeat(7, minmax(0, 1fr));
   gap: 4px 20px;
   align-items: end;
   transition: opacity 120ms ease;
@@ -45,6 +45,15 @@
   line-height: 1.1;
 }
 
+.sub {
+  font-size: 0.72em;
+  color: var(--color-text-faint);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .groupStart {
   border-left: 1px solid var(--color-surface-raised);
   padding-left: 20px;
@@ -53,7 +62,7 @@
 
 @include breakpoints.below(breakpoints.$bp-900) {
   .statStrip {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 10px 16px;
   }
 

--- a/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.module.scss
+++ b/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.module.scss
@@ -10,7 +10,7 @@
 
 .statStrip {
   display: grid;
-  grid-template-columns: 1.4fr repeat(7, minmax(0, 1fr));
+  grid-template-columns: 1.4fr repeat(8, minmax(0, 1fr));
   gap: 4px 20px;
   align-items: end;
   transition: opacity 120ms ease;
@@ -53,7 +53,7 @@
 
 @include breakpoints.below(breakpoints.$bp-900) {
   .statStrip {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 10px 16px;
   }
 

--- a/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.tsx
+++ b/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from "../../../../i18n/i18nContext"
-import { fixed, fullNumber } from "../damageFormat"
+import { decimalNumber, fixed, fullNumber } from "../damageFormat"
 import type { ParseSummary } from "./summaryStats"
 import styles from "./SimulationSummaryBar.module.scss"
 
@@ -39,6 +39,10 @@ export function SimulationSummaryBar({
       </div>
       <div className={styles.statStrip} style={{ opacity: isPending ? 0.6 : 1 }}>
         <Stat label={t("Avg Total Damage")} value={damage(summary?.meanTotalDamage)} lead />
+        <Stat
+          label={t("Avg DPS")}
+          value={summary ? decimalNumber(summary.meanDps, 2) : PLACEHOLDER}
+        />
         <Stat label={t("Best Parse")} value={damage(summary?.bestTotalDamage)} />
         <Stat label={t("Worst Parse")} value={damage(summary?.worstTotalDamage)} />
         <Stat

--- a/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.tsx
+++ b/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.tsx
@@ -1,0 +1,57 @@
+import { useI18n } from "../../../../i18n/i18nContext"
+import { fixed, fullNumber } from "../damageFormat"
+import type { ParseSummary } from "./summaryStats"
+import styles from "./SimulationSummaryBar.module.scss"
+
+const PLACEHOLDER = "—"
+
+function Stat({ label, value, lead }: { label: string; value: string; lead?: boolean }) {
+  return (
+    <div className={styles.stat + (lead ? ` ${styles.lead}` : "")}>
+      <span className={styles.label}>{label}</span>
+      <span className={styles.value}>{value}</span>
+    </div>
+  )
+}
+
+export function SimulationSummaryBar({
+  summary,
+  contextLabel,
+  isPending,
+  isStale,
+}: {
+  summary: ParseSummary | null
+  contextLabel: string
+  isPending: boolean
+  isStale: boolean
+}) {
+  const { t } = useI18n()
+  const damage = (value: number | undefined) => (summary ? fullNumber(value ?? 0) : PLACEHOLDER)
+  const hits = (value: number | undefined) => (summary ? fixed(value ?? 0, 2) : PLACEHOLDER)
+
+  return (
+    <div className={`panel ${styles.summaryPanel}${isStale ? ` ${styles.stale}` : ""}`}>
+      <div className="panel-head">
+        <h2>{t("Simulation Summary")}</h2>
+        <span className="panel-head-meta">
+          <span className="panel-head-meta-value">{contextLabel}</span>
+        </span>
+      </div>
+      <div className={styles.statStrip} style={{ opacity: isPending ? 0.6 : 1 }}>
+        <Stat label={t("Avg Total Damage")} value={damage(summary?.meanTotalDamage)} lead />
+        <Stat label={t("Best Parse")} value={damage(summary?.bestTotalDamage)} />
+        <Stat label={t("Worst Parse")} value={damage(summary?.worstTotalDamage)} />
+        <Stat
+          label={t("DPS Range")}
+          value={summary ? `${fixed(summary.rangeFraction * 100, 1)} %` : PLACEHOLDER}
+        />
+        <div className={styles.groupStart}>
+          <Stat label={t("Abrasion Hits")} value={hits(summary?.meanAbrasionHits)} />
+        </div>
+        <Stat label={t("Normal Hits")} value={hits(summary?.meanNormalHits)} />
+        <Stat label={t("Critical Hits")} value={hits(summary?.meanCriticalHits)} />
+        <Stat label={t("Affinity Hits")} value={hits(summary?.meanAffinityHits)} />
+      </div>
+    </div>
+  )
+}

--- a/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.tsx
+++ b/src/ui/features/simulation/simulation-summary-bar/SimulationSummaryBar.tsx
@@ -5,11 +5,22 @@ import styles from "./SimulationSummaryBar.module.scss"
 
 const PLACEHOLDER = "—"
 
-function Stat({ label, value, lead }: { label: string; value: string; lead?: boolean }) {
+function Stat({
+  label,
+  value,
+  sub,
+  lead,
+}: {
+  label: string
+  value: string
+  sub?: string
+  lead?: boolean
+}) {
   return (
     <div className={styles.stat + (lead ? ` ${styles.lead}` : "")}>
       <span className={styles.label}>{label}</span>
       <span className={styles.value}>{value}</span>
+      {sub !== undefined && <span className={styles.sub}>{sub}</span>}
     </div>
   )
 }
@@ -26,7 +37,9 @@ export function SimulationSummaryBar({
   isStale: boolean
 }) {
   const { t } = useI18n()
-  const damage = (value: number | undefined) => (summary ? fullNumber(value ?? 0) : PLACEHOLDER)
+  const dps = (value: number | undefined) => (summary ? decimalNumber(value ?? 0, 2) : PLACEHOLDER)
+  const damage = (value: number | undefined) =>
+    summary ? `${fullNumber(value ?? 0)} ${t("dmg")}` : PLACEHOLDER
   const hits = (value: number | undefined) => (summary ? fixed(value ?? 0, 2) : PLACEHOLDER)
 
   return (
@@ -38,16 +51,26 @@ export function SimulationSummaryBar({
         </span>
       </div>
       <div className={styles.statStrip} style={{ opacity: isPending ? 0.6 : 1 }}>
-        <Stat label={t("Avg Total Damage")} value={damage(summary?.meanTotalDamage)} lead />
         <Stat
           label={t("Avg DPS")}
-          value={summary ? decimalNumber(summary.meanDps, 2) : PLACEHOLDER}
+          value={dps(summary?.meanDps)}
+          sub={damage(summary?.meanTotalDamage)}
+          lead
         />
-        <Stat label={t("Best Parse")} value={damage(summary?.bestTotalDamage)} />
-        <Stat label={t("Worst Parse")} value={damage(summary?.worstTotalDamage)} />
+        <Stat
+          label={t("Best Parse")}
+          value={dps(summary?.bestDps)}
+          sub={damage(summary?.bestTotalDamage)}
+        />
+        <Stat
+          label={t("Worst Parse")}
+          value={dps(summary?.worstDps)}
+          sub={damage(summary?.worstTotalDamage)}
+        />
         <Stat
           label={t("DPS Range")}
           value={summary ? `${fixed(summary.rangeFraction * 100, 1)} %` : PLACEHOLDER}
+          sub={summary ? `${t("best over worst")}` : PLACEHOLDER}
         />
         <div className={styles.groupStart}>
           <Stat label={t("Abrasion Hits")} value={hits(summary?.meanAbrasionHits)} />

--- a/src/ui/features/simulation/simulation-summary-bar/summaryStats.ts
+++ b/src/ui/features/simulation/simulation-summary-bar/summaryStats.ts
@@ -1,0 +1,56 @@
+import type { ParseRun } from "../../../../engine/dpsWorker"
+
+export interface ParseSummary {
+  runCount: number
+  meanTotalDamage: number
+  meanDps: number
+  bestTotalDamage: number
+  worstTotalDamage: number
+  rangeFraction: number
+  meanAbrasionHits: number
+  meanNormalHits: number
+  meanCriticalHits: number
+  meanAffinityHits: number
+}
+
+export function parseSummary(runs: readonly ParseRun[]): ParseSummary | null {
+  if (runs.length === 0) return null
+
+  let totalDamage = 0
+  let dps = 0
+  let abrasion = 0
+  let normal = 0
+  let critical = 0
+  let affinity = 0
+  let best = runs[0].totalDamage
+  let worst = runs[0].totalDamage
+
+  for (const run of runs) {
+    totalDamage += run.totalDamage
+    dps += run.dps
+    abrasion += run.abrasionHits
+    normal += run.normalHits
+    critical += run.criticalHits
+    affinity += run.affinityHits
+    if (run.totalDamage > best) best = run.totalDamage
+    if (run.totalDamage < worst) worst = run.totalDamage
+  }
+
+  const meanTotalDamage = totalDamage / runs.length
+  return {
+    runCount: runs.length,
+    meanTotalDamage,
+    meanDps: dps / runs.length,
+    bestTotalDamage: best,
+    worstTotalDamage: worst,
+    rangeFraction: meanTotalDamage > 0 ? (best - worst) / meanTotalDamage : 0,
+    meanAbrasionHits: abrasion / runs.length,
+    meanNormalHits: normal / runs.length,
+    meanCriticalHits: critical / runs.length,
+    meanAffinityHits: affinity / runs.length,
+  }
+}
+
+export function sortedTotalDamage(runs: readonly ParseRun[]): number[] {
+  return runs.map((run) => run.totalDamage).sort((left, right) => left - right)
+}

--- a/src/ui/features/simulation/simulation-summary-bar/summaryStats.ts
+++ b/src/ui/features/simulation/simulation-summary-bar/summaryStats.ts
@@ -5,7 +5,9 @@ export interface ParseSummary {
   meanTotalDamage: number
   meanDps: number
   bestTotalDamage: number
+  bestDps: number
   worstTotalDamage: number
+  worstDps: number
   rangeFraction: number
   meanAbrasionHits: number
   meanNormalHits: number
@@ -22,8 +24,8 @@ export function parseSummary(runs: readonly ParseRun[]): ParseSummary | null {
   let normal = 0
   let critical = 0
   let affinity = 0
-  let best = runs[0].totalDamage
-  let worst = runs[0].totalDamage
+  let best = runs[0]
+  let worst = runs[0]
 
   for (const run of runs) {
     totalDamage += run.totalDamage
@@ -32,8 +34,8 @@ export function parseSummary(runs: readonly ParseRun[]): ParseSummary | null {
     normal += run.normalHits
     critical += run.criticalHits
     affinity += run.affinityHits
-    if (run.totalDamage > best) best = run.totalDamage
-    if (run.totalDamage < worst) worst = run.totalDamage
+    if (run.totalDamage > best.totalDamage) best = run
+    if (run.totalDamage < worst.totalDamage) worst = run
   }
 
   const meanTotalDamage = totalDamage / runs.length
@@ -41,9 +43,12 @@ export function parseSummary(runs: readonly ParseRun[]): ParseSummary | null {
     runCount: runs.length,
     meanTotalDamage,
     meanDps: dps / runs.length,
-    bestTotalDamage: best,
-    worstTotalDamage: worst,
-    rangeFraction: meanTotalDamage > 0 ? (best - worst) / meanTotalDamage : 0,
+    bestTotalDamage: best.totalDamage,
+    bestDps: best.dps,
+    worstTotalDamage: worst.totalDamage,
+    worstDps: worst.dps,
+    rangeFraction:
+      meanTotalDamage > 0 ? (best.totalDamage - worst.totalDamage) / meanTotalDamage : 0,
     meanAbrasionHits: abrasion / runs.length,
     meanNormalHits: normal / runs.length,
     meanCriticalHits: critical / runs.length,
@@ -51,6 +56,6 @@ export function parseSummary(runs: readonly ParseRun[]): ParseSummary | null {
   }
 }
 
-export function sortedTotalDamage(runs: readonly ParseRun[]): number[] {
-  return runs.map((run) => run.totalDamage).sort((left, right) => left - right)
+export function sortedParses(runs: readonly ParseRun[]): ParseRun[] {
+  return [...runs].sort((left, right) => left.totalDamage - right.totalDamage)
 }

--- a/src/ui/features/simulation/simulation-tab/SimulationTab.module.scss
+++ b/src/ui/features/simulation/simulation-tab/SimulationTab.module.scss
@@ -1,0 +1,27 @@
+@use "breakpoints";
+
+.resultsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 12px;
+  align-items: start;
+  transition: opacity 120ms ease;
+}
+
+.spanColumns {
+  grid-column: 1 / -1;
+}
+
+.pending {
+  opacity: 0.6;
+}
+
+.stale {
+  opacity: 0.75;
+}
+
+@include breakpoints.below(breakpoints.$bp-1100) {
+  .resultsGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/ui/features/simulation/simulation-tab/SimulationTab.tsx
+++ b/src/ui/features/simulation/simulation-tab/SimulationTab.tsx
@@ -1,0 +1,116 @@
+import { useMemo, useState } from "react"
+import type { Inputs } from "../../../../engine/types"
+import type { Rotation } from "../../../../engine/rotation"
+import { loadCustomRotations } from "../../../../storage"
+import { useI18n } from "../../../../i18n/i18nContext"
+import { useParseSimulation } from "../../../hooks/useParseSimulation"
+import { rotationOptions, selectedRotationOptionId } from "../../rotation/rotationOptions"
+import { fullNumber } from "../damageFormat"
+import { clampRunCount, DEFAULT_RUN_COUNT } from "../simulationRunSettings"
+import { SimulationControlsPanel } from "../simulation-controls-panel/SimulationControlsPanel"
+import { SimulationSummaryBar } from "../simulation-summary-bar/SimulationSummaryBar"
+import { parseSummary, sortedTotalDamage } from "../simulation-summary-bar/summaryStats"
+import { SimulationDistributionPanel } from "../simulation-distribution-panel/SimulationDistributionPanel"
+import { SimulationParseLadderPanel } from "../simulation-parse-ladder-panel/SimulationParseLadderPanel"
+import { SimulationOutcomeMixPanel } from "../simulation-outcome-mix-panel/SimulationOutcomeMixPanel"
+import styles from "./SimulationTab.module.scss"
+
+export function SimulationTab({
+  inputs,
+  engineInputs,
+  expectedTotalDamage,
+}: {
+  inputs: Inputs
+  engineInputs: Inputs
+  expectedTotalDamage: number
+}) {
+  const { t } = useI18n()
+  const [saved] = useState<Rotation[]>(() => loadCustomRotations())
+  const options = useMemo(() => rotationOptions(inputs.classId, saved), [inputs.classId, saved])
+  const [optionId, setOptionId] = useState(() => selectedRotationOptionId(inputs))
+  const [runCount, setRunCount] = useState(DEFAULT_RUN_COUNT)
+  const [ranSignature, setRanSignature] = useState<string | null>(null)
+
+  const simulation = useParseSimulation()
+
+  const signature = useMemo(
+    () => JSON.stringify({ engineInputs, optionId }),
+    [engineInputs, optionId],
+  )
+  const isStale = ranSignature !== null && ranSignature !== signature
+
+  const summary = useMemo(() => parseSummary(simulation.runs), [simulation.runs])
+  const sortedTotals = useMemo(() => sortedTotalDamage(simulation.runs), [simulation.runs])
+
+  function run() {
+    const option = options.find((candidate) => candidate.id === optionId)
+    const clamped = clampRunCount(runCount)
+    setRunCount(clamped)
+    setRanSignature(signature)
+    simulation.start({
+      inputs: engineInputs,
+      rotation: option?.rotation ?? null,
+      runCount: clamped,
+    })
+  }
+
+  const rotationName = options.find((candidate) => candidate.id === optionId)?.name ?? ""
+  const contextLabel = !summary
+    ? t("not run yet")
+    : simulation.cancelled
+      ? `${fullNumber(simulation.completedRuns)} ${t("of")} ${fullNumber(simulation.requestedRuns)} ${t("runs")} · ${t("cancelled")}`
+      : `${fullNumber(summary.runCount)} ${t("runs")} · ${rotationName}`
+
+  return (
+    <>
+      <SimulationControlsPanel
+        options={options}
+        selectedOptionId={optionId}
+        onSelectOption={setOptionId}
+        runCount={runCount}
+        onRunCountChange={setRunCount}
+        status={simulation.status}
+        progress={simulation.progress}
+        isStale={isStale}
+        onRun={run}
+        onCancel={simulation.cancel}
+      />
+      <SimulationSummaryBar
+        summary={summary}
+        contextLabel={contextLabel}
+        isPending={simulation.status === "running"}
+        isStale={isStale}
+      />
+      {summary ? (
+        <div
+          className={
+            styles.resultsGrid +
+            (simulation.status === "running" ? ` ${styles.pending}` : "") +
+            (isStale ? ` ${styles.stale}` : "")
+          }
+        >
+          <div className={`panel ${styles.spanColumns}`}>
+            <h2>{t("Damage Distribution")}</h2>
+            <SimulationDistributionPanel
+              sortedTotals={sortedTotals}
+              meanTotalDamage={summary.meanTotalDamage}
+              expectedTotalDamage={expectedTotalDamage}
+            />
+          </div>
+          <div className="panel">
+            <h2>{t("Parse Ladder")}</h2>
+            <SimulationParseLadderPanel sortedTotals={sortedTotals} />
+          </div>
+          <div className="panel">
+            <h2>{t("Outcome Mix")}</h2>
+            <SimulationOutcomeMixPanel summary={summary} expectedRates={simulation.expectedRates} />
+          </div>
+        </div>
+      ) : (
+        <div className="empty-tab">
+          {t("Pick a rotation and a run count, then Run to simulate parses.")}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/ui/features/simulation/simulation-tab/SimulationTab.tsx
+++ b/src/ui/features/simulation/simulation-tab/SimulationTab.tsx
@@ -9,7 +9,7 @@ import { fullNumber } from "../damageFormat"
 import { clampRunCount, DEFAULT_RUN_COUNT } from "../simulationRunSettings"
 import { SimulationControlsPanel } from "../simulation-controls-panel/SimulationControlsPanel"
 import { SimulationSummaryBar } from "../simulation-summary-bar/SimulationSummaryBar"
-import { parseSummary, sortedTotalDamage } from "../simulation-summary-bar/summaryStats"
+import { parseSummary, sortedParses } from "../simulation-summary-bar/summaryStats"
 import { SimulationDistributionPanel } from "../simulation-distribution-panel/SimulationDistributionPanel"
 import { SimulationParseLadderPanel } from "../simulation-parse-ladder-panel/SimulationParseLadderPanel"
 import { SimulationOutcomeMixPanel } from "../simulation-outcome-mix-panel/SimulationOutcomeMixPanel"
@@ -18,11 +18,11 @@ import styles from "./SimulationTab.module.scss"
 export function SimulationTab({
   inputs,
   engineInputs,
-  expectedTotalDamage,
+  expectedDps,
 }: {
   inputs: Inputs
   engineInputs: Inputs
-  expectedTotalDamage: number
+  expectedDps: number
 }) {
   const { t } = useI18n()
   const [saved] = useState<Rotation[]>(() => loadCustomRotations())
@@ -40,7 +40,7 @@ export function SimulationTab({
   const isStale = ranSignature !== null && ranSignature !== signature
 
   const summary = useMemo(() => parseSummary(simulation.runs), [simulation.runs])
-  const sortedTotals = useMemo(() => sortedTotalDamage(simulation.runs), [simulation.runs])
+  const sorted = useMemo(() => sortedParses(simulation.runs), [simulation.runs])
 
   function run() {
     const option = options.find((candidate) => candidate.id === optionId)
@@ -90,16 +90,17 @@ export function SimulationTab({
           }
         >
           <div className={`panel ${styles.spanColumns}`}>
-            <h2>{t("Damage Distribution")}</h2>
+            <h2>{t("DPS Distribution")}</h2>
             <SimulationDistributionPanel
-              sortedTotals={sortedTotals}
-              meanTotalDamage={summary.meanTotalDamage}
-              expectedTotalDamage={expectedTotalDamage}
+              sorted={sorted}
+              meanDps={summary.meanDps}
+              expectedDps={expectedDps}
+              rotationDuration={simulation.rotationDuration}
             />
           </div>
           <div className="panel">
             <h2>{t("Parse Ladder")}</h2>
-            <SimulationParseLadderPanel sortedTotals={sortedTotals} />
+            <SimulationParseLadderPanel sorted={sorted} />
           </div>
           <div className="panel">
             <h2>{t("Outcome Mix")}</h2>

--- a/src/ui/features/simulation/simulationRunSettings.ts
+++ b/src/ui/features/simulation/simulationRunSettings.ts
@@ -1,0 +1,11 @@
+import { PARSE_RUN_CAP } from "../../../engine/dpsWorker"
+
+export const DEFAULT_RUN_COUNT = 1000
+export const MIN_RUN_COUNT = 100
+export const MAX_RUN_COUNT = PARSE_RUN_CAP
+export const RUN_COUNT_STEP = 100
+
+export function clampRunCount(requested: number): number {
+  if (!Number.isFinite(requested)) return DEFAULT_RUN_COUNT
+  return Math.min(MAX_RUN_COUNT, Math.max(MIN_RUN_COUNT, Math.round(requested)))
+}

--- a/src/ui/hooks/dpsWorkerClient.ts
+++ b/src/ui/hooks/dpsWorkerClient.ts
@@ -1,19 +1,32 @@
 import type { WorkerRequest, WorkerResponse } from "../../engine/dpsWorker"
 import DpsWorker from "../../engine/dpsWorker?worker"
-import { WORKER_DEBOUNCE_MS } from "./workerDebounce"
+import { debounceMsFor } from "./workerDebounce"
 
 type RequestKind = WorkerRequest["kind"]
-type ResponseOfKind<K extends RequestKind> = Extract<WorkerResponse, { kind: K }>
+type ResponseKind = WorkerResponse["kind"]
+type ResultKind = Extract<RequestKind, ResponseKind>
+type ResponseOfKind<K extends ResultKind> = Extract<WorkerResponse, { kind: K }>
 type ResponseListener = (response: WorkerResponse) => void
 
 type WithoutReqId<Request> = Request extends unknown ? Omit<Request, "reqId"> : never
 export type UnsentRequest = WithoutReqId<WorkerRequest>
 
+export type ProgressResponse = Extract<WorkerResponse, { kind: "parseSimulationProgress" }>
+type ProgressListener = (progress: ProgressResponse) => void
+
 const MAX_POOL_SIZE = 4
+
+const PROGRESS_OWNER_KIND: Partial<Record<ResponseKind, RequestKind>> = {
+  parseSimulationProgress: "parseSimulation",
+}
+const CANCEL_KIND_BY_KIND: Partial<Record<RequestKind, RequestKind>> = {
+  parseSimulation: "parseSimulationCancel",
+}
 
 interface KindState {
   responseListeners: Set<ResponseListener>
   pendingListeners: Set<() => void>
+  progressListeners: Set<ProgressListener>
   queued: WorkerRequest | null
   debounceHandle: ReturnType<typeof setTimeout> | null
   latestReqId: number
@@ -32,6 +45,7 @@ function stateFor(kind: RequestKind): KindState {
   const created: KindState = {
     responseListeners: new Set(),
     pendingListeners: new Set(),
+    progressListeners: new Set(),
     queued: null,
     debounceHandle: null,
     latestReqId: -1,
@@ -52,7 +66,7 @@ function workerFor(kind: RequestKind): Worker {
   if (assigned) return assigned
   if (pool.length < poolSize()) {
     const worker = new DpsWorker()
-    worker.onmessage = (event: MessageEvent<WorkerResponse>) => deliver(event.data)
+    worker.onmessage = (event: MessageEvent<WorkerResponse>) => receive(event.data)
     pool.push(worker)
   }
   const worker = pool[workerByKind.size % pool.length]
@@ -66,15 +80,35 @@ function setPending(state: KindState, isPending: boolean): void {
   for (const listener of state.pendingListeners) listener()
 }
 
+function receive(response: WorkerResponse): void {
+  const owner = PROGRESS_OWNER_KIND[response.kind]
+  if (owner) deliverProgress(owner, response as ProgressResponse)
+  else deliver(response)
+}
+
+function deliverProgress(kind: RequestKind, progress: ProgressResponse): void {
+  const state = stateFor(kind)
+  if (progress.reqId !== state.latestReqId) return
+  for (const listener of state.progressListeners) listener(progress)
+}
+
 function deliver(response: WorkerResponse): void {
-  const state = stateFor(response.kind)
+  const state = stateFor(response.kind as RequestKind)
   if (response.reqId === state.latestReqId) setPending(state, false)
   if (response.reqId <= state.lastDeliveredReqId) return
   state.lastDeliveredReqId = response.reqId
   for (const listener of state.responseListeners) listener(response)
 }
 
-function abandonRequests(state: KindState): void {
+function postCancel(kind: RequestKind, state: KindState): void {
+  const cancelKind = CANCEL_KIND_BY_KIND[kind]
+  if (!cancelKind) return
+  if (state.latestReqId <= state.lastDeliveredReqId) return
+  workerFor(kind).postMessage({ kind: cancelKind, reqId: state.latestReqId })
+}
+
+function abandonRequests(kind: RequestKind, state: KindState): void {
+  postCancel(kind, state)
   if (state.debounceHandle !== null) clearTimeout(state.debounceHandle)
   state.debounceHandle = null
   state.queued = null
@@ -85,19 +119,35 @@ function abandonRequests(state: KindState): void {
 export function postToDpsWorker(unsent: UnsentRequest): void {
   const request = { ...unsent, reqId: ++lastAssignedReqId } as WorkerRequest
   const state = stateFor(request.kind)
+  postCancel(request.kind, state)
   state.queued = request
   state.latestReqId = request.reqId
   setPending(state, true)
   if (state.debounceHandle !== null) clearTimeout(state.debounceHandle)
+  state.debounceHandle = null
+  const delayMs = debounceMsFor(request.kind)
+  if (delayMs <= 0) {
+    state.queued = null
+    workerFor(request.kind).postMessage(request)
+    return
+  }
   state.debounceHandle = setTimeout(() => {
     state.debounceHandle = null
     const queued = state.queued
     state.queued = null
     if (queued) workerFor(queued.kind).postMessage(queued)
-  }, WORKER_DEBOUNCE_MS)
+  }, delayMs)
 }
 
-export function subscribeToDpsWorker<K extends RequestKind>(
+export function cancelDpsWorkerRequest(kind: RequestKind): void {
+  const state = stateFor(kind)
+  if (state.debounceHandle !== null) clearTimeout(state.debounceHandle)
+  state.debounceHandle = null
+  state.queued = null
+  postCancel(kind, state)
+}
+
+export function subscribeToDpsWorker<K extends ResultKind>(
   kind: K,
   listener: (response: ResponseOfKind<K>) => void,
 ): () => void {
@@ -106,7 +156,18 @@ export function subscribeToDpsWorker<K extends RequestKind>(
   state.responseListeners.add(typedListener)
   return () => {
     state.responseListeners.delete(typedListener)
-    if (state.responseListeners.size === 0) abandonRequests(state)
+    if (state.responseListeners.size === 0) abandonRequests(kind, state)
+  }
+}
+
+export function subscribeToDpsWorkerProgress(
+  kind: RequestKind,
+  listener: ProgressListener,
+): () => void {
+  const state = stateFor(kind)
+  state.progressListeners.add(listener)
+  return () => {
+    state.progressListeners.delete(listener)
   }
 }
 

--- a/src/ui/hooks/useParseSimulation.ts
+++ b/src/ui/hooks/useParseSimulation.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from "react"
+import type { ExpectedOutcomeRates, ParseRun } from "../../engine/dpsWorker"
+import type { Inputs } from "../../engine/types"
+import type { Rotation } from "../../engine/rotation"
+import {
+  cancelDpsWorkerRequest,
+  postToDpsWorker,
+  subscribeToDpsWorker,
+  subscribeToDpsWorkerProgress,
+} from "./dpsWorkerClient"
+
+export type SimulationStatus = "idle" | "running" | "done" | "cancelled"
+
+export interface ParseSimulationRequest {
+  inputs: Inputs
+  rotation: Rotation | null
+  runCount: number
+}
+
+interface Completed {
+  runs: ParseRun[]
+  expectedRates: ExpectedOutcomeRates | null
+  rotationDuration: number
+  requestedRuns: number
+  completedRuns: number
+  cancelled: boolean
+}
+
+export interface ParseSimulationState extends Completed {
+  progress: { done: number; total: number }
+  status: SimulationStatus
+  start(request: ParseSimulationRequest): void
+  cancel(): void
+}
+
+const NO_RUNS: ParseRun[] = []
+const NO_PROGRESS = { done: 0, total: 0 }
+const NOT_RUN: Completed = {
+  runs: NO_RUNS,
+  expectedRates: null,
+  rotationDuration: 0,
+  requestedRuns: 0,
+  completedRuns: 0,
+  cancelled: false,
+}
+
+export function useParseSimulation(): ParseSimulationState {
+  const [completed, setCompleted] = useState<Completed | null>(null)
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
+  const [isRunning, setIsRunning] = useState(false)
+
+  useEffect(() => {
+    const stopResults = subscribeToDpsWorker("parseSimulation", (response) => {
+      setIsRunning(false)
+      setProgress({ done: response.completedRuns, total: response.requestedRuns })
+      setCompleted({
+        runs: response.runs,
+        expectedRates: response.expectedRates,
+        rotationDuration: response.rotationDuration,
+        requestedRuns: response.requestedRuns,
+        completedRuns: response.completedRuns,
+        cancelled: response.cancelled,
+      })
+    })
+    const stopProgress = subscribeToDpsWorkerProgress("parseSimulation", ({ done, total }) =>
+      setProgress({ done, total }),
+    )
+    return () => {
+      stopResults()
+      stopProgress()
+    }
+  }, [])
+
+  const start = useCallback(({ inputs, rotation, runCount }: ParseSimulationRequest) => {
+    setIsRunning(true)
+    setProgress({ done: 0, total: runCount })
+    postToDpsWorker({
+      kind: "parseSimulation",
+      inputs,
+      rotation,
+      runs: runCount,
+      seed: (Date.now() * 2654435761) | 0,
+    })
+  }, [])
+
+  const cancel = useCallback(() => cancelDpsWorkerRequest("parseSimulation"), [])
+
+  const status: SimulationStatus = isRunning
+    ? "running"
+    : completed === null
+      ? "idle"
+      : completed.cancelled
+        ? "cancelled"
+        : "done"
+
+  return { ...(completed ?? NOT_RUN), progress: progress ?? NO_PROGRESS, status, start, cancel }
+}

--- a/src/ui/hooks/workerDebounce.ts
+++ b/src/ui/hooks/workerDebounce.ts
@@ -1,1 +1,12 @@
+import type { WorkerRequest } from "../../engine/dpsWorker"
+
 export const WORKER_DEBOUNCE_MS = 150
+
+const DEBOUNCE_MS_BY_KIND: Partial<Record<WorkerRequest["kind"], number>> = {
+  parseSimulation: 0,
+  parseSimulationCancel: 0,
+}
+
+export function debounceMsFor(kind: WorkerRequest["kind"]): number {
+  return DEBOUNCE_MS_BY_KIND[kind] ?? WORKER_DEBOUNCE_MS
+}

--- a/tests/engine/bitterSeason.test.ts
+++ b/tests/engine/bitterSeason.test.ts
@@ -8,6 +8,7 @@ import {
   BITTER_SEASON_MAX_STACKS,
 } from "../../src/engine/buffs/bitterSeason"
 import { bitterSeasonTuningAtTier } from "../../src/data/innerWays/bitterSeason"
+import { mulberry32 } from "../../src/engine/rng"
 import { ZENITH_MAX_EXTENDED_DURATION_FRAMES } from "../../src/data/innerWays/swordHorizonZenith"
 import { allowedInnerWaysForClass, getSchool } from "../../src/engine/panel"
 
@@ -473,5 +474,26 @@ describe("Bitter Season — Bellstrike Umbra engine integration", () => {
     const baseDot = base.perSkill.find((row) => row.name === DOT_ROW_NAME)!.expectedDamage
     const bumpedDot = bumped.perSkill.find((row) => row.name === DOT_ROW_NAME)!.expectedDamage
     expect(bumpedDot).toBeGreaterThan(baseDot)
+  })
+})
+
+describe("bitterSeasonStackSchedule under a parse run", () => {
+  const hits = Array.from({ length: 60 }, (_unused, index) => index * 0.3)
+
+  it("averages 500 runs when given no rng", () => {
+    const schedule = bitterSeasonStackSchedule(hits, 0.15, 18)
+    const fractional = Array.from({ length: 200 }, (_unused, step) =>
+      schedule.expectedStacksAtTime(step * 0.05),
+    ).filter((stacks) => !Number.isInteger(stacks))
+    expect(fractional.length).toBeGreaterThan(0)
+  })
+
+  it("runs a single trajectory when given an rng", () => {
+    const schedule = bitterSeasonStackSchedule(hits, 0.15, 18, mulberry32(404))
+    for (let step = 0; step < 200; step++) {
+      const stacks = schedule.expectedStacksAtTime(step * 0.05)
+      expect(Number.isInteger(stacks)).toBe(true)
+      expect(stacks).toBeLessThanOrEqual(BITTER_SEASON_MAX_STACKS)
+    }
   })
 })

--- a/tests/engine/concentration.test.ts
+++ b/tests/engine/concentration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { concentrationActiveProbSchedule } from "../../src/engine/buffs/concentration"
+import { mulberry32 } from "../../src/engine/rng"
 
 function hitTrain(duration: number, interval = 0.3): number[] {
   const hits: number[] = []
@@ -51,6 +52,25 @@ describe("concentrationActiveProbSchedule", () => {
     const sched = concentrationActiveProbSchedule(hitTrain(120, 0.05), 1, 120)
     for (let t = 0; t <= 120; t += 5) {
       expect(sched.getActiveProbAtTime(t)).toBeLessThanOrEqual(1)
+    }
+  })
+})
+
+describe("concentrationActiveProbSchedule under a parse run", () => {
+  const hits = hitTrain(60.7)
+
+  it("averages 500 runs when given no rng", () => {
+    const sched = concentrationActiveProbSchedule(hits, 0.4227, 60.7)
+    const partial = Array.from({ length: 200 }, (_unused, step) =>
+      sched.getActiveProbAtTime(step * 0.05),
+    ).filter((prob) => prob > 0 && prob < 1)
+    expect(partial.length).toBeGreaterThan(0)
+  })
+
+  it("runs a single trajectory when given an rng", () => {
+    const sched = concentrationActiveProbSchedule(hits, 0.4227, 60.7, mulberry32(77))
+    for (let step = 0; step < 200; step++) {
+      expect([0, 1]).toContain(sched.getActiveProbAtTime(step * 0.05))
     }
   })
 })

--- a/tests/engine/dpsWorkerOffload.test.ts
+++ b/tests/engine/dpsWorkerOffload.test.ts
@@ -3,10 +3,14 @@
 import { describe, expect, it } from "vitest"
 import {
   computeGearAnalysisRequest,
+  computeParseSimulation,
   computeRankingRequest,
   computeRotationDps,
   computeSetTiles,
+  PARSE_RUN_CAP,
+  type ParseSimulationWorkerRequest,
 } from "../../src/engine/dpsWorker"
+import { RUN_SEED_STRIDE } from "../../src/engine/rng"
 import { computeGearAnalysis } from "../../src/engine/gearAnalysis"
 import { builtinRotationsForClass, defaultRotationForClass } from "../../src/engine/builtinLibrary"
 import { computeRanking } from "../../src/engine/itemRanking"
@@ -143,5 +147,83 @@ describe("computeRotationDps", () => {
     expect(res.dpsByOptionId[builtin.id]).toBe(
       runEngine({ ...umbraInputs, activeCustomRotation: builtin }).dps,
     )
+  })
+})
+
+describe("computeParseSimulation", () => {
+  const rotation = defaultRotationForClass("bellstrikeUmbra")
+  const seed = 20260816
+
+  function request(overrides: Partial<ParseSimulationWorkerRequest> = {}) {
+    return { reqId: 1, inputs: umbraInputs, rotation, runs: 6, seed, ...overrides }
+  }
+
+  it("echoes reqId", async () => {
+    expect((await computeParseSimulation(request({ reqId: 91 }))).reqId).toBe(91)
+  })
+
+  it("matches a direct runEngine loop over the same seeds", async () => {
+    const res = await computeParseSimulation(request())
+    const runInputs = {
+      ...umbraInputs,
+      activeCustomRotation: rotation,
+      selectedBuiltinRotationId: null,
+    }
+
+    expect(res.runs).toHaveLength(6)
+    res.runs.forEach((run, index) => {
+      const expected = runEngine(runInputs, {
+        seed: (seed + index * RUN_SEED_STRIDE) | 0,
+        collect: "totals",
+      })
+      expect(run.totalDamage).toBe(expected.totalDamage)
+      expect(run.dps).toBe(expected.dps)
+      expect(run.criticalHits).toBe(expected.outcomeCounts!.crit)
+      expect(run.affinityHits).toBe(expected.outcomeCounts!.affinity)
+      expect(run.abrasionHits).toBe(expected.outcomeCounts!.abrasion)
+      expect(run.normalHits).toBe(expected.outcomeCounts!.normal)
+    })
+  })
+
+  it("decorrelates consecutive run seeds", async () => {
+    const res = await computeParseSimulation(request({ runs: 20 }))
+    const totals = new Set(res.runs.map((run) => run.totalDamage))
+    expect(totals.size).toBe(20)
+  })
+
+  it("caps the run count", async () => {
+    const res = await computeParseSimulation(
+      request({ runs: PARSE_RUN_CAP + 500 }),
+      undefined,
+      () => true,
+    )
+    expect(res.requestedRuns).toBe(PARSE_RUN_CAP)
+  })
+
+  it("reports progress once per chunk and ends at total", async () => {
+    const seen: { done: number; total: number }[] = []
+    const res = await computeParseSimulation(request({ runs: 12 }), (done, total) =>
+      seen.push({ done, total }),
+    )
+    expect(seen.length).toBeGreaterThan(0)
+    expect(seen.every((entry) => entry.total === 12)).toBe(true)
+    expect(seen[seen.length - 1].done).toBe(12)
+    expect(res.cancelled).toBe(false)
+    expect(res.completedRuns).toBe(12)
+  })
+
+  it("stops early when cancelled and keeps the runs it completed", async () => {
+    const res = await computeParseSimulation(request({ runs: 500 }), undefined, () => true)
+    expect(res.cancelled).toBe(true)
+    expect(res.completedRuns).toBeLessThan(500)
+    expect(res.runs).toHaveLength(res.completedRuns)
+    expect(res.completedRuns).toBeGreaterThan(0)
+  })
+
+  it("reports the expected outcome rates the runs were drawn against", async () => {
+    const res = await computeParseSimulation(request({ runs: 4 }))
+    const rates = res.expectedRates!
+    const sum = rates.abrasion + rates.normal + rates.crit + rates.affinity
+    expect(sum).toBeCloseTo(1, 6)
   })
 })

--- a/tests/engine/hawkwing.test.ts
+++ b/tests/engine/hawkwing.test.ts
@@ -5,6 +5,7 @@ import {
   HAWKWING_STEP_SEC,
   hawkwingStacksSchedule,
 } from "../../src/engine/buffs/hawkwing"
+import { mulberry32 } from "../../src/engine/rng"
 
 function hitTrain(duration: number, interval = 0.3): number[] {
   const hits: number[] = []
@@ -73,5 +74,26 @@ describe("hawkwingStacksSchedule", () => {
     expect(
       averageBonus(hitTrain(rotationDurationSec, 0.05), 1, rotationDurationSec),
     ).toBeLessThanOrEqual(0.1)
+  })
+})
+
+describe("hawkwingStacksSchedule under a parse run", () => {
+  const hits = hitTrain(60.7)
+
+  it("averages 500 runs when given no rng", () => {
+    const schedule = hawkwingStacksSchedule(hits, 0.4, 60.7)
+    const fractional = Array.from({ length: 200 }, (_unused, step) =>
+      schedule.getExpectedStacksAtTime(step * HAWKWING_STEP_SEC),
+    ).filter((stacks) => !Number.isInteger(stacks))
+    expect(fractional.length).toBeGreaterThan(0)
+  })
+
+  it("runs a single trajectory when given an rng", () => {
+    const schedule = hawkwingStacksSchedule(hits, 0.4, 60.7, mulberry32(31))
+    for (let step = 0; step < 100; step++) {
+      const stacks = schedule.getExpectedStacksAtTime(step * HAWKWING_STEP_SEC)
+      expect(Number.isInteger(stacks)).toBe(true)
+      expect(stacks).toBeLessThanOrEqual(HAWKWING_MAX_STACKS)
+    }
   })
 })

--- a/tests/engine/parseSimulation.test.ts
+++ b/tests/engine/parseSimulation.test.ts
@@ -1,0 +1,198 @@
+// Scoped to Bellstrike Umbra — see CLAUDE.md § "Implemented classes".
+import { describe, expect, it } from "vitest"
+import { runEngine } from "../../src/engine/dps"
+import { computeSkillDamage, type FormulaContext } from "../../src/engine/formula"
+import { defaultInputs } from "../../src/engine/defaults"
+import { withDerivedStats } from "../../src/engine/derivedInputs"
+import { applyArmorSet, applyBowSet, buildContext } from "../../src/engine/panel"
+import { mulberry32, RUN_SEED_STRIDE } from "../../src/engine/rng"
+import { SET_ID } from "../../src/data/sets/ids"
+import type { Inputs } from "../../src/engine/types"
+
+const umbra: Inputs = { ...defaultInputs, classId: "bellstrikeUmbra" }
+
+function engineInputs(variant: Inputs = umbra): Inputs {
+  return applyBowSet(applyArmorSet(withDerivedStats(variant)))
+}
+
+const procFree = engineInputs({ ...umbra, set: null, mindMethods: defaultInputs.mindMethods })
+const withProcs = engineInputs({ ...umbra, set: SET_ID.hawking })
+
+function sampled(inputs: Inputs, seed: number) {
+  return runEngine(inputs, { seed, collect: "totals" })
+}
+
+function context(): FormulaContext {
+  return buildContext(procFree)
+}
+
+const FLAT_ART = {
+  name: "probe",
+  physMultiplier: 1,
+  attributeMultiplier: 1,
+  skillType: "weapon",
+}
+
+describe("a sampled engine run", () => {
+  it("leaves the deterministic result byte-identical when no seed is given", () => {
+    const first = runEngine(procFree)
+    const second = runEngine(procFree)
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+    expect(first.outcomeCounts).toBeUndefined()
+    expect(first.expectedOutcomeShare).toBeUndefined()
+  })
+
+  it("preserves totalDamage and dps exactly when detail collection is off", () => {
+    const full = runEngine(procFree, { seed: 11 })
+    const totalsOnly = runEngine(procFree, { seed: 11, collect: "totals" })
+    expect(totalsOnly.totalDamage).toBe(full.totalDamage)
+    expect(totalsOnly.dps).toBe(full.dps)
+    expect(totalsOnly.outcomeCounts).toEqual(full.outcomeCounts)
+  })
+
+  it("drops the timeline, casts and buff windows it was told not to collect", () => {
+    const totalsOnly = runEngine(procFree, { seed: 3, collect: "totals" })
+    expect(totalsOnly.timeline).toEqual([])
+    expect(totalsOnly.casts).toEqual([])
+    expect(totalsOnly.buffWindows).toEqual([])
+    expect(totalsOnly.perSkill).toEqual([])
+  })
+
+  it("same seed produces an identical run", () => {
+    expect(sampled(procFree, 4242).totalDamage).toBe(sampled(procFree, 4242).totalDamage)
+    expect(sampled(procFree, 4242).outcomeCounts).toEqual(sampled(procFree, 4242).outcomeCounts)
+  })
+
+  it("different seeds produce different totals", () => {
+    expect(sampled(procFree, 1).totalDamage).not.toBe(sampled(procFree, 2).totalDamage)
+  })
+
+  it("counts every damage event exactly once across the four outcome tallies", () => {
+    const result = runEngine(procFree, { seed: 77 })
+    const counts = result.outcomeCounts!
+    const tallied = counts.abrasion + counts.normal + counts.crit + counts.affinity
+    const events = (result.timeline ?? []).filter((entry) => entry.inWindow).length
+    expect(tallied).toBe(events)
+  })
+
+  it("mean of sampled runs converges to the deterministic total for a build with no proc mechanics", () => {
+    const expected = runEngine(procFree).totalDamage
+    const runs = 2000
+    let sum = 0
+    for (let index = 0; index < runs; index++) {
+      sum += sampled(procFree, (index * RUN_SEED_STRIDE) | 0).totalDamage
+    }
+    expect(Math.abs(sum / runs - expected) / expected).toBeLessThan(0.01)
+  }, 30000)
+
+  it("mean of sampled runs tracks the deterministic total within 5% when proc mechanics round an expectation", () => {
+    const expected = runEngine(withProcs).totalDamage
+    const runs = 400
+    let sum = 0
+    for (let index = 0; index < runs; index++) {
+      sum += sampled(withProcs, (index * RUN_SEED_STRIDE) | 0).totalDamage
+    }
+    expect(Math.abs(sum / runs - expected) / expected).toBeLessThan(0.05)
+  })
+})
+
+describe("a sampled hit", () => {
+  it("pins abrasion to the minimum roll and affinity to the maximum", () => {
+    const ctx = context()
+    const cells = computeSkillDamage(FLAT_ART, ctx, 1).cells
+    const tail = (1 + cells.H) * (cells.I || 1) * (1 + cells.E)
+    const abrasion = computeSkillDamage(FLAT_ART, ctx, 1, () => 0).rolled!
+    expect(abrasion.outcome).toBe("abrasion")
+    expect(abrasion.damage).toBeCloseTo(cells.DZ * tail, 6)
+
+    const affinityDraw = cells.AL + cells.AN + cells.AP / 2
+    const affinity = computeSkillDamage(FLAT_ART, ctx, 1, () => affinityDraw).rolled!
+    expect(affinity.outcome).toBe("affinity")
+    expect(affinity.damage).toBeCloseTo(cells.ED * tail, 6)
+  })
+
+  it("rolls a normal hit uniformly between normalMin and normalMax", () => {
+    const ctx = context()
+    const cells = computeSkillDamage(FLAT_ART, ctx, 1).cells
+    const tail = (1 + cells.H) * (cells.I || 1) * (1 + cells.E)
+    const normalDraw = 1 - 1e-9
+
+    const draws = [normalDraw, 0]
+    const low = computeSkillDamage(FLAT_ART, ctx, 1, () => draws.shift() ?? 0).rolled!
+    expect(low.outcome).toBe("normal")
+    expect(low.damage).toBeCloseTo(cells.normalMin * tail, 6)
+
+    const highDraws = [normalDraw, 1 - 1e-12]
+    const high = computeSkillDamage(FLAT_ART, ctx, 1, () => highDraws.shift() ?? 0).rolled!
+    expect(high.damage).toBeCloseTo(cells.normalMax * tail, 4)
+  })
+
+  it("weights the four outcomes by the chances it reports", () => {
+    const ctx = context()
+    const rng = mulberry32(9001)
+    const seen = { abrasion: 0, normal: 0, crit: 0, affinity: 0 }
+    const samples = 40000
+    let chance = computeSkillDamage(FLAT_ART, ctx, 1, () => 0).rolled!.chance
+    for (let index = 0; index < samples; index++) {
+      const rolled = computeSkillDamage(FLAT_ART, ctx, 1, rng).rolled!
+      seen[rolled.outcome] += 1
+      chance = rolled.chance
+    }
+    expect(seen.crit / samples).toBeCloseTo(chance.crit, 2)
+    expect(seen.affinity / samples).toBeCloseTo(chance.affinity, 2)
+    expect(seen.abrasion / samples).toBeCloseTo(chance.abrasion, 2)
+  })
+
+  it("honours guaranteedNormal and guaranteedCrit in a sampled roll", () => {
+    const ctx = context()
+    const normal = computeSkillDamage({ ...FLAT_ART, guaranteedNormal: 1 }, ctx, 1, () => 0.99)
+    expect(normal.rolled!.outcome).toBe("normal")
+    expect(normal.rolled!.chance.normal).toBe(1)
+
+    const crit = computeSkillDamage({ ...FLAT_ART, guaranteedCrit: 1 }, ctx, 1, () => 0)
+    expect(crit.rolled!.outcome).toBe("crit")
+    expect(crit.rolled!.chance.crit).toBe(1)
+  })
+
+  it("treats a conditional final crit promotion as a guaranteed crit when sampling", () => {
+    const ctx = context()
+    const art = {
+      ...FLAT_ART,
+      conditionalFinalCrit: { threshold: 0, bonusBelowThreshold: 0 },
+    }
+    const rolled = computeSkillDamage(art, ctx, 1, () => 0).rolled!
+    expect(rolled.outcome).toBe("crit")
+    expect(rolled.chance.crit).toBe(1)
+  })
+
+  it("never draws abrasion when precision is guaranteed", () => {
+    const ctx = context()
+    const rolled = computeSkillDamage(
+      { ...FLAT_ART, guaranteedPrecision: 1 },
+      ctx,
+      1,
+      () => 0,
+    ).rolled!
+    expect(rolled.outcome).not.toBe("abrasion")
+    expect(rolled.chance.abrasion).toBe(0)
+  })
+
+  it("always draws the normal track for a Heavenwork row", () => {
+    const ctx = context()
+    const rolled = computeSkillDamage(
+      { ...FLAT_ART, skillType: "Heavenwork" },
+      ctx,
+      1,
+      () => 0,
+    ).rolled!
+    expect(rolled.outcome).toBe("normal")
+    expect(rolled.chance.normal).toBe(1)
+  })
+
+  it("reports the same expected damage whether or not it also rolled", () => {
+    const ctx = context()
+    const plain = computeSkillDamage(FLAT_ART, ctx, 1)
+    const rolling = computeSkillDamage(FLAT_ART, ctx, 1, () => 0.5)
+    expect(rolling.expectedDamage).toBe(plain.expectedDamage)
+  })
+})

--- a/tests/ui/dpsWorkerClient.test.ts
+++ b/tests/ui/dpsWorkerClient.test.ts
@@ -50,6 +50,28 @@ function reqIdOfLastPost(workerIndex: number): number {
   return (posted[posted.length - 1] as WorkerRequest).reqId
 }
 
+function parseSimulationRequest(): UnsentRequest {
+  return { kind: "parseSimulation", inputs: defaultInputs, rotation: null, runs: 10, seed: 1 }
+}
+
+function parseSimulationResponse(reqId: number): WorkerResponse {
+  return {
+    kind: "parseSimulation",
+    reqId,
+    runs: [],
+    expectedRates: null,
+    rotationDuration: 0,
+    requestedRuns: 10,
+    completedRuns: 10,
+    cancelled: false,
+    warnings: [],
+  }
+}
+
+function progressResponse(reqId: number, done: number): WorkerResponse {
+  return { kind: "parseSimulationProgress", reqId, done, total: 10 }
+}
+
 beforeEach(() => {
   vi.useFakeTimers()
 })
@@ -197,7 +219,7 @@ describe("dpsWorkerClient", () => {
 
   it("spreads every request kind over a pool bounded by the core count", async () => {
     const client = await freshClient(3)
-    const kinds: WorkerRequest["kind"][] = [
+    const kinds = [
       "dpsDeltas",
       "retunement",
       "reattunement",
@@ -205,7 +227,7 @@ describe("dpsWorkerClient", () => {
       "ranking",
       "setTiles",
       "graduation",
-    ]
+    ] as const
     for (const kind of kinds) {
       client.subscribeToDpsWorker(kind, () => {})
       client.postToDpsWorker({ ...rankingRequest(), kind } as UnsentRequest)
@@ -214,5 +236,84 @@ describe("dpsWorkerClient", () => {
 
     expect(created).toHaveLength(2)
     expect(created.every((worker) => worker.posted.length > 0)).toBe(true)
+  })
+
+  it("posts a parse simulation without waiting out the debounce", async () => {
+    const client = await freshClient()
+    client.subscribeToDpsWorker("parseSimulation", () => {})
+
+    client.postToDpsWorker(parseSimulationRequest())
+
+    expect(created[0].posted).toHaveLength(1)
+  })
+
+  it("routes progress without retiring the request", async () => {
+    const client = await freshClient()
+    const seen: number[] = []
+    client.subscribeToDpsWorker("parseSimulation", () => seen.push(-1))
+    client.subscribeToDpsWorkerProgress("parseSimulation", ({ done }) => seen.push(done))
+
+    client.postToDpsWorker(parseSimulationRequest())
+    const reqId = reqIdOfLastPost(0)
+    respond(0, progressResponse(reqId, 3))
+    respond(0, progressResponse(reqId, 7))
+
+    expect(seen).toEqual([3, 7])
+    expect(client.isDpsWorkerPending("parseSimulation")).toBe(true)
+
+    respond(0, parseSimulationResponse(reqId))
+    expect(seen).toEqual([3, 7, -1])
+    expect(client.isDpsWorkerPending("parseSimulation")).toBe(false)
+  })
+
+  it("ignores progress from a superseded run", async () => {
+    const client = await freshClient()
+    const seen: number[] = []
+    client.subscribeToDpsWorker("parseSimulation", () => {})
+    client.subscribeToDpsWorkerProgress("parseSimulation", ({ done }) => seen.push(done))
+
+    client.postToDpsWorker(parseSimulationRequest())
+    const stale = reqIdOfLastPost(0)
+    client.postToDpsWorker(parseSimulationRequest())
+
+    respond(0, progressResponse(stale, 5))
+    expect(seen).toEqual([])
+  })
+
+  it("tells the worker to stop the run it is superseding", async () => {
+    const client = await freshClient()
+    client.subscribeToDpsWorker("parseSimulation", () => {})
+
+    client.postToDpsWorker(parseSimulationRequest())
+    const first = reqIdOfLastPost(0)
+    client.postToDpsWorker(parseSimulationRequest())
+
+    expect(created[0].posted[1]).toEqual({ kind: "parseSimulationCancel", reqId: first })
+  })
+
+  it("keeps the partial result of a run the user cancelled", async () => {
+    const client = await freshClient()
+    const delivered: number[] = []
+    client.subscribeToDpsWorker("parseSimulation", (response) => delivered.push(response.reqId))
+
+    client.postToDpsWorker(parseSimulationRequest())
+    const reqId = reqIdOfLastPost(0)
+    client.cancelDpsWorkerRequest("parseSimulation")
+
+    expect(created[0].posted[1]).toEqual({ kind: "parseSimulationCancel", reqId })
+
+    respond(0, parseSimulationResponse(reqId))
+    expect(delivered).toEqual([reqId])
+  })
+
+  it("cancels the sweep when the last listener unsubscribes", async () => {
+    const client = await freshClient()
+    const stop = client.subscribeToDpsWorker("parseSimulation", () => {})
+
+    client.postToDpsWorker(parseSimulationRequest())
+    const reqId = reqIdOfLastPost(0)
+    stop()
+
+    expect(created[0].posted[1]).toEqual({ kind: "parseSimulationCancel", reqId })
   })
 })

--- a/tests/ui/simulationDistributionChart.test.tsx
+++ b/tests/ui/simulationDistributionChart.test.tsx
@@ -2,20 +2,34 @@ import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 import { I18nProvider } from "../../src/i18n/I18nProvider"
 import { SimulationDistributionPanel } from "../../src/ui/features/simulation/simulation-distribution-panel/SimulationDistributionPanel"
-import { damageHistogram } from "../../src/ui/features/simulation/simulation-distribution-panel/damageHistogram"
-import { compactDamage } from "../../src/ui/features/simulation/damageFormat"
+import { parseHistogram } from "../../src/ui/features/simulation/simulation-distribution-panel/parseHistogram"
+import { decimalNumber } from "../../src/ui/features/simulation/damageFormat"
+import type { ParseRun } from "../../src/engine/dpsWorker"
 
-const totals = Array.from({ length: 200 }, (_unused, index) => 371_000 + (index % 40) * 2100).sort(
-  (left, right) => left - right,
-)
+const DURATION = 60
 
-function renderChart(sortedTotals = totals, expectedTotalDamage = 410_000) {
+const runs: ParseRun[] = Array.from({ length: 200 }, (_unused, index) => {
+  const totalDamage = 371_000 + (index % 40) * 2100
+  return {
+    totalDamage,
+    dps: totalDamage / DURATION,
+    abrasionHits: 1,
+    normalHits: 5,
+    criticalHits: 3,
+    affinityHits: 1,
+  }
+}).sort((left, right) => left.totalDamage - right.totalDamage)
+
+const dpsValues = runs.map((entry) => entry.dps)
+
+function renderChart(sorted = runs, expectedDps = 410_000 / DURATION) {
   const { container } = render(
     <I18nProvider>
       <SimulationDistributionPanel
-        sortedTotals={sortedTotals}
-        meanTotalDamage={411_950}
-        expectedTotalDamage={expectedTotalDamage}
+        sorted={sorted}
+        meanDps={411_950 / DURATION}
+        expectedDps={expectedDps}
+        rotationDuration={DURATION}
       />
     </I18nProvider>,
   )
@@ -30,12 +44,12 @@ describe("SimulationDistributionPanel", () => {
   it("draws one bar per bin across the full plot width", () => {
     const container = renderChart()
     const bars = container.querySelectorAll("svg rect")
-    const bins = damageHistogram(totals).bins
+    const bins = parseHistogram(dpsValues).bins
 
     expect(bars).toHaveLength(bins.length + 1)
   })
 
-  it("runs the damage axis from the worst parse to the best without rounding outward", () => {
+  it("runs the DPS axis from the worst parse to the best without rounding outward", () => {
     const container = renderChart()
     const bars = [...container.querySelectorAll("svg rect")].slice(1)
     const first = bars[0]
@@ -43,8 +57,8 @@ describe("SimulationDistributionPanel", () => {
 
     expect(Number(first.getAttribute("x"))).toBeLessThan(1)
     expect(Number(last.getAttribute("x")) + Number(last.getAttribute("width"))).toBeGreaterThan(99)
-    expect(screen.getByText(compactDamage(totals[0]))).toBeInTheDocument()
-    expect(screen.getByText(compactDamage(totals[totals.length - 1]))).toBeInTheDocument()
+    expect(screen.getByText(decimalNumber(dpsValues[0], 0))).toBeInTheDocument()
+    expect(screen.getByText(decimalNumber(dpsValues[dpsValues.length - 1], 0))).toBeInTheDocument()
   })
 
   it("scales the tallest bar to the top of the plot without clipping", () => {
@@ -67,7 +81,7 @@ describe("SimulationDistributionPanel", () => {
   })
 
   it("leaves out the expectation line when it falls outside the sample", () => {
-    const container = renderChart(totals, 50)
+    const container = renderChart(runs, 50)
     const lines = [...container.querySelectorAll("svg line")].filter(
       (line) => line.getAttribute("x1") === line.getAttribute("x2"),
     )
@@ -83,7 +97,9 @@ describe("SimulationDistributionPanel", () => {
 
     fireEvent.mouseMove(target, { clientX: 100 })
 
-    expect(screen.getByText(/runs$/)).toBeInTheDocument()
+    expect(screen.getByText(/runs · /)).toBeInTheDocument()
+    expect(screen.getByText(/DPS$/)).toBeInTheDocument()
+    expect(screen.getByText(/dmg$/)).toBeInTheDocument()
   })
 
   it("drops the readout once the pointer leaves", () => {
@@ -94,7 +110,7 @@ describe("SimulationDistributionPanel", () => {
     fireEvent.mouseMove(target, { clientX: 100 })
     fireEvent.mouseLeave(target)
 
-    expect(screen.queryByText(/runs$/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/runs · /)).not.toBeInTheDocument()
   })
 
   it("says nothing at all without runs", () => {

--- a/tests/ui/simulationDistributionChart.test.tsx
+++ b/tests/ui/simulationDistributionChart.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { I18nProvider } from "../../src/i18n/I18nProvider"
+import { SimulationDistributionPanel } from "../../src/ui/features/simulation/simulation-distribution-panel/SimulationDistributionPanel"
+import { damageHistogram } from "../../src/ui/features/simulation/simulation-distribution-panel/damageHistogram"
+import { compactDamage } from "../../src/ui/features/simulation/damageFormat"
+
+const totals = Array.from({ length: 200 }, (_unused, index) => 371_000 + (index % 40) * 2100).sort(
+  (left, right) => left - right,
+)
+
+function renderChart(sortedTotals = totals, expectedTotalDamage = 410_000) {
+  const { container } = render(
+    <I18nProvider>
+      <SimulationDistributionPanel
+        sortedTotals={sortedTotals}
+        meanTotalDamage={411_950}
+        expectedTotalDamage={expectedTotalDamage}
+      />
+    </I18nProvider>,
+  )
+  return container
+}
+
+function plot(container: HTMLElement): HTMLElement {
+  return container.querySelector("svg")!.parentElement as HTMLElement
+}
+
+describe("SimulationDistributionPanel", () => {
+  it("draws one bar per bin across the full plot width", () => {
+    const container = renderChart()
+    const bars = container.querySelectorAll("svg rect")
+    const bins = damageHistogram(totals).bins
+
+    expect(bars).toHaveLength(bins.length + 1)
+  })
+
+  it("runs the damage axis from the worst parse to the best without rounding outward", () => {
+    const container = renderChart()
+    const bars = [...container.querySelectorAll("svg rect")].slice(1)
+    const first = bars[0]
+    const last = bars[bars.length - 1]
+
+    expect(Number(first.getAttribute("x"))).toBeLessThan(1)
+    expect(Number(last.getAttribute("x")) + Number(last.getAttribute("width"))).toBeGreaterThan(99)
+    expect(screen.getByText(compactDamage(totals[0]))).toBeInTheDocument()
+    expect(screen.getByText(compactDamage(totals[totals.length - 1]))).toBeInTheDocument()
+  })
+
+  it("scales the tallest bar to the top of the plot without clipping", () => {
+    const container = renderChart()
+    const heights = [...container.querySelectorAll("svg rect")].map((bar) =>
+      Number(bar.getAttribute("height")),
+    )
+
+    expect(Math.max(...heights)).toBeLessThanOrEqual(100)
+    expect(Math.max(...heights)).toBeGreaterThan(0)
+  })
+
+  it("marks the median, the mean and the deterministic expectation", () => {
+    const container = renderChart()
+    const lines = [...container.querySelectorAll("svg line")].filter(
+      (line) => line.getAttribute("x1") === line.getAttribute("x2"),
+    )
+
+    expect(lines).toHaveLength(3)
+  })
+
+  it("leaves out the expectation line when it falls outside the sample", () => {
+    const container = renderChart(totals, 50)
+    const lines = [...container.querySelectorAll("svg line")].filter(
+      (line) => line.getAttribute("x1") === line.getAttribute("x2"),
+    )
+
+    expect(lines).toHaveLength(2)
+    expect(screen.queryByText("Expected")).not.toBeInTheDocument()
+  })
+
+  it("reads out the bin range and its run count under the pointer", () => {
+    const container = renderChart()
+    const target = plot(container)
+    target.getBoundingClientRect = () => ({ left: 0, width: 200, top: 0, height: 220 }) as DOMRect
+
+    fireEvent.mouseMove(target, { clientX: 100 })
+
+    expect(screen.getByText(/runs$/)).toBeInTheDocument()
+  })
+
+  it("drops the readout once the pointer leaves", () => {
+    const container = renderChart()
+    const target = plot(container)
+    target.getBoundingClientRect = () => ({ left: 0, width: 200, top: 0, height: 220 }) as DOMRect
+
+    fireEvent.mouseMove(target, { clientX: 100 })
+    fireEvent.mouseLeave(target)
+
+    expect(screen.queryByText(/runs$/)).not.toBeInTheDocument()
+  })
+
+  it("says nothing at all without runs", () => {
+    renderChart([])
+
+    expect(screen.getByText("(none)")).toBeInTheDocument()
+  })
+})

--- a/tests/ui/simulationStats.test.ts
+++ b/tests/ui/simulationStats.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 import type { ParseRun } from "../../src/engine/dpsWorker"
 import {
   parseSummary,
-  sortedTotalDamage,
+  sortedParses,
 } from "../../src/ui/features/simulation/simulation-summary-bar/summaryStats"
 import {
   ladderAxisSpan,
@@ -12,8 +12,8 @@ import {
 } from "../../src/ui/features/simulation/simulation-parse-ladder-panel/parseLadder"
 import {
   binCountFor,
-  damageHistogram,
-} from "../../src/ui/features/simulation/simulation-distribution-panel/damageHistogram"
+  parseHistogram,
+} from "../../src/ui/features/simulation/simulation-distribution-panel/parseHistogram"
 import {
   outcomeMix,
   OUTCOME_ORDER,
@@ -60,6 +60,13 @@ describe("parseSummary", () => {
     expect(summary.worstTotalDamage).toBe(80)
   })
 
+  it("takes the best and worst DPS from the same runs as the best and worst damage", () => {
+    const summary = parseSummary(spread)!
+    expect(summary.bestDps).toBeCloseTo(130 / 60, 10)
+    expect(summary.worstDps).toBeCloseTo(80 / 60, 10)
+    expect(summary.meanDps).toBeCloseTo(summary.meanTotalDamage / 60, 10)
+  })
+
   it("states the range as best minus worst over the mean, in percent", () => {
     const summary = parseSummary([run(90), run(110)])!
     expect(summary.rangeFraction).toBeCloseTo(0.2, 10)
@@ -73,46 +80,52 @@ describe("parseSummary", () => {
     expect(parseSummary([run(100), run(100)])!.rangeFraction).toBe(0)
   })
 
-  it("sorts the totals ascending without touching the runs", () => {
-    const sorted = sortedTotalDamage(spread)
-    expect(sorted[0]).toBe(80)
-    expect(sorted[sorted.length - 1]).toBe(130)
+  it("sorts the runs ascending without touching the caller's array", () => {
+    const sorted = sortedParses(spread)
+    expect(sorted[0].totalDamage).toBe(80)
+    expect(sorted[sorted.length - 1].totalDamage).toBe(130)
     expect(spread[0].totalDamage).toBe(100)
   })
 })
 
 describe("parseLadder", () => {
-  const sorted = sortedTotalDamage(spread)
+  const sorted = sortedParses(spread)
 
   it("ranks max and min as the best and worst observed parse", () => {
-    expect(parseAtRank(sorted, 100)).toBe(130)
-    expect(parseAtRank(sorted, 0)).toBe(80)
+    expect(parseAtRank(sorted, 100)!.totalDamage).toBe(130)
+    expect(parseAtRank(sorted, 0)!.totalDamage).toBe(80)
+  })
+
+  it("reports both the DPS and the damage of the run at each rank", () => {
+    for (const row of parseLadder(sorted)) {
+      expect(row.dps).toBeCloseTo(row.totalDamage / 60, 10)
+    }
   })
 
   it("never invents a damage value between two observed runs", () => {
-    const observed = new Set(sorted)
+    const observed = new Set(sorted.map((entry) => entry.totalDamage))
     for (const row of parseLadder(sorted)) expect(observed.has(row.totalDamage)).toBe(true)
   })
 
   it("places a top-99 parse above ninety-nine percent of the runs", () => {
-    const many = sortedTotalDamage(Array.from({ length: 1000 }, (_unused, index) => run(index + 1)))
-    const value = parseAtRank(many, 99)
-    const beaten = many.filter((total) => total < value).length
+    const many = sortedParses(Array.from({ length: 1000 }, (_unused, index) => run(index + 1)))
+    const value = parseAtRank(many, 99)!.totalDamage
+    const beaten = many.filter((entry) => entry.totalDamage < value).length
     expect(beaten / many.length).toBeGreaterThanOrEqual(0.98)
     expect(value).toBe(990)
   })
 
   it("reports every rank as its own deviation from the median", () => {
     const rows = parseLadder(sorted)
-    const median = parseAtRank(sorted, 50)
+    const median = parseAtRank(sorted, 50)!.dps
     for (const row of rows) {
-      expect(row.deltaFromMedian).toBeCloseTo((row.totalDamage - median) / median, 10)
+      expect(row.deltaFromMedian).toBeCloseTo((row.dps - median) / median, 10)
     }
     expect(rows.find((row) => row.rank === 50)!.deltaFromMedian).toBe(0)
   })
 
   it("repeats one value across every rank when all runs are identical", () => {
-    const flat = sortedTotalDamage([run(500), run(500), run(500)])
+    const flat = sortedParses([run(500), run(500), run(500)])
     const rows = parseLadder(flat)
     expect(rows).toHaveLength(PARSE_RANKS.length)
     expect(rows.every((row) => row.totalDamage === 500)).toBe(true)
@@ -124,28 +137,28 @@ describe("parseLadder", () => {
   })
 })
 
-describe("damageHistogram", () => {
-  const sorted = sortedTotalDamage(spread)
+describe("parseHistogram", () => {
+  const sorted = sortedParses(spread).map((entry) => entry.totalDamage)
 
   it("spans the bins from the worst parse to the best", () => {
-    const histogram = damageHistogram(sorted)
+    const histogram = parseHistogram(sorted)
     expect(histogram.bins[0].start).toBe(80)
     expect(histogram.bins[histogram.bins.length - 1].end).toBeCloseTo(130, 10)
   })
 
   it("counts every run into exactly one bin", () => {
-    const histogram = damageHistogram(sorted)
+    const histogram = parseHistogram(sorted)
     const counted = histogram.bins.reduce((sum, bin) => sum + bin.count, 0)
     expect(counted).toBe(sorted.length)
   })
 
   it("puts the best parse in the last bin rather than past the end", () => {
-    const histogram = damageHistogram(sorted)
+    const histogram = parseHistogram(sorted)
     expect(histogram.bins[histogram.bins.length - 1].count).toBeGreaterThan(0)
   })
 
   it("falls back to a single bin when every parse is identical", () => {
-    const histogram = damageHistogram([42, 42, 42])
+    const histogram = parseHistogram([42, 42, 42])
     expect(histogram.bins).toHaveLength(1)
     expect(histogram.bins[0].count).toBe(3)
     expect(histogram.binWidth).toBe(0)

--- a/tests/ui/simulationStats.test.ts
+++ b/tests/ui/simulationStats.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest"
+import type { ParseRun } from "../../src/engine/dpsWorker"
+import {
+  parseSummary,
+  sortedTotalDamage,
+} from "../../src/ui/features/simulation/simulation-summary-bar/summaryStats"
+import {
+  ladderAxisSpan,
+  parseAtRank,
+  parseLadder,
+  PARSE_RANKS,
+} from "../../src/ui/features/simulation/simulation-parse-ladder-panel/parseLadder"
+import {
+  binCountFor,
+  damageHistogram,
+} from "../../src/ui/features/simulation/simulation-distribution-panel/damageHistogram"
+import {
+  outcomeMix,
+  OUTCOME_ORDER,
+  totalMeanHits,
+} from "../../src/ui/features/simulation/simulation-outcome-mix-panel/outcomeMix"
+import {
+  clampRunCount,
+  MAX_RUN_COUNT,
+  MIN_RUN_COUNT,
+} from "../../src/ui/features/simulation/simulationRunSettings"
+
+function run(
+  totalDamage: number,
+  hits = { abrasion: 1, normal: 5, crit: 3, affinity: 1 },
+): ParseRun {
+  return {
+    totalDamage,
+    dps: totalDamage / 60,
+    abrasionHits: hits.abrasion,
+    normalHits: hits.normal,
+    criticalHits: hits.crit,
+    affinityHits: hits.affinity,
+  }
+}
+
+const spread = [100, 120, 90, 110, 130, 80, 105, 95, 115, 125].map((total) => run(total))
+
+describe("parseSummary", () => {
+  it("averages the total damage and every hit category over the runs", () => {
+    const summary = parseSummary([
+      run(100, { abrasion: 2, normal: 4, crit: 6, affinity: 0 }),
+      run(200, { abrasion: 0, normal: 6, crit: 4, affinity: 2 }),
+    ])!
+    expect(summary.meanTotalDamage).toBe(150)
+    expect(summary.meanAbrasionHits).toBe(1)
+    expect(summary.meanNormalHits).toBe(5)
+    expect(summary.meanCriticalHits).toBe(5)
+    expect(summary.meanAffinityHits).toBe(1)
+  })
+
+  it("reports the best and worst parse as the highest and lowest observed totals", () => {
+    const summary = parseSummary(spread)!
+    expect(summary.bestTotalDamage).toBe(130)
+    expect(summary.worstTotalDamage).toBe(80)
+  })
+
+  it("states the range as best minus worst over the mean, in percent", () => {
+    const summary = parseSummary([run(90), run(110)])!
+    expect(summary.rangeFraction).toBeCloseTo(0.2, 10)
+  })
+
+  it("reports no summary at all when no run finished", () => {
+    expect(parseSummary([])).toBeNull()
+  })
+
+  it("keeps the range at zero when every parse dealt the same damage", () => {
+    expect(parseSummary([run(100), run(100)])!.rangeFraction).toBe(0)
+  })
+
+  it("sorts the totals ascending without touching the runs", () => {
+    const sorted = sortedTotalDamage(spread)
+    expect(sorted[0]).toBe(80)
+    expect(sorted[sorted.length - 1]).toBe(130)
+    expect(spread[0].totalDamage).toBe(100)
+  })
+})
+
+describe("parseLadder", () => {
+  const sorted = sortedTotalDamage(spread)
+
+  it("ranks max and min as the best and worst observed parse", () => {
+    expect(parseAtRank(sorted, 100)).toBe(130)
+    expect(parseAtRank(sorted, 0)).toBe(80)
+  })
+
+  it("never invents a damage value between two observed runs", () => {
+    const observed = new Set(sorted)
+    for (const row of parseLadder(sorted)) expect(observed.has(row.totalDamage)).toBe(true)
+  })
+
+  it("places a top-99 parse above ninety-nine percent of the runs", () => {
+    const many = sortedTotalDamage(Array.from({ length: 1000 }, (_unused, index) => run(index + 1)))
+    const value = parseAtRank(many, 99)
+    const beaten = many.filter((total) => total < value).length
+    expect(beaten / many.length).toBeGreaterThanOrEqual(0.98)
+    expect(value).toBe(990)
+  })
+
+  it("reports every rank as its own deviation from the median", () => {
+    const rows = parseLadder(sorted)
+    const median = parseAtRank(sorted, 50)
+    for (const row of rows) {
+      expect(row.deltaFromMedian).toBeCloseTo((row.totalDamage - median) / median, 10)
+    }
+    expect(rows.find((row) => row.rank === 50)!.deltaFromMedian).toBe(0)
+  })
+
+  it("repeats one value across every rank when all runs are identical", () => {
+    const flat = sortedTotalDamage([run(500), run(500), run(500)])
+    const rows = parseLadder(flat)
+    expect(rows).toHaveLength(PARSE_RANKS.length)
+    expect(rows.every((row) => row.totalDamage === 500)).toBe(true)
+    expect(ladderAxisSpan(rows)).toBe(0)
+  })
+
+  it("has no rows without runs", () => {
+    expect(parseLadder([])).toEqual([])
+  })
+})
+
+describe("damageHistogram", () => {
+  const sorted = sortedTotalDamage(spread)
+
+  it("spans the bins from the worst parse to the best", () => {
+    const histogram = damageHistogram(sorted)
+    expect(histogram.bins[0].start).toBe(80)
+    expect(histogram.bins[histogram.bins.length - 1].end).toBeCloseTo(130, 10)
+  })
+
+  it("counts every run into exactly one bin", () => {
+    const histogram = damageHistogram(sorted)
+    const counted = histogram.bins.reduce((sum, bin) => sum + bin.count, 0)
+    expect(counted).toBe(sorted.length)
+  })
+
+  it("puts the best parse in the last bin rather than past the end", () => {
+    const histogram = damageHistogram(sorted)
+    expect(histogram.bins[histogram.bins.length - 1].count).toBeGreaterThan(0)
+  })
+
+  it("falls back to a single bin when every parse is identical", () => {
+    const histogram = damageHistogram([42, 42, 42])
+    expect(histogram.bins).toHaveLength(1)
+    expect(histogram.bins[0].count).toBe(3)
+    expect(histogram.binWidth).toBe(0)
+  })
+
+  it("narrows the bin count for a short run", () => {
+    expect(binCountFor(50)).toBeLessThan(binCountFor(1000))
+    expect(binCountFor(4)).toBe(12)
+    expect(binCountFor(100000)).toBe(40)
+  })
+})
+
+describe("outcomeMix", () => {
+  const summary = parseSummary([run(100, { abrasion: 1, normal: 5, crit: 3, affinity: 1 })])!
+
+  it("shares the four outcomes over the total hits of an average parse", () => {
+    const rows = outcomeMix(summary, null)
+    expect(totalMeanHits(summary)).toBe(10)
+    expect(rows.find((row) => row.category === "critical")!.observedShare).toBeCloseTo(0.3, 10)
+    expect(rows.reduce((sum, row) => sum + row.observedShare, 0)).toBeCloseTo(1, 10)
+  })
+
+  it("keeps the category order fixed regardless of which outcome dominates", () => {
+    const dominated = parseSummary([run(100, { abrasion: 90, normal: 1, crit: 1, affinity: 1 })])!
+    expect(outcomeMix(dominated, null).map((row) => row.category)).toEqual([...OUTCOME_ORDER])
+  })
+
+  it("reports no expected rate when the engine supplied none", () => {
+    for (const row of outcomeMix(summary, null)) {
+      expect(row.expectedShare).toBeNull()
+      expect(row.deltaPoints).toBeNull()
+    }
+  })
+
+  it("states the gap to the expected rate in percentage points", () => {
+    const rows = outcomeMix(summary, { abrasion: 0.1, normal: 0.5, crit: 0.25, affinity: 0.15 })
+    expect(rows.find((row) => row.category === "critical")!.deltaPoints).toBeCloseTo(5, 10)
+    expect(rows.find((row) => row.category === "abrasion")!.deltaPoints).toBeCloseTo(0, 10)
+  })
+})
+
+describe("clampRunCount", () => {
+  it("holds a run count inside the range the worker will honour", () => {
+    expect(clampRunCount(MAX_RUN_COUNT + 1)).toBe(MAX_RUN_COUNT)
+    expect(clampRunCount(1)).toBe(MIN_RUN_COUNT)
+    expect(clampRunCount(2500)).toBe(2500)
+  })
+
+  it("falls back to the default when the field holds no number", () => {
+    expect(clampRunCount(Number.NaN)).toBe(1000)
+  })
+})

--- a/tests/ui/simulationTab.test.tsx
+++ b/tests/ui/simulationTab.test.tsx
@@ -37,7 +37,7 @@ const umbra = applyBowSet(
 function renderTab() {
   render(
     <I18nProvider>
-      <SimulationTab inputs={umbra} engineInputs={umbra} expectedTotalDamage={100} />
+      <SimulationTab inputs={umbra} engineInputs={umbra} expectedDps={100} />
     </I18nProvider>,
   )
 }
@@ -86,7 +86,6 @@ describe("SimulationTab", () => {
     renderTab()
 
     expect(screen.getByText("not run yet")).toBeInTheDocument()
-    expect(screen.getByText("Avg Total Damage")).toBeInTheDocument()
     expect(screen.getByText("Avg DPS")).toBeInTheDocument()
     expect(screen.queryByText("Parse Ladder")).not.toBeInTheDocument()
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
@@ -139,10 +138,11 @@ describe("SimulationTab", () => {
     respond(completion(reqId, [80, 100, 120]))
 
     expect(screen.getByText("Parse Ladder")).toBeInTheDocument()
-    expect(screen.getByText("Damage Distribution")).toBeInTheDocument()
+    expect(screen.getByText("DPS Distribution")).toBeInTheDocument()
     expect(screen.getByText("Outcome Mix")).toBeInTheDocument()
     expect(screen.getByText(/^3 runs · /)).toBeInTheDocument()
-    expect(screen.getByText("1.67")).toBeInTheDocument()
+    expect(screen.getAllByText("1.67").length).toBeGreaterThan(0)
+    expect(screen.getByText("100 dmg")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Run" })).not.toBeDisabled()
   })
 

--- a/tests/ui/simulationTab.test.tsx
+++ b/tests/ui/simulationTab.test.tsx
@@ -87,6 +87,7 @@ describe("SimulationTab", () => {
 
     expect(screen.getByText("not run yet")).toBeInTheDocument()
     expect(screen.getByText("Avg Total Damage")).toBeInTheDocument()
+    expect(screen.getByText("Avg DPS")).toBeInTheDocument()
     expect(screen.queryByText("Parse Ladder")).not.toBeInTheDocument()
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
   })
@@ -141,6 +142,7 @@ describe("SimulationTab", () => {
     expect(screen.getByText("Damage Distribution")).toBeInTheDocument()
     expect(screen.getByText("Outcome Mix")).toBeInTheDocument()
     expect(screen.getByText(/^3 runs · /)).toBeInTheDocument()
+    expect(screen.getByText("1.67")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Run" })).not.toBeDisabled()
   })
 

--- a/tests/ui/simulationTab.test.tsx
+++ b/tests/ui/simulationTab.test.tsx
@@ -1,0 +1,192 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { WorkerResponse } from "../../src/engine/dpsWorker"
+
+const { created, MockWorker } = vi.hoisted(() => {
+  const instances: {
+    posted: unknown[]
+    onmessage: ((event: { data: unknown }) => void) | null
+  }[] = []
+  class Mock {
+    posted: unknown[] = []
+    onmessage: ((event: { data: unknown }) => void) | null = null
+    constructor() {
+      instances.push(this)
+    }
+    postMessage(request: unknown) {
+      this.posted.push(request)
+    }
+    terminate() {}
+  }
+  return { created: instances, MockWorker: Mock }
+})
+
+vi.mock("../../src/engine/dpsWorker?worker", () => ({ default: MockWorker }))
+
+const { defaultInputs } = await import("../../src/engine/defaults")
+const { withDerivedStats } = await import("../../src/engine/derivedInputs")
+const { applyArmorSet, applyBowSet } = await import("../../src/engine/panel")
+const { I18nProvider } = await import("../../src/i18n/I18nProvider")
+const { SimulationTab } =
+  await import("../../src/ui/features/simulation/simulation-tab/SimulationTab")
+
+const umbra = applyBowSet(
+  applyArmorSet(withDerivedStats({ ...defaultInputs, classId: "bellstrikeUmbra" })),
+)
+
+function renderTab() {
+  render(
+    <I18nProvider>
+      <SimulationTab inputs={umbra} engineInputs={umbra} expectedTotalDamage={100} />
+    </I18nProvider>,
+  )
+}
+
+function lastRequest(): Record<string, unknown> {
+  const posted = created[0].posted
+  return posted[posted.length - 1] as Record<string, unknown>
+}
+
+function respond(response: WorkerResponse): void {
+  act(() => created[0].onmessage?.({ data: response }))
+}
+
+function completion(
+  reqId: number,
+  totals: number[],
+  overrides: Partial<Extract<WorkerResponse, { kind: "parseSimulation" }>> = {},
+): WorkerResponse {
+  return {
+    kind: "parseSimulation",
+    reqId,
+    runs: totals.map((totalDamage) => ({
+      totalDamage,
+      dps: totalDamage / 60,
+      abrasionHits: 1,
+      normalHits: 5,
+      criticalHits: 3,
+      affinityHits: 1,
+    })),
+    expectedRates: { abrasion: 0.1, normal: 0.5, crit: 0.3, affinity: 0.1 },
+    rotationDuration: 60,
+    requestedRuns: totals.length,
+    completedRuns: totals.length,
+    cancelled: false,
+    warnings: [],
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("SimulationTab", () => {
+  it("shows placeholders in the summary strip before the first run", () => {
+    renderTab()
+
+    expect(screen.getByText("not run yet")).toBeInTheDocument()
+    expect(screen.getByText("Avg Total Damage")).toBeInTheDocument()
+    expect(screen.queryByText("Parse Ladder")).not.toBeInTheDocument()
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
+  })
+
+  it("starts a simulation with the run count in the field", () => {
+    renderTab()
+
+    fireEvent.click(screen.getByRole("button", { name: "Run" }))
+
+    expect(lastRequest().kind).toBe("parseSimulation")
+    expect(lastRequest().runs).toBe(1000)
+  })
+
+  it("clamps a run count above the ceiling before starting", () => {
+    renderTab()
+
+    fireEvent.change(screen.getByLabelText("Runs"), { target: { value: "99999" } })
+    fireEvent.click(screen.getByRole("button", { name: "Run" }))
+
+    expect(lastRequest().runs).toBe(10000)
+  })
+
+  it("disables Run and enables Cancel while a simulation is in flight", () => {
+    renderTab()
+
+    fireEvent.click(screen.getByRole("button", { name: "Run" }))
+
+    expect(screen.getByRole("button", { name: "Run" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Cancel" })).not.toBeDisabled()
+    expect(screen.getByRole("progressbar")).toBeInTheDocument()
+  })
+
+  it("fills the progress bar as runs complete", () => {
+    renderTab()
+    fireEvent.click(screen.getByRole("button", { name: "Run" }))
+    const reqId = lastRequest().reqId as number
+
+    respond({ kind: "parseSimulationProgress", reqId, done: 250, total: 1000 })
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "250")
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuetext", "250 of 1,000 runs")
+  })
+
+  it("shows the distribution once the runs land", () => {
+    renderTab()
+    fireEvent.click(screen.getByRole("button", { name: "Run" }))
+    const reqId = lastRequest().reqId as number
+
+    respond(completion(reqId, [80, 100, 120]))
+
+    expect(screen.getByText("Parse Ladder")).toBeInTheDocument()
+    expect(screen.getByText("Damage Distribution")).toBeInTheDocument()
+    expect(screen.getByText("Outcome Mix")).toBeInTheDocument()
+    expect(screen.getByText(/^3 runs · /)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Run" })).not.toBeDisabled()
+  })
+
+  it("keeps the last completed result after a cancel and says how many runs it covers", () => {
+    renderTab()
+    fireEvent.click(screen.getByRole("button", { name: "Run" }))
+    const reqId = lastRequest().reqId as number
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    respond(
+      completion(reqId, [90, 110], { cancelled: true, completedRuns: 2, requestedRuns: 1000 }),
+    )
+
+    expect(screen.getByText("2 of 1,000 runs · cancelled")).toBeInTheDocument()
+    expect(screen.getByText("Parse Ladder")).toBeInTheDocument()
+  })
+
+  it("warns that the result predates the current build once the rotation changes", () => {
+    renderTab()
+    fireEvent.click(screen.getByRole("button", { name: "Run" }))
+    respond(completion(lastRequest().reqId as number, [80, 100, 120]))
+
+    expect(
+      screen.queryByText("Your build changed since this simulation — run it again"),
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Rotation" }))
+    const other = screen
+      .getAllByRole("option")
+      .find((option) => option.getAttribute("aria-selected") !== "true")!
+    fireEvent.mouseDown(other)
+
+    expect(
+      screen.getByText("Your build changed since this simulation — run it again"),
+    ).toBeInTheDocument()
+  })
+
+  it("leaves the result alone when only the run count changes", () => {
+    renderTab()
+    fireEvent.click(screen.getByRole("button", { name: "Run" }))
+    respond(completion(lastRequest().reqId as number, [80, 100, 120]))
+
+    fireEvent.change(screen.getByLabelText("Runs"), { target: { value: "5000" } })
+
+    expect(
+      screen.queryByText("Your build changed since this simulation — run it again"),
+    ).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Adds a Simulation tab that rolls a rotation many times and reports the distribution of parses it produced, and cuts release v0.3.1.

## Why

The engine is deterministic: every hit contributes probability-weighted **expected** damage, with the four outcome tracks blended into one number. That gives an average, but never a *parse* — how far a lucky pull sits above an unlucky one, how often crits actually land, what a top-1 % run is worth. This adds that.

## What it does

Pick a rotation and a run count (default 1000), press Run. Each parse is a full seeded engine re-run. Results are a summary strip leading with average DPS, a DPS distribution histogram, a WarcraftLogs-style parse ladder (MAX / 99 / 95 / 80 / MEDIAN / 20 / 5 / 1 / MIN), and an outcome mix. It runs on a worker with a live progress bar and a cancel that keeps the partial sample.

## Three things worth a reviewer's attention

**1. Sampling lives inside the kernel, not at its call sites.** `conditionalFinalCrit` can promote a hit to a guaranteed crit *inside* `computeSkillDamage`, and that promotion is not visible in the `cells` it returns — a sampler at the call sites would have had to re-implement it, which `docs/CALCULATION.md` § "One kernel" forbids. `computeSkillDamage` takes an optional generator and returns the track it rolled alongside the unchanged expected value.

**2. A sampled pass is *cheaper* than a deterministic one** — measured 2.4 ms against 7.6 ms, so 1000 runs takes about 2.4 s. The four proc-mechanic schedules each average 500 seeded sweeps on the deterministic path; handed the run's own generator they realise a single trajectory instead. That is both correct per-run and roughly 500x cheaper, and it is what makes full re-runs affordable.

**3. On a build with proc mechanics the parse mean will not exactly equal the header's total.** Measured about 0.2 % on Hawkwing: the deterministic path computes `round(E[stacks])` while the sim averages `f(stacks)`, and those are not equal. The parse mean is the more faithful number, and "fixing" it would move `engineBaseline.fixture.json`. Rather than hide it, the histogram draws the deterministic expectation as a labelled reference line. A test pins convergence within 1 % on a proc-free build and bounds the biased case at 5 %.

## Worker and client

A new chunked, cancellable `parseSimulation` kind returns the raw runs, so every statistic on the tab derives from one array and the panels cannot disagree. The client gains a progress channel routed **ahead of** the response channel — that channel retires a request id on first delivery, so progress sent down it would swallow both the later progress and the real result — plus a per-kind debounce table and a cancel that also fires when the last listener leaves.

## Migration

**No migration needed:** no persisted shape changes. The seed and collect flag are engine-boundary parameters, `Result` is never stored, and the run count and rotation pick stay in component state.

## Docs

Two edits, each gated on a rule that actually changed:

- `docs/CALCULATION.md` § "Mechanic rules" — a stochastic schedule must honour the run's generator and realise one trajectory, rather than averaging its own fixed-seed sweep.
- `docs/UI.md` rule 5, plus a new rule 9 — in-flight work is now aborted rather than merely ignored, and a progress-reporting kind rides its own message kind.

The wiki's `Damage-Calculation` and `Glossary` claimed damage is never sampled; corrected in its own commit in the wiki clone.

## Release

The last commit bumps to v0.3.1 with the in-app changelog entry. The range also covers the gear-analysis subtab and the Bellstrike Splendor fixes that reached `main` separately.

## Verification

`pnpm format:check`, `lint`, the English-only grep, `typecheck`, `build` and `test` all pass — 148 files / 1555 tests. `engineBaseline.fixture.json` and `buffEngineEquivalence` are **untouched and green**, which is the proof the deterministic path did not move; do not re-baseline them. Also driven by hand in the browser: progress fills, cancel keeps its partial result, and the outcome mix shows observed-vs-expected gaps under 0.11 pp — the sampler proving itself unbiased.
