### PR TITLE
Schedule the default breakthrough off a per-tier release date

### DIFF
--- a/src/data/baseStats/breakthroughTiers.json
+++ b/src/data/baseStats/breakthroughTiers.json
@@ -124,6 +124,7 @@
     "generalDamageTaken": 0.15,
     "fatigueDamageTaken": 0.1,
     "multiplier": 1.65,
+    "release": "2026-09-03T03:30:00Z",
     "attributes": [
       {
         "id": 1,

--- a/src/definitions/baseStats/breakthroughs.ts
+++ b/src/definitions/baseStats/breakthroughs.ts
@@ -16,11 +16,40 @@ export interface BreakthroughTier {
   fatigueDamageTaken: number
   multiplier: number
   attributes?: BreakthroughAttribute[]
+  // In-game unlock instant, UTC. A tier without one is already live.
+  release?: string
 }
 
 export const BREAKTHROUGH_TIERS: readonly BreakthroughTier[] = [
   ...(breakthroughTiers as BreakthroughTier[]),
 ].sort((left, right) => left.breakthrough - right.breakthrough)
+
+const DEFAULT_BREAKTHROUGH_BEFORE_ANY_RELEASE = 16
+
+export interface BreakthroughRelease {
+  breakthrough: number
+  at: number
+}
+
+export const BREAKTHROUGH_RELEASES: readonly BreakthroughRelease[] = BREAKTHROUGH_TIERS.filter(
+  (tier) => typeof tier.release === "string" && !Number.isNaN(Date.parse(tier.release)),
+)
+  .map((tier) => ({ breakthrough: tier.breakthrough, at: Date.parse(tier.release!) }))
+  .sort((left, right) => left.at - right.at)
+
+export function releasedBreakthroughs(now: number = Date.now()): readonly BreakthroughRelease[] {
+  return BREAKTHROUGH_RELEASES.filter((release) => now >= release.at)
+}
+
+export function newestBreakthroughRelease(now: number = Date.now()): number {
+  return releasedBreakthroughs(now).reduce((highest, release) => {
+    return release.breakthrough > highest ? release.breakthrough : highest
+  }, 0)
+}
+
+export function defaultBreakthrough(now: number = Date.now()): number {
+  return Math.max(newestBreakthroughRelease(now), DEFAULT_BREAKTHROUGH_BEFORE_ANY_RELEASE)
+}
 
 export function getBreakthrough(breakthrough: number): BreakthroughTier {
   const tier = BREAKTHROUGH_TIERS.find((candidate) => candidate.breakthrough === breakthrough)

--- a/src/engine/defaults.ts
+++ b/src/engine/defaults.ts
@@ -1,6 +1,10 @@
 import type { Inputs } from "./types"
 import { EMPTY_EQUIPPED, defaultCombatSettings } from "./types"
 import { DEFAULT_ODDITIES } from "../definitions/baseStats"
+import {
+  defaultBreakthrough,
+  newestBreakthroughRelease,
+} from "../definitions/baseStats/breakthroughs"
 import { SET_ID } from "../data/sets/ids"
 
 export const emptyMindMethod = { name: "", stacks: "" } as const
@@ -8,6 +12,7 @@ export const emptyMindMethod = { name: "", stacks: "" } as const
 export const defaultInputs: Inputs = {
   classId: "bellstrikeUmbra",
   breakthrough: 13,
+  followedBreakthroughRelease: newestBreakthroughRelease(),
 
   phys: { min: 1043.0, max: 2006.0, penetration: 0.292 },
   bellstrike: { min: 57.0, max: 0, penetration: 0 },
@@ -82,7 +87,7 @@ export const defaultInputs: Inputs = {
 export const blankInputs: Inputs = {
   ...defaultInputs,
   classId: "bellstrikeUmbra",
-  breakthrough: 16,
+  breakthrough: defaultBreakthrough(),
   phys: { min: 0, max: 0, penetration: 0 },
   bellstrike: { min: 0, max: 0, penetration: 0 },
   stonesplit: { min: 0, max: 0, penetration: 0 },

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -78,6 +78,7 @@ export function defaultCombatSettings(): CombatSettings {
 export interface Inputs {
   classId: string
   breakthrough: number
+  followedBreakthroughRelease?: number
 
   phys: AttackBlock
   bellstrike: AttackBlock

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -12,6 +12,11 @@ import {
 } from "./definitions/innerWays/registry"
 import { withoutDerivedStats, withZeroedDerivedStats } from "./engine/derivedInputs"
 import { getDefaultTalentsForClass, DEFAULT_ODDITIES } from "./definitions/baseStats"
+import {
+  defaultBreakthrough,
+  newestBreakthroughRelease,
+  releasedBreakthroughs,
+} from "./definitions/baseStats/breakthroughs"
 import type { Rotation, RotationStep } from "./engine/rotation"
 import { newRotationId, newStepId, isRotation } from "./engine/rotation"
 import type { Skill, SkillHit, HitTrigger, TriggerCondition, HitVariant } from "./engine/skill"
@@ -212,7 +217,7 @@ function hydrateInputs(inputs: Inputs): Inputs {
   if (typeof next.breakthrough !== "number" || !VALID_BREAKTHROUGHS.has(next.breakthrough)) {
     const trial =
       typeof legacyTargetId === "string" ? (legacyTargetId.match(/^(\d+)/)?.[1] ?? "") : ""
-    next.breakthrough = LEGACY_TARGET_TO_BREAKTHROUGH[trial] ?? 16
+    next.breakthrough = LEGACY_TARGET_TO_BREAKTHROUGH[trial] ?? defaultBreakthrough()
   }
   delete (next as unknown as Record<string, unknown>).targetId
   delete (next as unknown as Record<string, unknown>).shareDebuff5JingShen
@@ -380,22 +385,47 @@ function makeDefaultProfile(name: string, inputs: Inputs): StoredProfile {
   return { id: newProfileId(), name, inputs: hydrateInputs(inputs) }
 }
 
+function followBreakthroughReleases(inputs: Inputs, now: number): Inputs {
+  const newestRelease = newestBreakthroughRelease(now)
+  const followedRelease =
+    typeof inputs.followedBreakthroughRelease === "number" ? inputs.followedBreakthroughRelease : 0
+  if (followedRelease === newestRelease) return inputs
+  let breakthrough = inputs.breakthrough
+  for (const release of releasedBreakthroughs(now)) {
+    if (release.breakthrough <= followedRelease) continue
+    const supersededDefault = defaultBreakthrough(release.at - 1)
+    if (breakthrough === supersededDefault) breakthrough = release.breakthrough
+  }
+  return { ...inputs, breakthrough, followedBreakthroughRelease: newestRelease }
+}
+
 export function loadProfiles(): ProfilesState & { firstRun: boolean } {
+  const now = Date.now()
   try {
     const raw = kvStore.get(PROFILES_KEY)
     if (raw) {
       const result = runProfileMigrations(JSON.parse(raw))
       const migrated = result?.blob as ProfilesBlob | undefined
       if (migrated && Array.isArray(migrated.profiles)) {
-        const profiles = migrated.profiles
+        const hydrated = migrated.profiles
           .filter(isStoredProfile)
-          .map((p) => ({ ...p, inputs: hydrateInputs(p.inputs) }))
+          .map((stored) => ({ ...stored, inputs: hydrateInputs(stored.inputs) }))
+        const profiles = hydrated.map((profile) => ({
+          ...profile,
+          inputs: followBreakthroughReleases(profile.inputs, now),
+        }))
+        const releaseFollowed = profiles.some(
+          (profile, index) => profile.inputs !== hydrated[index].inputs,
+        )
         if (profiles.length > 0) {
           const activeId = profiles.some((p) => p.id === migrated.activeId)
             ? migrated.activeId
             : profiles[0].id
           // Persist the upgraded blob so the chain is walked once, not per load.
-          if (result && (result.applied.length > 0 || migrated.v !== PROFILES_VERSION)) {
+          if (
+            releaseFollowed ||
+            (result && (result.applied.length > 0 || migrated.v !== PROFILES_VERSION))
+          ) {
             saveProfiles({ profiles, activeId })
           }
           return { profiles, activeId, firstRun: false }
@@ -406,7 +436,11 @@ export function loadProfiles(): ProfilesState & { firstRun: boolean } {
 
   const legacy = loadInputs()
   if (legacy) {
-    const profile = makeDefaultProfile("Default", legacy)
+    const legacyProfile = makeDefaultProfile("Default", legacy)
+    const profile = {
+      ...legacyProfile,
+      inputs: followBreakthroughReleases(legacyProfile.inputs, now),
+    }
     const state: ProfilesState = { profiles: [profile], activeId: profile.id }
     saveProfiles(state)
     try {

--- a/tests/engine/breakthroughMigration.test.ts
+++ b/tests/engine/breakthroughMigration.test.ts
@@ -1,12 +1,15 @@
 // Additive migration, no version bump — see CLAUDE.md → "localStorage migrations".
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { kvStore } from "../../src/kvStore"
 import { loadProfiles } from "../../src/storage"
 import { defaultInputs } from "../../src/engine/defaults"
+import { BREAKTHROUGH_RELEASES } from "../../src/definitions/baseStats/breakthroughs"
 import type { Inputs } from "../../src/engine/types"
 
 const PROFILES_KEY = "wwm.profiles"
 const PROFILES_VERSION = 4
+
+const BEFORE_EVERY_RELEASE = Math.min(...BREAKTHROUGH_RELEASES.map((release) => release.at)) - 1
 
 function writeLegacyProfilesBlob(targetId: string | undefined, breakthrough?: unknown): void {
   const inputs: Partial<Inputs> & { targetId?: string } = { ...defaultInputs }
@@ -27,11 +30,19 @@ function writeLegacyProfilesBlob(targetId: string | undefined, breakthrough?: un
   )
 }
 
+// Pinned before every breakthrough release so these assert the legacy mapping
+// rather than the release follow — see breakthroughRelease.test.ts.
 describe("breakthrough migration (additive field, no version bump)", () => {
   beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(BEFORE_EVERY_RELEASE)
     try {
       kvStore.remove(PROFILES_KEY)
     } catch {}
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("maps legacy targetId '86' to breakthrough 13 and strips targetId", () => {
@@ -47,13 +58,13 @@ describe("breakthrough migration (additive field, no version bump)", () => {
     expect(profiles[0].inputs.breakthrough).toBe(16)
   })
 
-  it("falls back to 16 for a dropped low-level trial", () => {
+  it("falls back to the current default for a dropped low-level trial", () => {
     writeLegacyProfilesBlob("51")
     const { profiles } = loadProfiles()
     expect(profiles[0].inputs.breakthrough).toBe(16)
   })
 
-  it("falls back to 16 when both targetId and breakthrough are missing", () => {
+  it("falls back to the current default when both targetId and breakthrough are missing", () => {
     writeLegacyProfilesBlob(undefined)
     const { profiles } = loadProfiles()
     expect(profiles[0].inputs.breakthrough).toBe(16)
@@ -66,13 +77,13 @@ describe("breakthrough migration (additive field, no version bump)", () => {
     expect("targetId" in profiles[0].inputs).toBe(false)
   })
 
-  it("heals a malformed breakthrough value back to 16", () => {
+  it("heals a malformed breakthrough value back to the current default", () => {
     writeLegacyProfilesBlob(undefined, "sixteen")
     const { profiles } = loadProfiles()
     expect(profiles[0].inputs.breakthrough).toBe(16)
   })
 
-  it("heals an out-of-range breakthrough value back to 16", () => {
+  it("heals an out-of-range breakthrough value back to the current default", () => {
     writeLegacyProfilesBlob(undefined, 99)
     const { profiles } = loadProfiles()
     expect(profiles[0].inputs.breakthrough).toBe(16)

--- a/tests/engine/breakthroughRelease.test.ts
+++ b/tests/engine/breakthroughRelease.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { kvStore } from "../../src/kvStore"
+import { loadProfiles, saveProfiles } from "../../src/storage"
+import { defaultInputs } from "../../src/engine/defaults"
+import {
+  BREAKTHROUGH_RELEASES,
+  defaultBreakthrough,
+  newestBreakthroughRelease,
+  releasedBreakthroughs,
+} from "../../src/definitions/baseStats/breakthroughs"
+import type { Inputs } from "../../src/engine/types"
+
+const PROFILES_KEY = "wwm.profiles"
+const PROFILES_VERSION = 4
+
+const BREAKTHROUGH_17_RELEASE = BREAKTHROUGH_RELEASES.find(
+  (release) => release.breakthrough === 17,
+)!.at
+
+function writeProfiles(builds: readonly Partial<Inputs>[]): void {
+  kvStore.set(
+    PROFILES_KEY,
+    JSON.stringify({
+      v: PROFILES_VERSION,
+      profiles: builds.map((build, index) => ({
+        id: `p${index}`,
+        name: `Profile ${index}`,
+        inputs: { ...defaultInputs, followedBreakthroughRelease: undefined, ...build },
+      })),
+      activeId: "p0",
+    }),
+  )
+}
+
+function loadedBreakthroughs(): number[] {
+  return loadProfiles().profiles.map((profile) => profile.inputs.breakthrough)
+}
+
+function storedBreakthroughs(): number[] {
+  const blob = JSON.parse(kvStore.get(PROFILES_KEY) ?? "{}") as { profiles?: { inputs: Inputs }[] }
+  return (blob.profiles ?? []).map((profile) => profile.inputs.breakthrough)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  try {
+    kvStore.remove(PROFILES_KEY)
+  } catch {}
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("breakthrough release schedule", () => {
+  it("reads each release date off the tier it belongs to", () => {
+    expect(new Date(BREAKTHROUGH_17_RELEASE).toISOString()).toBe("2026-09-03T03:30:00.000Z")
+  })
+
+  it("keeps the releases ordered by date", () => {
+    const dates = BREAKTHROUGH_RELEASES.map((release) => release.at)
+    expect(dates).toEqual([...dates].sort((left, right) => left - right))
+  })
+
+  it("counts no release as pending before its date", () => {
+    expect(releasedBreakthroughs(BREAKTHROUGH_17_RELEASE - 1)).not.toContainEqual({
+      breakthrough: 17,
+      at: BREAKTHROUGH_17_RELEASE,
+    })
+  })
+})
+
+describe("defaultBreakthrough", () => {
+  it("holds the old default up to the last instant before the release", () => {
+    expect(defaultBreakthrough(BREAKTHROUGH_17_RELEASE - 1)).toBe(16)
+  })
+
+  it("flips at the release instant itself", () => {
+    expect(defaultBreakthrough(BREAKTHROUGH_17_RELEASE)).toBe(17)
+  })
+
+  it("flips at the same moment worldwide, not at each viewer's local 05:30", () => {
+    const tokyoMorning = Date.parse("2026-09-03T05:30:00+09:00")
+    const berlinMorning = Date.parse("2026-09-03T05:30:00+02:00")
+    const losAngelesMorning = Date.parse("2026-09-03T05:30:00-07:00")
+    expect(defaultBreakthrough(tokyoMorning)).toBe(16)
+    expect(defaultBreakthrough(berlinMorning)).toBe(17)
+    expect(defaultBreakthrough(losAngelesMorning)).toBe(17)
+  })
+
+  it("never drops below the pre-release default", () => {
+    expect(newestBreakthroughRelease(0)).toBe(0)
+    expect(defaultBreakthrough(0)).toBe(16)
+  })
+})
+
+describe("following a breakthrough release", () => {
+  it("leaves saved profiles alone before the release", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE - 1)
+    writeProfiles([{ breakthrough: 16 }, { breakthrough: 14 }])
+    expect(loadedBreakthroughs()).toEqual([16, 14])
+  })
+
+  it("moves every profile still on the superseded default up to 17", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16 }, { breakthrough: 16 }])
+    expect(loadedBreakthroughs()).toEqual([17, 17])
+  })
+
+  it("leaves a deliberately chosen breakthrough untouched", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 12 }, { breakthrough: 14 }, { breakthrough: 21 }])
+    expect(loadedBreakthroughs()).toEqual([12, 14, 21])
+  })
+
+  it("persists the follow so it happens once, not per load", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16 }])
+    loadProfiles()
+    expect(storedBreakthroughs()).toEqual([17])
+  })
+
+  it("stamps the profile rather than a global localStorage entry", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16 }])
+    const { profiles } = loadProfiles()
+    expect(profiles[0].inputs.followedBreakthroughRelease).toBe(17)
+    expect(Object.keys(localStorage)).toEqual([PROFILES_KEY])
+  })
+
+  it("does not follow twice, so re-picking the superseded default sticks", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16, followedBreakthroughRelease: 17 }])
+    expect(loadedBreakthroughs()).toEqual([16])
+  })
+
+  it("follows each profile independently", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16 }, { breakthrough: 16, followedBreakthroughRelease: 17 }])
+    expect(loadedBreakthroughs()).toEqual([17, 16])
+  })
+
+  it("keeps the stamp across a save round trip", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16 }])
+    saveProfiles(loadProfiles())
+    const blob = JSON.parse(kvStore.get(PROFILES_KEY) ?? "{}") as { profiles: { inputs: Inputs }[] }
+    expect(blob.profiles[0].inputs.followedBreakthroughRelease).toBe(17)
+  })
+
+  it("writes storage on the load that follows, and not on the next one", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16 }])
+    loadProfiles()
+    const writes = vi.spyOn(kvStore, "set")
+    expect(loadedBreakthroughs()).toEqual([17])
+    expect(writes).not.toHaveBeenCalled()
+    writes.mockRestore()
+  })
+
+  it("re-picking the superseded default after the follow survives a reload", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16 }])
+    const followed = loadProfiles()
+    expect(followed.profiles[0].inputs.breakthrough).toBe(17)
+    saveProfiles({
+      ...followed,
+      profiles: [
+        {
+          ...followed.profiles[0],
+          inputs: { ...followed.profiles[0].inputs, breakthrough: 16 },
+        },
+      ],
+    })
+    expect(loadedBreakthroughs()).toEqual([16])
+  })
+
+  it("changes nothing on the build but the breakthrough and the stamp", () => {
+    vi.setSystemTime(BREAKTHROUGH_17_RELEASE)
+    writeProfiles([{ breakthrough: 16 }, { breakthrough: 14 }])
+    const [followed, untouched] = loadProfiles().profiles
+    expect({ ...followed.inputs, breakthrough: 14 }).toEqual(untouched.inputs)
+  })
+})

