### PR TITLE
fix(i18n): translate attunement rows in the Gear-Stat Lift table

### DIFF
--- a/src/engine/itemRanking.ts
+++ b/src/engine/itemRanking.ts
@@ -9,13 +9,14 @@ import {
   gearWordIdForPath,
   statLineLabel,
 } from "../data/stats/statLines"
+import { statLineKey } from "../i18n/contentKeys"
 import {
   AGILITY_PER_POINT,
   MOMENTUM_PER_POINT,
   POWER_PER_POINT,
 } from "../definitions/baseStats/attributeConversion"
 import { WEAPON_BOOST_STAT_KEY } from "./statRegistry"
-import { attunementsForClass } from "./attunements"
+import { attunementLabelKey, attunementsForClass } from "./attunements"
 import { addStatDelta, resolveEnginePath } from "./statPaths"
 import { builtinSkillsForClass, defaultRotationForClass } from "./builtinLibrary"
 import { resolveRotation } from "./rotation"
@@ -23,6 +24,7 @@ import { resolveRotation } from "./rotation"
 export interface WordSpec<TName extends string = string> {
   word: TName
   label: string
+  labelKey: string
   amount: number
   unit: "raw" | "percent"
   apply(inputs: Inputs): Inputs
@@ -63,6 +65,7 @@ function wordSpec(
   return {
     word,
     label: statLineLabel(word),
+    labelKey: statLineKey(word),
     amount: roll,
     unit: GEAR_WORD_UNIT[word],
     apply: (inputs) => clone(inputs, (next) => apply(next, roll)),
@@ -160,6 +163,7 @@ function buildAttunementSpecs(inputs: Inputs): WordSpec[] {
     .map((opt) => ({
       word: opt.id,
       label: opt.label,
+      labelKey: attunementLabelKey(opt, inputs.classId),
       amount: opt.max,
       unit: "percent" as const,
       apply: (i: Inputs) =>
@@ -214,6 +218,7 @@ export function computeRanking(inputs: Inputs, baseDps: number): ItemRankingRow[
       rows.push({
         statLineId: spec.word,
         label: spec.label,
+        labelKey: spec.labelKey,
         source,
         amount: spec.amount,
         unit: spec.unit,

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -374,6 +374,7 @@ export interface BuffWindow {
 export interface ItemRankingRow {
   statLineId: string
   label: string
+  labelKey: string
   source: "tunement" | "attunement"
   amount: number
   unit: "raw" | "percent"

--- a/src/ui/features/overview/item-ranking-table/ItemRankingTable.tsx
+++ b/src/ui/features/overview/item-ranking-table/ItemRankingTable.tsx
@@ -1,6 +1,5 @@
 import type { ItemRankingRow } from "../../../../engine/types"
 import { useI18n } from "../../../../i18n/i18nContext"
-import { statLineKey } from "../../../../i18n/contentKeys"
 import styles from "./ItemRankingTable.module.scss"
 
 interface Props {
@@ -48,7 +47,7 @@ export function ItemRankingTable({ rows }: Props) {
       <tbody>
         {sorted.map((row, index) => (
           <tr key={row.statLineId + index}>
-            <td>{t(statLineKey(row.statLineId), row.label)}</td>
+            <td>{t(row.labelKey, row.label)}</td>
             <td>{row.unit === "percent" ? fmt(row.amount * 100, 2) + " %" : fmt(row.amount, 2)}</td>
             <td
               className={`${styles.dpsDelta} ${deltaSignClass(row.dpsDelta)}`}

--- a/tests/engine/itemRanking.test.ts
+++ b/tests/engine/itemRanking.test.ts
@@ -9,6 +9,7 @@ import { attunementsForClass, getAttunement } from "../../src/engine/attunements
 import { runEngine } from "../../src/engine/dps"
 import { defaultInputs } from "../../src/engine/defaults"
 import type { GearPiece } from "../../src/engine/types"
+import english from "../../src/i18n/locales/en.json"
 
 // Scoped to Bellstrike Umbra — the only implemented class (CLAUDE.md
 // § "Implemented classes").
@@ -28,6 +29,13 @@ describe("computeRanking — Bellstrike Umbra baseline rows", () => {
       "Heavenquaker Spear Charged Skill DMG Boost",
       "Strategic Sword - Bleeding DMG Boost",
     ])
+  })
+
+  it("names every row by a key the translation catalogue carries", () => {
+    const uncatalogued = rows
+      .map((row) => row.labelKey)
+      .filter((labelKey) => !(labelKey in (english as Record<string, string>)))
+    expect(uncatalogued).toEqual([])
   })
 
   it("includes the default rotation's resolved weapons (Sword + Spear)", () => {


### PR DESCRIPTION
## The bug

The Gear-Stat Lift card resolved every row through `content.statLine.<id>`. That is correct for gear-word rows, but `computeRanking` also emits attunement rows, whose id lives under `content.attunement.<id>[.<classId>]`. The lookup missed, so `t()` fell back to the English label carried on the row and every non-English locale showed those rows in English.

## The fix

A row now carries the key that names it, instead of the table deriving one from the id:

- `WordSpec` gains `labelKey` — gear words set `statLineKey(word)`, attunements set `attunementLabelKey(opt, inputs.classId)`, which picks the class-specific key when the option has a `labelByClass` entry, the same way the gear UI does.
- `ItemRankingRow.labelKey` carries it to the UI; `ItemRankingTable` renders `t(row.labelKey, row.label)`.

Verified on Bellstrike Umbra: all six attunement rows resolve in `ko.json`, including the class-named variants (`content.attunement.spearQ.bellstrikeUmbra`).

New guard in `tests/engine/itemRanking.test.ts` — *"names every row by a key the translation catalogue carries"* — fails on the old code, since no `content.statLine.swordQ` key exists.

No migration needed: `ItemRankingRow` is computed engine output, never persisted, and no id was renamed.

`pnpm typecheck`, `pnpm test` (166 files, 1839 tests), `pnpm lint` and `pnpm format:check` are green.
