### PR TITLE
Release v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-winds-meet-dps",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/changelog/entries/v0-3-2.ts
+++ b/src/changelog/entries/v0-3-2.ts
@@ -1,0 +1,61 @@
+import type { ChangelogEntryDetails } from "../types"
+
+export const details: ChangelogEntryDetails = {
+  sections: [
+    {
+      label: "Added",
+      items: [
+        {
+          text: "A parse simulation keeps running when you leave its tab, and a toast tracks it, cancels it, or opens the results.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "A toast shows how many gear and DPS calculations are still running, and pending numbers dim until they land.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Controls that would change the build are locked while a simulation runs, and unlock when it ends or is cancelled.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Changed",
+      items: [
+        {
+          text: "Analyses reopen with their last result instead of an empty panel, and a repeated one answers straight from memory.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The equipped slot tiles fill in on their own, without waiting for the whole inventory to be recalculated.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Gear sweeps now run in parallel, so their numbers land sooner.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The gear inventory lists only the active profile's pieces; the global view and its owner badges are gone.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The gear swap preview sits directly under the subtab card, in its own column beside the piece details.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The Simulation tab keeps its rotation choice and run count when you leave and come back.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Fixed",
+      items: [
+        {
+          text: "Power, agility and momentum raise minimum attack at the same rate whether they came from gear words or points.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+  ],
+}

--- a/src/changelog/registry.ts
+++ b/src/changelog/registry.ts
@@ -2,6 +2,12 @@ import type { ChangelogEntry } from "./types"
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: "0.3.2",
+    date: "2026-08-17",
+    headline: "Background runs, cached results, faster gear sweeps",
+    loadDetails: () => import("./entries/v0-3-2").then((module) => module.details),
+  },
+  {
     version: "0.3.1",
     date: "2026-08-16",
     headline: "Simulate parses, and rank every gear slot's payoff",


### PR DESCRIPTION
Bumps the app version to 0.3.2 and adds the in-app changelog entry for everything since v0.3.1.

Covers three commits: the worker result cache and off-tab simulation, the single-source attribute per-point table, and the parallel gear sweeps.

### Added
- A parse simulation keeps running when you leave its tab, and a toast tracks it, cancels it, or opens the results.
- A toast shows how many gear and DPS calculations are still running, and pending numbers dim until they land.
- Controls that would change the build are locked while a simulation runs, and unlock when it ends or is cancelled.

### Changed
- Analyses reopen with their last result instead of an empty panel, and a repeated one answers straight from memory.
- The equipped slot tiles fill in on their own, without waiting for the whole inventory to be recalculated.
- Gear sweeps now run in parallel, so their numbers land sooner.
- The gear inventory lists only the active profile's pieces; the global view and its owner badges are gone.
- The gear swap preview sits directly under the subtab card, in its own column beside the piece details.
- The Simulation tab keeps its rotation choice and run count when you leave and come back.

### Fixed
- Power, agility and momentum raise minimum attack at the same rate whether they came from gear words or points.

No migration needed: the changelog is display-only and no stored shape changed in this range.