--- a/tests/engine/engineBaseline.test.ts
+++ b/tests/engine/engineBaseline.test.ts
@@ -15,6 +15,7 @@ import { defaultInputs } from "../../src/engine/defaults"
 import { withDerivedStats } from "../../src/engine/derivedInputs"
 import { applyArmorSet, applyBowSet } from "../../src/engine/panel"
 import { loadProfiles } from "../../src/storage"
+import { newestBreakthroughRelease } from "../../src/definitions/baseStats/breakthroughs"
 import { defaultRotationForClass } from "../../src/engine/builtinLibrary"
 import { SET_ID } from "../../src/data/sets/ids"
 import type { Inputs, Result } from "../../src/engine/types"
@@ -36,13 +37,19 @@ const ANCHOR_FILE = anchorProfileFile as unknown as ProfileFile
 // `inputs` cannot be handed to the engine directly — this is App.tsx's pipeline.
 function anchorInputs(): Inputs {
   localStorage.clear()
+  // Stamped as having followed every breakthrough release: unstamped, the
+  // anchor's stored breakthrough follows the next one and moves every figure
+  // below on a release date rather than on a commit.
+  const profile = {
+    ...ANCHOR_FILE.profile,
+    inputs: {
+      ...ANCHOR_FILE.profile.inputs,
+      followedBreakthroughRelease: newestBreakthroughRelease(Number.MAX_SAFE_INTEGER),
+    },
+  }
   localStorage.setItem(
     PROFILES_KEY,
-    JSON.stringify({
-      v: ANCHOR_FILE.v,
-      profiles: [ANCHOR_FILE.profile],
-      activeId: ANCHOR_FILE.profile.id,
-    }),
+    JSON.stringify({ v: ANCHOR_FILE.v, profiles: [profile], activeId: profile.id }),
   )
   return loadProfiles().profiles[0].inputs
 }


