### PR TITLE
Fix Full Potential figures, release v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-winds-meet-dps",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "engines": {
     "node": ">=26"

--- a/src/changelog/entries/v0-4-2.ts
+++ b/src/changelog/entries/v0-4-2.ts
@@ -1,0 +1,15 @@
+import type { ChangelogEntryDetails } from "../types"
+
+export const details: ChangelogEntryDetails = {
+  sections: [
+    {
+      label: "Fixed",
+      items: [
+        {
+          text: "FP and FP(E) now report a piece's true best retune, relay and attunement, instead of understating unequipped gear.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+  ],
+}

--- a/src/changelog/registry.ts
+++ b/src/changelog/registry.ts
@@ -2,6 +2,12 @@ import type { ChangelogEntry } from "./types"
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: "0.4.2",
+    date: "2026-08-29",
+    headline: "Truer Full Potential figures on gear tiles",
+    loadDetails: () => import("./entries/v0-4-2").then((module) => module.details),
+  },
+  {
     version: "0.4.1",
     date: "2026-08-27",
     headline: "Screenshot gear import, Korean, and a Build summary",

--- a/src/engine/fullPotential.ts
+++ b/src/engine/fullPotential.ts
@@ -1,34 +1,34 @@
-// Every retune and attunement candidate is scored with an exact runEngine
-// call on the piece-removed baseline (not a linearised marginal-rate
-// pre-pass — that disagreed with the retunement panel and drifted between
-// build states).
-import type { GearPiece, Inputs } from "./types"
+import type { GearPiece, GearSlot, Inputs } from "./types"
 import { runEngine } from "./dps"
-import { applyPieceContribution, maxRelayedClone } from "./gearStats"
+import { applyPieceContribution, maxRelayedClone, relayedCapValue } from "./gearStats"
 import { getWordSpecs } from "./itemRanking"
 import { attunementsFor } from "./attunements"
 import { poolForClass } from "../definitions/classes/registry"
 import { annotatePoolForSlot, rerollableSlots } from "./retunement"
 
-function applyBestRetune(piece: GearPiece, inputs: Inputs): GearPiece {
-  if (piece.relayed) return piece
+function slotEmptyBaseline(slot: GearSlot, inputs: Inputs): Inputs {
+  const equippedId = inputs.equipped[slot]
+  const equipped = equippedId ? (inputs.inventory.find((p) => p.id === equippedId) ?? null) : null
+  return equipped ? applyPieceContribution(inputs, equipped, -1) : inputs
+}
+
+function bestRetunedVariant(piece: GearPiece, inputs: Inputs, baseline: Inputs): GearPiece {
   const pool = poolForClass(inputs.classId)
   if (!pool || pool.stats.length === 0) return piece
 
   const specs = getWordSpecs(inputs)
-  const baseline = applyPieceContribution(inputs, piece, -1)
-  const currentDps = runEngine(applyPieceContribution(baseline, piece, +1)).dps
-
   let bestPiece = piece
-  let bestDps = currentDps
+  let bestDps = runEngine(applyPieceContribution(baseline, piece, +1)).dps
+
   for (const slotIndex of rerollableSlots(piece)) {
     const annotated = annotatePoolForSlot(piece, slotIndex, pool)
     for (const { word, legal, isCurrent } of annotated) {
       if (!legal || isCurrent) continue
       const spec = specs.find((s) => s.word === word)
       if (!spec) continue
-      const swappedWords = piece.words.map((w, i) =>
-        i === slotIndex ? { word, value: spec.amount, retuned: true } : w,
+      const value = piece.relayed ? relayedCapValue(spec.amount, spec.unit) : spec.amount
+      const swappedWords = piece.words.map((existing, index) =>
+        index === slotIndex ? { word, value, retuned: true } : existing,
       ) as GearPiece["words"]
       const candidate: GearPiece = { ...piece, words: swappedWords }
       const dps = runEngine(applyPieceContribution(baseline, candidate, +1)).dps
@@ -41,11 +41,10 @@ function applyBestRetune(piece: GearPiece, inputs: Inputs): GearPiece {
   return bestPiece
 }
 
-function applyBestAttunement(piece: GearPiece, inputs: Inputs): GearPiece {
+function applyBestAttunement(piece: GearPiece, inputs: Inputs, baseline: Inputs): GearPiece {
   const opts = attunementsFor(piece.slot, inputs.classId).filter((o) => o.enginePath !== null)
   if (opts.length === 0) return piece
 
-  const baseline = applyPieceContribution(inputs, piece, -1)
   let bestPiece = piece
   let bestDps = runEngine(applyPieceContribution(baseline, piece, +1)).dps
   for (const opt of opts) {
@@ -64,33 +63,27 @@ function applyBestAttunement(piece: GearPiece, inputs: Inputs): GearPiece {
 }
 
 export function getFTPiece(piece: GearPiece, inputs: Inputs): GearPiece {
+  const baseline = slotEmptyBaseline(piece.slot, inputs)
+
   if (piece.relayed) {
-    return applyBestAttunement(maxRelayedClone(piece, inputs), inputs)
+    return applyBestAttunement(maxRelayedClone(piece, inputs), inputs, baseline)
   }
 
-  const retuned = applyBestRetune(piece, inputs)
-
-  const baseline = applyPieceContribution(inputs, piece, -1)
+  const retuned = bestRetunedVariant(piece, inputs, baseline)
   const retunedDps = runEngine(applyPieceContribution(baseline, retuned, +1)).dps
-  const relayed = maxRelayedClone(retuned, inputs)
+  const relayed = bestRetunedVariant(maxRelayedClone(piece, inputs), inputs, baseline)
   const relayedDps = runEngine(applyPieceContribution(baseline, relayed, +1)).dps
   const afterRelayDecision = relayedDps > retunedDps ? relayed : retuned
 
-  return applyBestAttunement(afterRelayDecision, inputs)
+  return applyBestAttunement(afterRelayDecision, inputs, baseline)
 }
 
 export function ftDpsWhenEquipped(piece: GearPiece, inputs: Inputs): number {
-  const equippedId = inputs.equipped[piece.slot]
-  const equipped = equippedId ? (inputs.inventory.find((p) => p.id === equippedId) ?? null) : null
-  const baseline = equipped ? applyPieceContribution(inputs, equipped, -1) : inputs
+  const baseline = slotEmptyBaseline(piece.slot, inputs)
   const ft = getFTPiece(piece, inputs)
   return runEngine(applyPieceContribution(baseline, ft, +1)).dps
 }
 
-export function ftDpsWithSlotEmpty(slot: GearPiece["slot"], inputs: Inputs): number {
-  const equippedId = inputs.equipped[slot]
-  if (!equippedId) return runEngine(inputs).dps
-  const equipped = inputs.inventory.find((p) => p.id === equippedId) ?? null
-  if (!equipped) return runEngine(inputs).dps
-  return runEngine(applyPieceContribution(inputs, equipped, -1)).dps
+export function ftDpsWithSlotEmpty(slot: GearSlot, inputs: Inputs): number {
+  return runEngine(slotEmptyBaseline(slot, inputs)).dps
 }

--- a/tests/engine/fullPotential.test.ts
+++ b/tests/engine/fullPotential.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from "vitest"
 import { getFTPiece, ftDpsWhenEquipped } from "../../src/engine/fullPotential"
 import { computeDpsDeltas } from "../../src/engine/dpsWorker"
 import { runEngine } from "../../src/engine/dps"
-import { applyPieceContribution, relayedCapValue } from "../../src/engine/gearStats"
+import {
+  applyPieceContribution,
+  maxRelayedClone,
+  relayedCapValue,
+} from "../../src/engine/gearStats"
+import { attunementsFor } from "../../src/engine/attunements"
+import { withDerivedStats } from "../../src/engine/derivedInputs"
+import { applyArmorSet, applyBowSet } from "../../src/engine/panel"
 import { getWordSpecs } from "../../src/engine/itemRanking"
 import { poolForClass } from "../../src/definitions/classes/registry"
 import { annotatePoolForSlot, rerollableSlots } from "../../src/engine/retunement"
@@ -316,5 +323,132 @@ describe("computeDpsDeltas → fullPotential field", () => {
       pieceIds: [P.id],
     })
     expect(res.deltas[P.id].fullPotentialE).toBeLessThanOrEqual(0)
+  })
+})
+
+describe("FT variant selection", () => {
+  function derivedInputs(equipped: GearPiece[], inventory: GearPiece[]): Inputs {
+    const equippedIds = Object.fromEntries(equipped.map((p) => [p.slot, p.id]))
+    return applyBowSet(
+      applyArmorSet(
+        withDerivedStats({
+          ...umbraInputs,
+          inventory: [...equipped, ...inventory],
+          equipped: { ...umbraInputs.equipped, ...equippedIds },
+        }),
+      ),
+    )
+  }
+
+  function bestReachableDps(candidate: GearPiece, inputs: Inputs): number {
+    const equippedId = inputs.equipped[candidate.slot]
+    const equipped = equippedId ? (inputs.inventory.find((p) => p.id === equippedId) ?? null) : null
+    const slotEmpty = equipped ? applyPieceContribution(inputs, equipped, -1) : inputs
+    const specs = getWordSpecs(inputs)
+    const pool = poolForClass(inputs.classId)
+    const attunements = attunementsFor(candidate.slot, inputs.classId).filter(
+      (option) => option.enginePath !== null,
+    )
+
+    const retuneVariants: GearPiece[] = [candidate]
+    if (pool && !candidate.relayed) {
+      for (const slotIndex of rerollableSlots(candidate)) {
+        for (const { word, legal, isCurrent } of annotatePoolForSlot(candidate, slotIndex, pool)) {
+          if (!legal || isCurrent) continue
+          const spec = specs.find((s) => s.word === word)
+          if (!spec) continue
+          retuneVariants.push({
+            ...candidate,
+            words: candidate.words.map((existing, index) =>
+              index === slotIndex ? { word, value: spec.amount, retuned: true } : existing,
+            ) as GearPiece["words"],
+          })
+        }
+      }
+    }
+
+    let best = -Infinity
+    for (const variant of retuneVariants) {
+      for (const relayed of [false, true]) {
+        const built = relayed ? maxRelayedClone(variant, inputs) : variant
+        for (const attunement of [null, ...attunements]) {
+          const reachable: GearPiece = attunement
+            ? { ...built, attunement: attunement.id, attunementValue: attunement.max }
+            : built
+          best = Math.max(best, runEngine(applyPieceContribution(slotEmpty, reachable, +1)).dps)
+        }
+      }
+    }
+    return best
+  }
+
+  const WEAPON_BASE: Partial<GearPiece> = {
+    level: 96,
+    minPhys: 65,
+    maxPhys: 151,
+    attunement: "physPen",
+    attunementValue: 0.11,
+  }
+
+  const relayedHelm = piece(
+    [
+      w("maxPhys", 73.13),
+      w("power", 46),
+      w("agility", 46),
+      w("momentum", 46),
+      w("maxVoidAttack", 41.55),
+    ],
+    {
+      id: "helm-piece",
+      slot: "helm",
+      level: 96,
+      minPhys: 0,
+      maxPhys: 0,
+      relayed: true,
+      attunement: "physPen",
+      attunementValue: 0.11,
+    },
+  )
+
+  it("scores an unequipped candidate against its own slot emptied, not against a build still holding the equipped piece", () => {
+    const equippedWeapon = piece(
+      [
+        w("maxVoidAttack", 41.28),
+        w("maxVoidAttack", 41.19),
+        w("swordBoost", 0.0583),
+        w("maxPhys", 73.13),
+        w("momentum", 45.57),
+      ],
+      { ...WEAPON_BASE, id: "equipped-weapon", relayed: true },
+    )
+    const candidate = piece(
+      [
+        w("maxPhys", 64.7),
+        w("maxVoidAttack", 43.9),
+        w("momentum", 45.1),
+        w("swordBoost", 0.049),
+        w("affinity", 0.044),
+      ],
+      { ...WEAPON_BASE, id: "candidate-weapon" },
+    )
+    const inputs = derivedInputs([equippedWeapon, relayedHelm], [candidate])
+
+    expect(ftDpsWhenEquipped(candidate, inputs)).toBeCloseTo(bestReachableDps(candidate, inputs), 6)
+  })
+
+  it("picks the retune at the value the word carries once the piece is relayed, not at its unrelayed roll", () => {
+    const candidate = piece(
+      [
+        w("maxPhys", 5),
+        w("maxVoidAttack", 43.9),
+        w("momentum", 45.1),
+        w("swordBoost", 0.049),
+        w("affinity", 0.01),
+      ],
+      { ...WEAPON_BASE, id: "candidate-weapon" },
+    )
+    const inputs = derivedInputs([candidate, relayedHelm], [])
+
+    expect(ftDpsWhenEquipped(candidate, inputs)).toBeCloseTo(bestReachableDps(candidate, inputs), 6)
   })
 })


### PR DESCRIPTION
FP and FP(E) reported the wrong figure for a gear piece, and on the profile that surfaced it a clear upgrade read as a loss: the tile showed FP −325 / FP(E) −345 where the true values are +319 / +299.

## Two defects, both in the full-potential picker

**The variant was chosen against the wrong build state.** The best retune, relay and attunement were picked using the current build *minus the candidate's own stats*, then the winner was scored against the build *minus the equipped piece*. For an unequipped candidate those are different builds — the first still holds the equipped piece and subtracts stats the build never had — so the reported figure belonged to a variant that was never the best one. Here the picker chose `slot 1: maxVoidAttack → maxPhys`; on the real baseline the winner is `slot 4: affinity → maxPhys`, which is what the Retunement panel already advised.

**The retune was ranked at unrelayed roll values.** Every swap was scored with the piece's current rolls before deciding whether to relay, but relaying pushes every word to its 94 % cap — so that ranking does not hold for the piece actually returned. In an isolated fixture this alone costs ~87 DPS.

## The change

- `slotEmptyBaseline(slot, inputs)` is now the single baseline used for both selection and scoring, so the variant is always chosen against the build with its own slot emptied. `ftDpsWhenEquipped` and `ftDpsWithSlotEmpty` route through it too, dropping their duplicated copies of the same logic.
- `bestRetunedVariant` takes that baseline and evaluates each swap at the value the word will actually carry — the relayed cap on a relayed piece. `getFTPiece` runs the search on both the as-is piece and its max-relayed clone and keeps whichever wins, instead of retuning first and relaying blind.

## Tests

Two regression tests in `tests/engine/fullPotential.test.ts`, each isolating one defect — verified to fail on the old code by 8.19 and 87.42 DPS respectively, and to pass on the new:

- `scores an unequipped candidate against its own slot emptied, not against a build still holding the equipped piece`
- `picks the retune at the value the word carries once the piece is relayed, not at its unrelayed roll`

Both assert FT DPS equals an exhaustive enumeration of every reachable variant (retune × relay × attunement) on the slot-empty baseline.

Full suite green: 172 files, 1920 tests. Lint, typecheck and format clean.

## Release

Second commit bumps to **v0.4.2** (patch — fixes only) with the changelog entry and registry row. No migration needed: the fix is pure computation over values recomputed on every load, and the changelog is display-only — no stored shape changed.
