### PR TITLE
Make the app shell responsive across desktop, tablet and mobile

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -122,7 +122,8 @@ Follow the nearest existing worker hook rather than inventing a new shape.
   updating the list.**
 - Palette tokens and the element baseline live in the global base stylesheet.
   Breakpoints go through the shared mixin, never a hardcoded media query.
-  Repeated form-control declarations go through the shared field mixins.
+  Repeated form-control declarations go through the shared field mixins. Hover
+  styles go through the shared hover mixin, never a bare `:hover`.
 - Bare element selectors inside a module are not hashed and keep working through
   ancestor scoping. That is what lets a class-less shared input stay styled by
   whichever module renders it — **never add a class to it**.

--- a/src/app/App.module.scss
+++ b/src/app/App.module.scss
@@ -1,16 +1,5 @@
 @use "breakpoints";
 
-/* Margin on the h1 itself would get centered by align-items, offsetting the
- * title relative to the buttons — so the spacing lives on the row instead. */
-@mixin titlebarRow {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
-}
-
 .app {
   width: 100%;
   height: 100%;
@@ -77,25 +66,15 @@
   cursor: not-allowed;
 }
 
+/* Margin on the h1 itself would get centered by align-items, offsetting the
+ * title relative to the buttons — so the spacing lives on the row instead. */
 .appTitlebar {
-  @include titlebarRow;
-}
-
-@include breakpoints.below(breakpoints.$bp-700) {
-  .appTitlebar {
-    display: none;
-  }
-}
-
-.appTitlebarMobile {
-  @include titlebarRow;
-  display: none;
-}
-
-@include breakpoints.below(breakpoints.$bp-700) {
-  .appTitlebarMobile {
-    display: flex;
-  }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
 }
 
 .appTitle {

--- a/src/app/App.module.scss
+++ b/src/app/App.module.scss
@@ -118,8 +118,13 @@
   margin: 0 0 12px 0;
   overflow-x: auto;
   scrollbar-width: none;
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
-  mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+}
+
+@include breakpoints.below(breakpoints.$bp-980) {
+  .tabs {
+    -webkit-mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+    mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+  }
 }
 
 .tabs::-webkit-scrollbar {

--- a/src/app/App.module.scss
+++ b/src/app/App.module.scss
@@ -1,3 +1,16 @@
+@use "breakpoints";
+
+/* Margin on the h1 itself would get centered by align-items, offsetting the
+ * title relative to the buttons — so the spacing lives on the row instead. */
+@mixin titlebarRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
 .app {
   width: 100%;
   height: 100%;
@@ -7,8 +20,8 @@
   min-height: 0;
 }
 
-/* Negative margins offset body's 16px/24px padding so the sticky background
- * covers the full width as content scrolls underneath. */
+/* Negative margins offset body's padding so the sticky background covers the
+ * full width as content scrolls underneath. */
 .appHeader {
   position: sticky;
   top: 0;
@@ -16,6 +29,13 @@
   background: var(--color-bg);
   margin: -16px -24px 0;
   padding: 12px 24px 0;
+}
+
+@include breakpoints.below(breakpoints.$bp-700) {
+  .appHeader {
+    margin: -8px -10px 0;
+    padding: 8px 10px 0;
+  }
 }
 
 .appHeader > .tabs {
@@ -57,15 +77,25 @@
   cursor: not-allowed;
 }
 
-/* Margin on the h1 itself would get centered by align-items, offsetting the
- * title relative to the buttons — so the spacing lives on the row instead. */
 .appTitlebar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
+  @include titlebarRow;
+}
+
+@include breakpoints.below(breakpoints.$bp-700) {
+  .appTitlebar {
+    display: none;
+  }
+}
+
+.appTitlebarMobile {
+  @include titlebarRow;
+  display: none;
+}
+
+@include breakpoints.below(breakpoints.$bp-700) {
+  .appTitlebarMobile {
+    display: flex;
+  }
 }
 
 .appTitle {
@@ -86,6 +116,14 @@
   gap: 2px;
   border-bottom: 1px solid var(--color-border);
   margin: 0 0 12px 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+  mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .tab {
@@ -107,12 +145,16 @@
   top: 1px;
   text-decoration: none;
   display: inline-block;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
-.tab:hover {
-  color: var(--color-text);
-  background: var(--color-surface-raised);
-  border-color: var(--color-border-hover);
+@include breakpoints.hoverable {
+  .tab:hover {
+    color: var(--color-text);
+    background: var(--color-surface-raised);
+    border-color: var(--color-border-hover);
+  }
 }
 
 .tab.active {
@@ -124,4 +166,13 @@
 
 .tabRight {
   margin-left: auto;
+}
+
+@include breakpoints.below(breakpoints.$bp-700) {
+  .tab {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 8px 16px;
+  }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,17 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
-import { HashRouter, NavLink, Navigate, Route, Routes, useLocation } from "react-router-dom"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  HashRouter,
+  NavLink,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom"
 import { runEngine } from "../engine/dps"
 import { applyArmorSet, applyBowSet } from "../engine/panel"
 import { withDerivedStats } from "../engine/derivedInputs"
+import { builtinRotationsForClass, defaultRotationForClass } from "../engine/builtinLibrary"
 import type { Inputs, StoredProfile } from "../engine/types"
 import { OverviewTab } from "../ui/features/overview/overview-tab/OverviewTab"
 import { MetricsCard, WarningsList } from "../ui/layout/output-panel/OutputPanel"
@@ -20,6 +29,7 @@ import { SimulationToast, SIMULATION_PATH } from "../ui/layout/simulation-toast/
 import { DpsActivityToast } from "../ui/layout/dps-activity-toast/DpsActivityToast"
 import { GraduationBuildDialog } from "../ui/features/gear/graduation-build-dialog/GraduationBuildDialog"
 import { SetupWizard, type SetupMode } from "../ui/features/setup/setup-wizard/SetupWizard"
+import { usesCustomRotation } from "../ui/features/rotation/rotationOptions"
 import { useI18n } from "../i18n/i18nContext"
 import { I18nProvider } from "../i18n/I18nProvider"
 import { ConfirmProvider } from "../ui/components/confirm-dialog/ConfirmDialog"
@@ -49,8 +59,10 @@ function AppInner() {
   const [startedRunCount, setStartedRunCount] = useState(0)
   const [acknowledgedRunCount, setAcknowledgedRunCount] = useState(0)
   const isSimulationRunning = simulation.status === "running"
-  const isOnSimulationTab = useLocation().pathname === SIMULATION_PATH
+  const pathname = useLocation().pathname
+  const isOnSimulationTab = pathname === SIMULATION_PATH
   const areInputsLocked = isSimulationRunning && !isOnSimulationTab
+  const navigate = useNavigate()
 
   const startParseSimulation = simulation.start
   const startSimulation = useCallback(
@@ -119,6 +131,16 @@ function AppInner() {
     () => ({ ...result, graduationRate: graduation.rate }),
     [result, graduation.rate],
   )
+
+  const rotationName = useMemo(() => {
+    if (usesCustomRotation(inputs)) return inputs.activeCustomRotation!.name
+    const selectedBuiltin = builtinRotationsForClass(inputs.classId).find(
+      (rotation) => rotation.id === inputs.selectedBuiltinRotationId,
+    )
+    if (selectedBuiltin) return selectedBuiltin.name
+    return defaultRotationForClass(inputs.classId)?.name ?? null
+  }, [inputs])
+  const goToRotationTab = useCallback(() => navigate("/rotation"), [navigate])
 
   const { t } = useI18n()
   const confirm = useConfirm()
@@ -250,6 +272,11 @@ function AppInner() {
     return () => clearTimeout(id)
   }, [savedAt])
 
+  const tabRefs = useRef<Record<string, HTMLAnchorElement | null>>({})
+  useEffect(() => {
+    tabRefs.current[pathname]?.scrollIntoView({ block: "nearest", inline: "nearest" })
+  }, [pathname])
+
   const TABS: { path: string; label: string; align?: "right" }[] = [
     { path: "/overview", label: t("Overview") },
     { path: "/gear", label: t("Gear") },
@@ -259,6 +286,8 @@ function AppInner() {
     { path: "/talents", label: t("Talents & Oddities") },
     { path: "/profile", label: t("Profiles"), align: "right" },
   ]
+
+  const saveLabel = savedAt && !isDirty ? t("Saved ✓") : isDirty ? t("Save") : t("Saved")
 
   return (
     <div className={styles.app}>
@@ -303,7 +332,7 @@ function AppInner() {
               disabled={!isDirty}
               aria-label={t("Save")}
             >
-              {savedAt && !isDirty ? t("Saved ✓") : isDirty ? t("Save") : t("Saved")}
+              {saveLabel}
             </button>
             <button
               type="button"
@@ -325,6 +354,12 @@ function AppInner() {
           theoreticalDps={graduation.theoreticalDps}
           onGraduationClick={() => setGraduationDialogOpen(true)}
           graduationDisabled={isSimulationRunning}
+          rotationName={rotationName}
+          onRotationClick={goToRotationTab}
+          saveLabel={saveLabel}
+          onSave={handleSave}
+          saveDisabled={!isDirty}
+          saveDirty={isDirty}
         />
 
         <nav className={styles.tabs} role="tablist">
@@ -333,6 +368,9 @@ function AppInner() {
               key={tab.path}
               to={tab.path}
               role="tab"
+              ref={(node) => {
+                tabRefs.current[tab.path] = node
+              }}
               className={({ isActive }) =>
                 styles.tab +
                 (isActive ? ` ${styles.active}` : "") +
@@ -345,6 +383,25 @@ function AppInner() {
         </nav>
       </div>
       <div className={styles.tabPanel}>
+        <header className={styles.appTitlebarMobile}>
+          <div className={styles.appTitle}>
+            <h1>{t("Where Winds Meet DPS")}</h1>
+            <ChangelogButton />
+          </div>
+          <div className={styles.appTitlebarActions}>
+            <GithubLink />
+            <button
+              type="button"
+              className="reset-btn"
+              onClick={handleReset}
+              disabled={!isDirty || isSimulationRunning}
+              aria-label={t("Discard changes")}
+              title={t("Discard edits since the last save")}
+            >
+              {t("Discard changes")}
+            </button>
+          </div>
+        </header>
         <WarningsList result={result} />
         <fieldset className={styles.routeFields} disabled={areInputsLocked}>
           <Routes>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -347,26 +347,6 @@ function AppInner() {
           </div>
         </header>
 
-        <header className={styles.appTitlebarMobile}>
-          <div className={styles.appTitle}>
-            <h1>{t("Where Winds Meet DPS")}</h1>
-            <ChangelogButton />
-          </div>
-          <div className={styles.appTitlebarActions}>
-            <GithubLink />
-            <button
-              type="button"
-              className="reset-btn"
-              onClick={handleReset}
-              disabled={!isDirty || isSimulationRunning}
-              aria-label={t("Discard changes")}
-              title={t("Discard edits since the last save")}
-            >
-              {t("Discard changes")}
-            </button>
-          </div>
-        </header>
-
         <MetricsCard
           result={headerResult}
           className={styles.headerMetrics}
@@ -376,10 +356,6 @@ function AppInner() {
           graduationDisabled={isSimulationRunning}
           rotationName={rotationName}
           onRotationClick={goToRotationTab}
-          saveLabel={saveLabel}
-          onSave={handleSave}
-          saveDisabled={!isDirty}
-          saveDirty={isDirty}
         />
 
         <nav className={styles.tabs} role="tablist">

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -347,6 +347,26 @@ function AppInner() {
           </div>
         </header>
 
+        <header className={styles.appTitlebarMobile}>
+          <div className={styles.appTitle}>
+            <h1>{t("Where Winds Meet DPS")}</h1>
+            <ChangelogButton />
+          </div>
+          <div className={styles.appTitlebarActions}>
+            <GithubLink />
+            <button
+              type="button"
+              className="reset-btn"
+              onClick={handleReset}
+              disabled={!isDirty || isSimulationRunning}
+              aria-label={t("Discard changes")}
+              title={t("Discard edits since the last save")}
+            >
+              {t("Discard changes")}
+            </button>
+          </div>
+        </header>
+
         <MetricsCard
           result={headerResult}
           className={styles.headerMetrics}
@@ -383,25 +403,6 @@ function AppInner() {
         </nav>
       </div>
       <div className={styles.tabPanel}>
-        <header className={styles.appTitlebarMobile}>
-          <div className={styles.appTitle}>
-            <h1>{t("Where Winds Meet DPS")}</h1>
-            <ChangelogButton />
-          </div>
-          <div className={styles.appTitlebarActions}>
-            <GithubLink />
-            <button
-              type="button"
-              className="reset-btn"
-              onClick={handleReset}
-              disabled={!isDirty || isSimulationRunning}
-              aria-label={t("Discard changes")}
-              title={t("Discard edits since the last save")}
-            >
-              {t("Discard changes")}
-            </button>
-          </div>
-        </header>
         <WarningsList result={result} />
         <fieldset className={styles.routeFields} disabled={areInputsLocked}>
           <Routes>

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -12,3 +12,9 @@ $bp-560: 560px;
     @content;
   }
 }
+
+@mixin hoverable {
+  @media (hover: hover) {
+    @content;
+  }
+}

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1,3 +1,5 @@
+@use "breakpoints";
+
 :root {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
   color-scheme: light dark;
@@ -29,10 +31,19 @@
 
 body {
   margin: 0;
-  padding: 16px 24px;
+  padding: calc(16px + env(safe-area-inset-top)) calc(24px + env(safe-area-inset-right))
+    calc(16px + env(safe-area-inset-bottom)) calc(24px + env(safe-area-inset-left));
   height: 100vh;
+  height: 100dvh;
   box-sizing: border-box;
   overflow: hidden;
+}
+
+@include breakpoints.below(breakpoints.$bp-700) {
+  body {
+    padding: calc(8px + env(safe-area-inset-top)) calc(10px + env(safe-area-inset-right))
+      calc(8px + env(safe-area-inset-bottom)) calc(10px + env(safe-area-inset-left));
+  }
 }
 
 /* Without an explicit height, #root collapses to its content size, which

--- a/src/ui/layout/github-link/GithubLink.module.scss
+++ b/src/ui/layout/github-link/GithubLink.module.scss
@@ -1,3 +1,5 @@
+@use "breakpoints";
+
 .contributeNote {
   display: inline-flex;
   align-items: center;
@@ -15,8 +17,16 @@
   transition: color 0.1s;
 }
 
-.githubLink:hover {
-  color: var(--color-text);
+@include breakpoints.hoverable {
+  .githubLink:hover {
+    color: var(--color-text);
+  }
+}
+
+@include breakpoints.below(breakpoints.$bp-700) {
+  .noteText {
+    display: none;
+  }
 }
 
 .githubLink svg {

--- a/src/ui/layout/github-link/GithubLink.tsx
+++ b/src/ui/layout/github-link/GithubLink.tsx
@@ -8,7 +8,7 @@ export function GithubLink() {
   const { t } = useI18n()
   return (
     <span className={styles.contributeNote}>
-      {t("Want to contribute? Click here →")}
+      <span className={styles.noteText}>{t("Want to contribute? Click here →")}</span>
       <a
         className={styles.githubLink}
         href={GITHUB_REPO_URL}

--- a/src/ui/layout/output-panel/OutputPanel.module.scss
+++ b/src/ui/layout/output-panel/OutputPanel.module.scss
@@ -15,6 +15,7 @@
 
 .dps {
   flex: 1 1 220px;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--color-surface-raised);
@@ -33,6 +34,15 @@
   color: var(--color-accent);
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
+}
+
+.subline {
+  display: none;
+  font-size: 0.72em;
+  color: var(--color-text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .graduation {
@@ -99,11 +109,67 @@
   font-variant-numeric: tabular-nums;
 }
 
+.rotationChip {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 160px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.rotationChip .label {
+  font-size: 0.72em;
+  color: var(--color-text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.rotationChip .value {
+  font-size: 1em;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mobileSave {
+  display: none;
+}
+
 @include breakpoints.below(breakpoints.$bp-720) {
   .metricsCard {
     gap: 12px 24px;
   }
   .dps {
     border-right: none;
+  }
+}
+
+@include breakpoints.below(breakpoints.$bp-700) {
+  .metricsCard {
+    flex-wrap: nowrap;
+    gap: 12px;
+    padding: 6px 12px;
+    min-height: 48px;
+  }
+  .metricsCard > .stat {
+    display: none;
+  }
+  .rotationChip {
+    display: none;
+  }
+  .subline {
+    display: block;
+  }
+  .mobileSave {
+    display: inline-flex;
+    padding: 6px 10px;
+    font-size: 0.8em;
   }
 }

--- a/src/ui/layout/output-panel/OutputPanel.module.scss
+++ b/src/ui/layout/output-panel/OutputPanel.module.scss
@@ -132,7 +132,7 @@
 
 .rotationChip .value {
   font-size: 1em;
-  color: var(--color-text);
+  color: var(--color-accent-bright);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/ui/layout/output-panel/OutputPanel.module.scss
+++ b/src/ui/layout/output-panel/OutputPanel.module.scss
@@ -112,34 +112,41 @@
 .rotationChip {
   flex: 0 0 auto;
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  max-width: 160px;
-  background: transparent;
-  border: none;
-  padding: 0;
+  align-items: center;
+  gap: 10px;
+  max-width: 260px;
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 6px;
+  padding: 6px 10px;
   font: inherit;
   text-align: left;
   cursor: pointer;
+  transition: border-color 120ms ease;
 }
 
-.rotationChip .label {
-  font-size: 0.72em;
-  color: var(--color-text-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+@include breakpoints.hoverable {
+  .rotationChip:hover {
+    border-color: var(--color-border-hover);
+  }
+  .rotationChip:hover .graduationIcon {
+    color: var(--color-text);
+  }
 }
 
-.rotationChip .value {
-  font-size: 1em;
-  color: var(--color-accent-bright);
-  white-space: nowrap;
+.rotationChip:focus-visible {
+  border-color: var(--color-border-hover);
+  background: var(--color-bg);
+}
+
+.rotationStat {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.rotationStat .value {
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.mobileSave {
-  display: none;
 }
 
 @include breakpoints.below(breakpoints.$bp-720) {
@@ -166,10 +173,5 @@
   }
   .subline {
     display: block;
-  }
-  .mobileSave {
-    display: inline-flex;
-    padding: 6px 10px;
-    font-size: 0.8em;
   }
 }

--- a/src/ui/layout/output-panel/OutputPanel.tsx
+++ b/src/ui/layout/output-panel/OutputPanel.tsx
@@ -9,6 +9,16 @@ const fmt = (n: number, digits = 2) =>
     ? n.toLocaleString("en-US", { minimumFractionDigits: digits, maximumFractionDigits: digits })
     : "—"
 
+function formatCompactDamage(value: number): string {
+  if (!Number.isFinite(value)) return "—"
+  const sign = value < 0 ? "-" : ""
+  const magnitude = Math.abs(value)
+  if (magnitude >= 1_000_000_000) return `${sign}${(magnitude / 1_000_000_000).toFixed(1)}B`
+  if (magnitude >= 1_000_000) return `${sign}${(magnitude / 1_000_000).toFixed(1)}M`
+  if (magnitude >= 1_000) return `${sign}${(magnitude / 1_000).toFixed(1)}K`
+  return fmt(value, 0)
+}
+
 interface MetricsCardProps {
   result: Result
   className?: string
@@ -16,6 +26,12 @@ interface MetricsCardProps {
   theoreticalDps?: number | null
   onGraduationClick?: () => void
   graduationDisabled?: boolean
+  rotationName?: string | null
+  onRotationClick?: () => void
+  saveLabel?: string
+  onSave?: () => void
+  saveDisabled?: boolean
+  saveDirty?: boolean
 }
 
 function OpenIcon() {
@@ -47,6 +63,12 @@ export function MetricsCard({
   theoreticalDps = null,
   onGraduationClick,
   graduationDisabled = false,
+  rotationName = null,
+  onRotationClick,
+  saveLabel,
+  onSave,
+  saveDisabled = false,
+  saveDirty = false,
 }: MetricsCardProps) {
   const { t } = useI18n()
   const graduationText =
@@ -59,11 +81,16 @@ export function MetricsCard({
     theoreticalDps === null
       ? t("Current DPS divided by the theoretical class maximum")
       : `${t("Current DPS divided by the theoretical class maximum")}: ${fmt(theoreticalDps, 2)} DPS`
+  const durationText = `${fmt(result.rotationDuration, 0)}s`
   return (
     <div className={styles.metricsCard + (className ? ` ${className}` : "")}>
       <div className={styles.dps}>
         <span className={styles.label}>{t("DPS")}</span>
         <span className={styles.value}>{fmt(result.dps, 2)}</span>
+        <span className={styles.subline}>
+          {formatCompactDamage(result.totalDamage)} · {durationText}
+          {rotationName ? ` · ${rotationName}` : ""}
+        </span>
       </div>
       <div className={styles.stat}>
         <span className={styles.label}>{t("Total Damage")}</span>
@@ -71,8 +98,19 @@ export function MetricsCard({
       </div>
       <div className={styles.stat}>
         <span className={styles.label}>{t("Duration")}</span>
-        <span className={styles.value}>{fmt(result.rotationDuration, 0)}s</span>
+        <span className={styles.value}>{durationText}</span>
       </div>
+      {rotationName && (
+        <button
+          type="button"
+          className={styles.rotationChip}
+          onClick={onRotationClick}
+          title={rotationName}
+        >
+          <span className={styles.label}>{t("Rotation")}</span>
+          <span className={styles.value}>{rotationName}</span>
+        </button>
+      )}
       <button
         type="button"
         className={`${styles.graduation}${graduationPending ? ` ${styles.pending}` : ""}`}
@@ -91,6 +129,17 @@ export function MetricsCard({
         </span>
         <OpenIcon />
       </button>
+      {onSave && (
+        <button
+          type="button"
+          className={`save-btn ${styles.mobileSave}${saveDirty ? " dirty" : ""}`}
+          onClick={onSave}
+          disabled={saveDisabled}
+          aria-label={t("Save")}
+        >
+          {saveLabel}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/ui/layout/output-panel/OutputPanel.tsx
+++ b/src/ui/layout/output-panel/OutputPanel.tsx
@@ -28,10 +28,6 @@ interface MetricsCardProps {
   graduationDisabled?: boolean
   rotationName?: string | null
   onRotationClick?: () => void
-  saveLabel?: string
-  onSave?: () => void
-  saveDisabled?: boolean
-  saveDirty?: boolean
 }
 
 function OpenIcon() {
@@ -65,10 +61,6 @@ export function MetricsCard({
   graduationDisabled = false,
   rotationName = null,
   onRotationClick,
-  saveLabel,
-  onSave,
-  saveDisabled = false,
-  saveDirty = false,
 }: MetricsCardProps) {
   const { t } = useI18n()
   const graduationText =
@@ -96,20 +88,28 @@ export function MetricsCard({
         <span className={styles.label}>{t("Total Damage")}</span>
         <span className={styles.value}>{fmt(result.totalDamage, 0)}</span>
       </div>
-      <div className={styles.stat}>
-        <span className={styles.label}>{t("Duration")}</span>
-        <span className={styles.value}>{durationText}</span>
-      </div>
-      {rotationName && (
+      {rotationName ? (
         <button
           type="button"
           className={styles.rotationChip}
           onClick={onRotationClick}
           title={rotationName}
         >
-          <span className={styles.label}>{t("Rotation")}</span>
-          <span className={styles.value}>{rotationName}</span>
+          <span className={styles.stat}>
+            <span className={styles.label}>{t("Duration")}</span>
+            <span className={styles.value}>{durationText}</span>
+          </span>
+          <span className={`${styles.stat} ${styles.rotationStat}`}>
+            <span className={styles.label}>{t("Rotation")}</span>
+            <span className={styles.value}>{rotationName}</span>
+          </span>
+          <OpenIcon />
         </button>
+      ) : (
+        <div className={styles.stat}>
+          <span className={styles.label}>{t("Duration")}</span>
+          <span className={styles.value}>{durationText}</span>
+        </div>
       )}
       <button
         type="button"
@@ -129,17 +129,6 @@ export function MetricsCard({
         </span>
         <OpenIcon />
       </button>
-      {onSave && (
-        <button
-          type="button"
-          className={`save-btn ${styles.mobileSave}${saveDirty ? " dirty" : ""}`}
-          onClick={onSave}
-          disabled={saveDisabled}
-          aria-label={t("Save")}
-        >
-          {saveLabel}
-        </button>
-      )}
     </div>
   )
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom/vitest"
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}

--- a/tests/ui/simulationInputLock.test.tsx
+++ b/tests/ui/simulationInputLock.test.tsx
@@ -96,9 +96,7 @@ describe("input lock while a simulation runs", () => {
     startRunThenLeaveSimulationTab()
 
     expect(anyRouteControl()).toBeDisabled()
-    for (const button of screen.getAllByRole("button", { name: "Discard changes" })) {
-      expect(button).toBeDisabled()
-    }
+    expect(screen.getByRole("button", { name: "Discard changes" })).toBeDisabled()
   })
 
   it("gives the controls back once the runs land", () => {

--- a/tests/ui/simulationInputLock.test.tsx
+++ b/tests/ui/simulationInputLock.test.tsx
@@ -96,7 +96,9 @@ describe("input lock while a simulation runs", () => {
     startRunThenLeaveSimulationTab()
 
     expect(anyRouteControl()).toBeDisabled()
-    expect(screen.getByRole("button", { name: "Discard changes" })).toBeDisabled()
+    for (const button of screen.getAllByRole("button", { name: "Discard changes" })) {
+      expect(button).toBeDisabled()
+    }
   })
 
   it("gives the controls back once the runs land", () => {


### PR DESCRIPTION
## What

The shell — titlebar, DPS metrics bar, and main tab strip — now works at three widths: desktop (>1100px, unchanged), tablet (701–1100px), and mobile (≤700px). Content inside the routed tabs is untouched.

### Tab strip
- Scrolls horizontally with a hidden scrollbar instead of clipping; tabs no longer shrink or wrap
- Edge fade hints at clipped tabs, applied only below the width where the strip can actually overflow
- The active tab scrolls into view on navigation
- ≥44px hit targets below 700px

### DPS metrics bar
- New rotation readout: a chip on desktop/tablet (truncated, tooltip, click navigates to the Rotation tab), and part of the compact sub-line on mobile
- Below 700px the card is a single non-wrapping strip: big DPS with a sub-line (compact total damage · duration · rotation), graduation button unchanged — same pill, same fire
- Header still consumes only the single baseline engine pass

### Titlebar
- One titlebar at every width, sticky above the metrics; Save and Discard stay where they are
- The contribute note collapses to just the GitHub icon below 700px

### Viewport & input
- `100dvh` with `100vh` fallback, safe-area insets, tighter mobile body padding kept in sync with the header's negative-margin trick
- New shared `hoverable` mixin (`@media (hover: hover)`) so touch devices don't hold sticky hover; documented as a convention in docs/UI.md's styling list
- Breakpoints only through the shared `below()` mixin, reusing `$bp-1100`/`$bp-700`

## Notes
- No migration needed: presentation-only — no saved-profile shape, default, or allowlist changed
- Tests: jsdom `scrollIntoView` polyfill in tests/setup.ts; full suite (1755 tests / 162 files), typecheck, lint, format check, and build all pass