### PR DESCRIPTION
A breakthrough tier may now carry a `release` instant, and the default breakthrough is derived from whichever releases that instant has passed. Scheduling the next one is that one JSON field — no code, and no deploy timed to the unlock.

Breakthrough 17 is scheduled for `2026-09-03T03:30:00Z`.

## Why the instant is absolute

It is a UTC instant, not a wall-clock time, so every user flips at the same real moment — 05:30 in Berlin, 04:30 in London, 12:30 in Tokyo. A local-time cutoff would flip each user at a different instant, so two people comparing builds on the same day could see different defaults.

## How a profile follows a release

Each profile records the newest release it has already followed, and it moves only while it still sits on the default that release supersedes:

- A deliberate pick survives, including re-picking the superseded default afterwards.
- The stamp is on the profile rather than the browser, so it survives export and import, and profiles follow independently.
- A profile that skipped a release walks the chain in one load.

## Migration

**Migration added: additive, no version bump.** `Inputs.followedBreakthroughRelease` is optional, and its absence means "followed nothing" — the correct reading for every already-saved profile. The release-follow pass then repairs the breakthrough at load and persists once.

## The locked baseline

The engine baseline loads a captured profile stored at the superseded default, so it is now stamped as having followed everything. Unstamped, its figures would have moved on a release date rather than on a commit — a red suite on `main` with no commit to blame. This was found by backdating the release and running the full suite; 24 baseline tests failed before the fix.

## Testing

`tests/engine/breakthroughRelease.test.ts` covers the schedule, the worldwide-simultaneous flip, and the follow-once behaviour end to end — including that the load which follows writes storage and the next one does not. The tests were checked for bite by mutating persistence so the stamp is stripped on save: five failed.

Gates green on this branch: format, lint, the English-only grep, typecheck, build, 1936 tests.

The wiki page `Saved Profile Migrations` gained a section on the pattern; that is committed separately in the wiki clone and not yet pushed.
