### PR TITLE
Let a rotation open on a partly built Zenith bar

### DIFF
--- a/src/data/innerWays/swordHorizon.ts
+++ b/src/data/innerWays/swordHorizon.ts
@@ -1,7 +1,7 @@
 import { defineInnerWay } from "../../definitions/innerWays/innerWayDef"
 import { INNER_WAY_ID, INNER_WAY_NODE } from "./ids"
 import { PARAM } from "../skills/buffs/ids"
-import { SWORD_HORIZON_GATES, zenithBar } from "./swordHorizonZenith"
+import { SWORD_HORIZON_GATES, ZENITH_BAR_BUFF_ID, zenithBar } from "./swordHorizonZenith"
 import { crosswindBehavior } from "./swordHorizonCrosswind"
 import { SKILL } from "../skills/bellstrike-umbra/ids"
 
@@ -20,6 +20,7 @@ export const swordHorizon = defineInnerWay({
     },
   },
   gateBuffs: SWORD_HORIZON_GATES,
+  openingStackBuffIds: [ZENITH_BAR_BUFF_ID],
   buffDefs: [zenithBar],
   // Bleed Detonation is the only skill that advances the Zenith bar — the
   // restriction is part of what Sword Horizon is, not a class fact, even

--- a/src/data/innerWays/swordHorizonCrosswind.ts
+++ b/src/data/innerWays/swordHorizonCrosswind.ts
@@ -26,6 +26,7 @@ export function crosswindBehavior(build: BuildView): SkillBehavior | null {
   const tracker = new CrosswindTracker({
     maxCharges: ZENITH_BAR_MAX_CHARGES,
     retainOnMax: innerWayHasNode(swordHorizon, tier, INNER_WAY_NODE.crosswindChargeRetention),
+    initialCharges: build.openingStacks(ZENITH_BAR_BUFF_ID),
   })
 
   return {

--- a/src/data/rotations/rotations.json
+++ b/src/data/rotations/rotations.json
@@ -373,6 +373,9 @@
           }
         ],
         "permanentBuffIds": [],
+        "openingStacks": {
+          "buff-bellstrikeUmbra-zenith-bar": 5
+        },
         "createdAt": "2026-07-19T00:00:00.000Z",
         "updatedAt": "2026-07-19T00:00:00.000Z",
         "description": "Eazy's T5 Wolf Rotation"
@@ -764,6 +767,9 @@
           }
         ],
         "permanentBuffIds": [],
+        "openingStacks": {
+          "buff-bellstrikeUmbra-zenith-bar": 5
+        },
         "createdAt": "2026-07-19T00:00:00.000Z",
         "updatedAt": "2026-07-19T00:00:00.000Z",
         "description": "Tier 6 Wolf rotation from Eazy"
@@ -1130,6 +1136,9 @@
           }
         ],
         "permanentBuffIds": [],
+        "openingStacks": {
+          "buff-bellstrikeUmbra-zenith-bar": 5
+        },
         "createdAt": "2026-07-19T00:00:00.000Z",
         "updatedAt": "2026-07-19T00:00:00.000Z",
         "description": ""
@@ -1581,6 +1590,9 @@
           }
         ],
         "permanentBuffIds": [],
+        "openingStacks": {
+          "buff-bellstrikeUmbra-zenith-bar": 5
+        },
         "createdAt": "2026-07-19T00:00:00.000Z",
         "updatedAt": "2026-07-19T00:00:00.000Z",
         "description": "T6 rotation from Bilibili, 29 Blood bursts"
@@ -1987,6 +1999,9 @@
           }
         ],
         "permanentBuffIds": [],
+        "openingStacks": {
+          "buff-bellstrikeUmbra-zenith-bar": 5
+        },
         "createdAt": "2026-08-01T00:00:00.000Z",
         "updatedAt": "2026-08-01T00:00:00.000Z",
         "description": "36 Bleed Bursts"
@@ -2343,6 +2358,9 @@
           }
         ],
         "permanentBuffIds": [],
+        "openingStacks": {
+          "buff-bellstrikeUmbra-zenith-bar": 5
+        },
         "createdAt": "2026-08-08T00:00:00.000Z",
         "updatedAt": "2026-08-08T00:00:00.000Z",
         "description": "1-minute Dragon Head rotation from Nox"
@@ -2499,6 +2517,9 @@
           }
         ],
         "permanentBuffIds": [],
+        "openingStacks": {
+          "buff-bellstrikeUmbra-zenith-bar": 5
+        },
         "createdAt": "2026-08-08T00:00:00.000Z",
         "updatedAt": "2026-08-08T00:00:00.000Z",
         "description": "30-second Dragon Head rotation from Nox"

--- a/src/definitions/innerWays/innerWayDef.ts
+++ b/src/definitions/innerWays/innerWayDef.ts
@@ -59,6 +59,9 @@ export interface InnerWayDef {
   // Folded into every slotting class by the class registry; the two below
   // register directly instead — CLASSES.md § "One definition per class".
   gateBuffs?: readonly InnerWayGateBuff[]
+  // Authored, never derived from `maxStacks`: a gate buff is pre-settable only
+  // once something actually seeds a simulation from its opening count.
+  openingStackBuffIds?: readonly string[]
   buffDefs?: readonly BuffModule[]
   displayGates?: readonly DisplayGateRegistration[]
   skillBehaviors?: readonly SkillBehaviorRegistration[]

--- a/src/definitions/innerWays/registry.ts
+++ b/src/definitions/innerWays/registry.ts
@@ -96,6 +96,16 @@ export function hasInnerWay(slots: readonly SlottedInnerWay[], innerWayId: strin
   return slots.some((slot) => slotInnerWayId(slot) === innerWayId)
 }
 
+export function openingStackBuffIds(slots: readonly SlottedInnerWay[]): string[] {
+  const out: string[] = []
+  for (const def of INNER_WAYS) {
+    if (!def.openingStackBuffIds?.length) continue
+    if (!slots.some((slot) => slotInnerWayId(slot) === def.id)) continue
+    for (const buffId of def.openingStackBuffIds) if (!out.includes(buffId)) out.push(buffId)
+  }
+  return out
+}
+
 export function innerWayTier(slots: readonly SlottedInnerWay[], innerWayId: string): number | null {
   const slot = slots.find((candidate) => slotInnerWayId(candidate) === innerWayId)
   return slot ? tierFromStacks(slot.stacks) : null

--- a/src/engine/behavior.ts
+++ b/src/engine/behavior.ts
@@ -27,6 +27,7 @@ export interface BuildView {
   innerWayTier(name: string): number | null
   classSpecificAttunement(attunementId: string): number
   grantsMinPhysCritBoost(weaponType: string | undefined): boolean
+  openingStacks(buffId: string): number
 }
 
 export interface HitInput {

--- a/src/engine/buffs/crosswind.ts
+++ b/src/engine/buffs/crosswind.ts
@@ -12,12 +12,16 @@ export interface CrosswindOutcome {
 export interface CrosswindTrackerOptions {
   maxCharges: number
   retainOnMax: boolean
+  initialCharges?: number
 }
 
 export class CrosswindTracker {
-  private charges = 0
+  private charges: number
 
-  constructor(private readonly options: CrosswindTrackerOptions) {}
+  constructor(private readonly options: CrosswindTrackerOptions) {
+    const opening = Math.floor(options.initialCharges ?? 0)
+    this.charges = Math.max(0, Math.min(options.maxCharges, Number.isFinite(opening) ? opening : 0))
+  }
 
   get charge(): number {
     return this.charges

--- a/src/engine/castBuffs.ts
+++ b/src/engine/castBuffs.ts
@@ -57,7 +57,8 @@ export function collectCastBuffs(query: CastBuffQuery): CastBuffCollection {
     seen.add(id)
 
     const tracked = ledger.stacksAt(id, frame)
-    const stacks = tracked > 0 ? tracked : ledger.hasStackHistory(id) ? tracked : 1
+    const countsStacks = (status.maxStacks ?? 1) > 1
+    const stacks = tracked > 0 || countsStacks || ledger.hasStackHistory(id) ? tracked : 1
     const dotIntervalSec =
       hasDot(status) && status.dot && status.dot.tickIntervalFrames > 0
         ? status.dot.tickIntervalFrames / fps

--- a/src/engine/rotation.ts
+++ b/src/engine/rotation.ts
@@ -14,6 +14,7 @@ export interface Rotation {
   classId: string
   steps: RotationStep[]
   permanentBuffIds: string[]
+  openingStacks?: Record<string, number>
   createdAt: string
   updatedAt: string
   description?: string
@@ -80,6 +81,13 @@ export function isRotation(x: unknown): x is Rotation {
   if (!Array.isArray(r.permanentBuffIds)) return false
   for (const id of r.permanentBuffIds) {
     if (typeof id !== "string") return false
+  }
+  if (r.openingStacks !== undefined) {
+    if (!r.openingStacks || typeof r.openingStacks !== "object" || Array.isArray(r.openingStacks))
+      return false
+    for (const stacks of Object.values(r.openingStacks as Record<string, unknown>)) {
+      if (typeof stacks !== "number" || !Number.isFinite(stacks) || stacks < 0) return false
+    }
   }
   if (typeof r.createdAt !== "string") return false
   if (typeof r.updatedAt !== "string") return false

--- a/src/engine/timeline.ts
+++ b/src/engine/timeline.ts
@@ -228,6 +228,13 @@ export function simulateTimeline(inputs: Inputs, options?: EngineRunOptions): Re
     if (statusById.has(id)) openPermanent(id)
   }
 
+  for (const [id, stacks] of Object.entries(rotation.openingStacks ?? {})) {
+    const status = statusById.get(id)
+    if (!status || stacks <= 0) continue
+    openPermanent(status.id)
+    recordStack(status.id, spanStart, Math.min(stacks, status.maxStacks))
+  }
+
   function activeBuffsAt(frame: number): (Buff | Debuff)[] {
     const out: (Buff | Debuff)[] = []
     for (const id of ledger.activeIdsAt(frame)) {
@@ -247,6 +254,7 @@ export function simulateTimeline(inputs: Inputs, options?: EngineRunOptions): Re
     innerWayTier: (innerWayId) => innerWayTier(inputs.mindMethods, innerWayId),
     classSpecificAttunement: (attunementId) => inputs.classSpecificAttunement[attunementId] ?? 0,
     grantsMinPhysCritBoost: grantsMinPhysCritBoostFor(inputs.classId),
+    openingStacks: (buffId) => rotation.openingStacks?.[buffId] ?? 0,
   }
 
   const behaviorFor = buildBehaviors(buildView)

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -881,6 +881,8 @@
   "rotation.editor.durationComputed": "Duration (computed)",
   "rotation.editor.eachStepPicksHint": "Each step picks a saved skill; hit-triggered buffs/skills land at the hit's frame offset. The Buffs column shows what's still active once that cast fully resolves, chips are ordered by when each buff first appears in the rotation, and always-on spec passives are listed in the Class Talents tab instead.",
   "rotation.editor.forkToCustom": "Fork to Custom",
+  "rotation.editor.opening": "Opening",
+  "rotation.editor.openingReadonly": "Fork to Custom to change the opening stacks",
   "rotation.editor.permanentBuffs": "Permanent buffs",
   "rotation.editor.permanentBuffsDebuffs": "Permanent Buffs/Debuffs",
   "rotation.editor.permanentDebuffs": "Permanent Debuffs",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -881,6 +881,8 @@
   "rotation.editor.durationComputed": "지속 시간(계산값)",
   "rotation.editor.eachStepPicksHint": "각 단계에서 저장된 스킬을 선택합니다. 적중으로 발동하는 버프와 스킬은 해당 타격의 프레임 오프셋에 적용됩니다. 버프 열에는 시전이 완전히 끝난 뒤에도 활성인 효과가 표시되며, 칩은 로테이션에 처음 등장한 순서로 정렬됩니다. 상시 유파 패시브는 유파 천부 탭에 표시됩니다.",
   "rotation.editor.forkToCustom": "사용자 지정으로 복제",
+  "rotation.editor.opening": "시작",
+  "rotation.editor.openingReadonly": "시작 중첩을 변경하려면 사용자 지정으로 복제하세요",
   "rotation.editor.permanentBuffs": "상시 버프",
   "rotation.editor.permanentBuffsDebuffs": "상시 버프/디버프",
   "rotation.editor.permanentDebuffs": "상시 디버프",

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -156,8 +156,21 @@ function migrateRotationIds<T>(rotation: T): T {
       migrateCleftpeakBuffId(migrateEntityId(buffId)),
     )
   }
+  if (r.openingStacks !== undefined) next.openingStacks = sanitizeOpeningStacks(r.openingStacks)
   delete (next as unknown as Record<string, unknown>).prePullHitsCount
   return next as unknown as T
+}
+
+// additive — see CLAUDE.md → "localStorage migrations"
+function sanitizeOpeningStacks(stored: unknown): Record<string, number> {
+  if (!stored || typeof stored !== "object" || Array.isArray(stored)) return {}
+  const healed: Record<string, number> = {}
+  for (const [buffId, stacks] of Object.entries(stored as Record<string, unknown>)) {
+    if (typeof stacks !== "number" || !Number.isFinite(stacks) || stacks < 0) continue
+    const whole = Math.floor(stacks)
+    if (whole > 0) healed[migrateCleftpeakBuffId(migrateEntityId(buffId))] = whole
+  }
+  return healed
 }
 
 // A word outside the catalogue already scores nothing, so clearing the row costs
@@ -566,6 +579,7 @@ export function importCustomRotation(text: string): Rotation {
     permanentBuffIds: Array.isArray(candidate.permanentBuffIds)
       ? candidate.permanentBuffIds.filter((x): x is string => typeof x === "string")
       : [],
+    openingStacks: sanitizeOpeningStacks(candidate.openingStacks),
     createdAt: now,
     updatedAt: now,
   }

--- a/src/ui/features/rotation/rotation-editor-panel/RotationEditorPanel.module.scss
+++ b/src/ui/features/rotation/rotation-editor-panel/RotationEditorPanel.module.scss
@@ -271,3 +271,63 @@
   padding: 4px;
   font-size: 0.85em;
 }
+.openingRow {
+  background: var(--color-surface-selected);
+  border-color: rgba(192, 160, 96, 0.28);
+}
+.openingRowReadonly .pip,
+.openingRowReadonly .pipCount {
+  opacity: 0.45;
+}
+.openingBadge {
+  font-size: 0.7em;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+.pips {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+.pip {
+  width: 22px;
+  height: 15px;
+  padding: 0;
+  border-radius: 2px;
+  border: 1px solid hsla(var(--buff-hue), 40%, 50%, 0.4);
+  background: hsla(var(--buff-hue), 40%, 40%, 0.12);
+  cursor: pointer;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+}
+.pip:disabled {
+  cursor: default;
+}
+@include breakpoints.hoverable {
+  .pip:hover:not(:disabled) {
+    border-color: hsla(var(--buff-hue), 60%, 65%, 0.9);
+  }
+}
+.pipOn {
+  background: hsla(var(--buff-hue), 52%, 46%, 0.85);
+  border-color: hsl(var(--buff-hue), 60%, 66%);
+}
+.pipEmpty {
+  width: 17px;
+  border-style: dashed;
+  border-color: var(--color-border-strong);
+  background: transparent;
+}
+.pipEmpty.pipOn {
+  background: var(--color-surface-selected);
+  border-color: var(--color-accent);
+  border-style: solid;
+}
+.pipCount {
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+  color: hsl(var(--buff-hue), 55%, 72%);
+  min-width: 34px;
+}

--- a/src/ui/features/rotation/rotation-editor-panel/RotationEditorPanel.tsx
+++ b/src/ui/features/rotation/rotation-editor-panel/RotationEditorPanel.tsx
@@ -15,6 +15,8 @@ import { Combobox, type ComboboxOption } from "../../../components/combobox/Comb
 import { FPS } from "../../../../engine/timeline"
 import { isPrePullSkill, type Skill } from "../../../../engine/skill"
 import { builtinSkillsForClass, builtinRotationsForClass } from "../../../../engine/builtinLibrary"
+import { builtinBuffsForClass } from "../../../../engine/builtinBuffs"
+import { openingStackBuffIds } from "../../../../definitions/innerWays/registry"
 import { hiddenTimelineBuffIds } from "../../../../engine/buffs/catalog"
 import { STAT_DEF_BY_KEY } from "../../../../engine/statRegistry"
 import { buffChipHue, castBuffDisplayOrder, visibleCastBuffs } from "../buffChips"
@@ -136,6 +138,14 @@ export function RotationEditorPanel({ inputs, onChange, result }: Props) {
     () => loadCustomDebuffsForClass(inputs.classId),
     [inputs.classId],
   )
+  const openingStackBuffs = useMemo<Buff[]>(() => {
+    const openable = openingStackBuffIds(inputs.mindMethods)
+    if (openable.length === 0) return []
+    const byId = new Map(builtinBuffsForClass(inputs.classId).map((buff) => [buff.id, buff]))
+    return openable
+      .map((buffId) => byId.get(buffId))
+      .filter((buff): buff is Buff => !!buff && buff.maxStacks > 1)
+  }, [inputs.classId, inputs.mindMethods])
   const skillsById = useMemo(
     () => new Map(classSkills.map((skill) => [skill.id, skill] as const)),
     [classSkills],
@@ -276,6 +286,14 @@ export function RotationEditorPanel({ inputs, onChange, result }: Props) {
   function setPermanentBuffIds(ids: string[]) {
     commitRotation((rotation) => ({ ...rotation, permanentBuffIds: ids }))
   }
+  function setOpeningStacks(buffId: string, stacks: number) {
+    commitRotation((rotation) => {
+      const next = { ...rotation.openingStacks }
+      if (stacks > 0) next[buffId] = stacks
+      else delete next[buffId]
+      return { ...rotation, openingStacks: next }
+    })
+  }
   function handleNew() {
     const empty = makeRotation(inputs.classId)
     onChange({ ...inputs, activeCustomRotation: empty, selectedBuiltinRotationId: null })
@@ -290,6 +308,7 @@ export function RotationEditorPanel({ inputs, onChange, result }: Props) {
         return { ...step, id: newStepId(), hitCount: skill ? skill.hits.length : step.hitCount }
       }),
       permanentBuffIds: [...activeRotation.permanentBuffIds],
+      openingStacks: { ...activeRotation.openingStacks },
     })
     onChange({ ...inputs, activeCustomRotation: copy, selectedBuiltinRotationId: null })
   }
@@ -472,6 +491,14 @@ export function RotationEditorPanel({ inputs, onChange, result }: Props) {
           <div className={styles.divider} />
 
           <div className={styles.entries}>
+            {openingStackBuffs.map((buff) => (
+              <OpeningStackRow
+                key={buff.id}
+                buff={buff}
+                value={activeRotation.openingStacks?.[buff.id] ?? 0}
+                onChange={isCustom ? (stacks) => setOpeningStacks(buff.id, stacks) : null}
+              />
+            ))}
             {steps.map((step, idx) => {
               const skill = skillsById.get(step.skillId)
               const maxHits = Math.max(1, skill?.hits.length ?? 1)
@@ -620,6 +647,63 @@ export function RotationEditorPanel({ inputs, onChange, result }: Props) {
           <div className="hint">{t("rotation.editor.eachStepPicksHint")}</div>
         </div>
       )}
+    </div>
+  )
+}
+
+function OpeningStackRow({
+  buff,
+  value,
+  onChange,
+}: {
+  buff: Buff
+  value: number
+  onChange: ((stacks: number) => void) | null
+}) {
+  const { t } = useI18n()
+  const max = buff.maxStacks
+  const clamped = Math.max(0, Math.min(max, value))
+  const charges = Array.from({ length: max + 1 }, (_, charge) => charge)
+  const pipClassName = (charge: number): string => {
+    const filled = charge === 0 ? clamped === 0 : charge <= clamped
+    return [styles.pip, charge === 0 ? styles.pipEmpty : "", filled ? styles.pipOn : ""]
+      .filter(Boolean)
+      .join(" ")
+  }
+  const style = { "--buff-hue": buffChipHue(buff.name, buff.id) } as React.CSSProperties
+  const rowClassName = [styles.entry, styles.openingRow, onChange ? "" : styles.openingRowReadonly]
+    .filter(Boolean)
+    .join(" ")
+  return (
+    <div
+      className={rowClassName}
+      style={style}
+      title={onChange ? undefined : t("rotation.editor.openingReadonly")}
+    >
+      <div className={styles.idx}>—</div>
+      <span className={styles.openingBadge}>{t("rotation.editor.opening")}</span>
+      <span className={styles.skillStatic}>{t(buffKey(buff.id), buff.name)}</span>
+      <span className={styles.castReadonly} />
+      <span className={styles.prepull} />
+      <div className={styles.buffsCell}>
+        <span className={styles.pips}>
+          {charges.map((charge) => (
+            <button
+              key={charge}
+              type="button"
+              className={pipClassName(charge)}
+              aria-pressed={charge === clamped}
+              aria-label={`${charge} / ${max}`}
+              disabled={!onChange}
+              onClick={() => onChange?.(charge)}
+              title={`${charge} / ${max}`}
+            />
+          ))}
+        </span>
+        <span className={styles.pipCount}>
+          {clamped} / {max}
+        </span>
+      </div>
     </div>
   )
 }

--- a/tests/engine/behavior.test.ts
+++ b/tests/engine/behavior.test.ts
@@ -11,6 +11,7 @@ const build = {
   innerWayTier: () => null,
   classSpecificAttunement: () => 0,
   grantsMinPhysCritBoost: () => false,
+  openingStacks: () => 0,
 }
 
 const context: HitContext = {

--- a/tests/engine/bellstrikeUmbraParity.test.ts
+++ b/tests/engine/bellstrikeUmbraParity.test.ts
@@ -146,21 +146,24 @@ describe("Bellstrike Umbra (bellstrikeUmbra) — T6-Bili parity vs the reference
     // Intentionally loose, re-centered bands (see the file header) — not the
     // site's cached target. Re-center as further mechanics land; do not
     // widen a band to paper over a regression.
-    expect(result.dps).toBeGreaterThan(48860)
-    expect(result.dps).toBeLessThan(49030)
-    expect(result.totalDamage).toBeGreaterThan(2964000)
-    expect(result.totalDamage).toBeLessThan(2979000)
-    expect(detonation?.expectedDamage).toBeGreaterThan(1592000)
-    expect(detonation?.expectedDamage).toBeLessThan(1606000)
+    expect(result.dps).toBeGreaterThan(49220)
+    expect(result.dps).toBeLessThan(49390)
+    expect(result.totalDamage).toBeGreaterThan(2986000)
+    expect(result.totalDamage).toBeLessThan(3001000)
+    expect(detonation?.expectedDamage).toBeGreaterThan(1614000)
+    expect(detonation?.expectedDamage).toBeLessThan(1628000)
 
-    // The engine sits ~1.2 % ABOVE the cached target, from two sources the
+    // The engine sits ~1.9 % ABOVE the cached target, from three sources the
     // cached run predates: bleed ticks and Bleed Detonation take all-martial
-    // (and ticks sword boost) per the lvl-110 workbook's Sword typing, and a
-    // DoT tick now keeps the flat damage its own data authors.
+    // (and ticks sword boost) per the lvl-110 workbook's Sword typing, a
+    // DoT tick now keeps the flat damage its own data authors, and the
+    // built-in rotations open on a full Zenith bar, which lands the bar's
+    // damage bonus on detonations the cached run scored from empty — the
+    // detonation row alone therefore runs ~2.7 % over.
     expect(result.dps / SITE_TARGET_DPS).toBeGreaterThan(0.999)
-    expect(result.dps / SITE_TARGET_DPS).toBeLessThan(1.02)
+    expect(result.dps / SITE_TARGET_DPS).toBeLessThan(1.025)
     expect(result.totalDamage / SITE_TARGET_TOTAL).toBeGreaterThan(0.999)
-    expect(result.totalDamage / SITE_TARGET_TOTAL).toBeLessThan(1.02)
-    expect((detonation?.expectedDamage ?? 0) / SITE_TARGET_DETONATION).toBeLessThan(1.018)
+    expect(result.totalDamage / SITE_TARGET_TOTAL).toBeLessThan(1.025)
+    expect((detonation?.expectedDamage ?? 0) / SITE_TARGET_DETONATION).toBeLessThan(1.03)
   })
 })

--- a/tests/engine/castBuffStacks.test.ts
+++ b/tests/engine/castBuffStacks.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { collectCastBuffs } from "../../src/engine/castBuffs"
+import { StatusLedger } from "../../src/engine/ledger"
+import { makeBuff } from "../../src/engine/buff"
+import type { Buff } from "../../src/engine/buff"
+
+const CLASS = "testClass"
+
+function stacksShownFor(buff: Buff, seed?: { frame: number; value: number }): number {
+  const ledger = new StatusLedger(0, 600)
+  ledger.openPermanent(buff.id)
+  if (seed) ledger.recordStack(buff.id, seed.frame, seed.value)
+  const { buffs } = collectCastBuffs({
+    frame: 0,
+    timeSec: 0,
+    fps: 60,
+    ledger,
+    statusById: new Map([[buff.id, buff]]),
+    buffEngine: null,
+  })
+  return buffs.find((tag) => tag.id === buff.id)!.stacks
+}
+
+const counter = makeBuff(CLASS, { name: "Counter", maxStacks: 5 })
+const plainBuff = makeBuff(CLASS, { name: "Plain", maxStacks: 1 })
+
+describe("a cast's status stacks", () => {
+  it("shows a counter as empty while it is up but holds nothing", () => {
+    expect(stacksShownFor(counter)).toBe(0)
+  })
+
+  it("shows a counter's recorded count once one exists", () => {
+    expect(stacksShownFor(counter, { frame: 0, value: 3 })).toBe(3)
+  })
+
+  it("still shows a buff that does not count as a single stack", () => {
+    expect(stacksShownFor(plainBuff)).toBe(1)
+  })
+})

--- a/tests/engine/classExtensionPoints.test.ts
+++ b/tests/engine/classExtensionPoints.test.ts
@@ -69,6 +69,7 @@ const buildFor = (classId: string) => ({
   innerWayTier: () => null,
   classSpecificAttunement: () => 0,
   grantsMinPhysCritBoost: () => false,
+  openingStacks: () => 0,
 })
 
 describe("a class can be wired from outside the engine", () => {

--- a/tests/engine/classRegistry.test.ts
+++ b/tests/engine/classRegistry.test.ts
@@ -183,6 +183,7 @@ describe("bellstrikeUmbra — every declared ClassDef field is wired", () => {
       innerWayTier: (name) => (name === "swordHorizon" ? 1 : null),
       classSpecificAttunement: () => 0,
       grantsMinPhysCritBoost: () => false,
+      openingStacks: () => 0,
     }
     expect(buildBehaviors(build)(bleedDetonation)).not.toBe(DEFAULT_BEHAVIOR)
     const noSwordHorizon: BuildView = { ...build, innerWayTier: () => null }

--- a/tests/engine/crosswindOpeningStacks.test.ts
+++ b/tests/engine/crosswindOpeningStacks.test.ts
@@ -1,0 +1,100 @@
+// Scoped to bellstrikeUmbra — TESTING.md § "Class scoping".
+import { describe, expect, it } from "vitest"
+import { CrosswindTracker } from "../../src/engine/buffs/crosswind"
+import { simulateTimeline } from "../../src/engine/timeline"
+import { defaultInputs } from "../../src/engine/defaults"
+import { builtinSkill } from "../builtins"
+import { SKILL } from "../../src/data/skills/bellstrike-umbra/ids"
+import { makeRotation, makeStep } from "../../src/engine/rotation"
+import { ZENITH_BAR_BUFF_ID } from "../../src/data/innerWays/swordHorizonZenith"
+import type { Inputs } from "../../src/engine/types"
+
+const MAX = 5
+const CLASS = "bellstrikeUmbra"
+
+const tracker = (initialCharges?: number) =>
+  new CrosswindTracker({ maxCharges: MAX, retainOnMax: false, initialCharges })
+
+describe("CrosswindTracker — opening charges", () => {
+  it("opens empty when no opening count is given", () => {
+    expect(tracker().charge).toBe(0)
+  })
+
+  it("opens on the given count", () => {
+    expect(tracker(3).charge).toBe(3)
+  })
+
+  it("advances by one per detonation from the opening count, exactly as from empty", () => {
+    const opened = tracker(3)
+    opened.onDetonation()
+    expect(opened.charge).toBe(4)
+    opened.onDetonation()
+    expect(opened.charge).toBe(5)
+  })
+
+  it("reaches its guaranteed-affinity detonation earlier by the opening count", () => {
+    const empty = tracker()
+    const opened = tracker(3)
+    const detonationsUntilAffinity = (subject: CrosswindTracker) => {
+      let casts = 0
+      while (!subject.onDetonation().guaranteedAffinity) casts++
+      return casts
+    }
+    expect(detonationsUntilAffinity(empty) - detonationsUntilAffinity(opened)).toBe(3)
+  })
+
+  it("grants the damage bonus on the very first detonation when it opens charged", () => {
+    expect(tracker().onDetonation().damageBonusActive).toBe(false)
+    expect(tracker(1).onDetonation().damageBonusActive).toBe(true)
+  })
+
+  it("resets to empty after a detonation at max, not back to the opening count", () => {
+    const opened = tracker(MAX)
+    expect(opened.onDetonation().guaranteedAffinity).toBe(true)
+    expect(opened.charge).toBe(0)
+  })
+
+  it("clamps an opening count above the cap and below zero", () => {
+    expect(tracker(99).charge).toBe(MAX)
+    expect(tracker(-2).charge).toBe(0)
+  })
+})
+
+function zenithStacksPerCast(opening: number): number[] {
+  const filler = builtinSkill(CLASS, SKILL.swordq)!
+  const detonation = builtinSkill(CLASS, SKILL.bleedDetonation)!
+  const inputs: Inputs = {
+    ...defaultInputs,
+    classId: CLASS,
+    mindMethods: [
+      { name: "Sword Horizon", id: "swordHorizon", stacks: "tier 6" },
+      ...defaultInputs.mindMethods.slice(1),
+    ] as Inputs["mindMethods"],
+    activeCustomRotation: makeRotation(CLASS, {
+      name: "opening-stacks",
+      steps: [
+        makeStep({ skillId: filler.id, hitCount: filler.hits.length }),
+        makeStep({ skillId: detonation.id, hitCount: detonation.hits.length }),
+      ],
+      openingStacks: { [ZENITH_BAR_BUFF_ID]: opening },
+    }),
+  }
+  return (simulateTimeline(inputs).casts ?? []).map(
+    (cast) => cast.buffs.find((buff) => buff.id === ZENITH_BAR_BUFF_ID)?.stacks ?? 0,
+  )
+}
+
+describe("Zenith Bar opening stacks — the rotation timeline", () => {
+  it("shows the opening count on a cast that lands before the first detonation", () => {
+    expect(zenithStacksPerCast(3)[0]).toBe(3)
+  })
+
+  it("advances from the opening count on the first detonation, rather than from empty", () => {
+    expect(zenithStacksPerCast(3)[1]).toBe(4)
+    expect(zenithStacksPerCast(0)[1]).toBe(1)
+  })
+
+  it("draws the bar empty, not at a single stack, when the rotation opens on nothing", () => {
+    expect(zenithStacksPerCast(0)[0]).toBe(0)
+  })
+})

--- a/tests/engine/engineBaseline.fixture.json
+++ b/tests/engine/engineBaseline.fixture.json
@@ -1,7 +1,7 @@
 {
   "anchor": {
-    "dps": 75079.84,
-    "totalDamage": 4325850.03,
+    "dps": 75548.12,
+    "totalDamage": 4352830.94,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -66,7 +66,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2158142.62,
+        "expectedDamage": 2185123.53,
         "castCount": 0
       },
       {
@@ -184,14 +184,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "84bbd33e69e158f10a95da5d95a3e6f36ae5dc7a2646b1ed377da762cc9f83ce"
+    "digest": "afc977b36c6c8144f8081aa43a89975bbe2f3099c93456ff37a995f2c576b691"
   },
   "anchor:noAttunement": {
-    "dps": 67483.3,
-    "totalDamage": 3888162.66,
+    "dps": 67867.45,
+    "totalDamage": 3910296.3,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -256,7 +256,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 1770420.53,
+        "expectedDamage": 1792554.17,
         "castCount": 0
       },
       {
@@ -374,14 +374,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "9e42bc91db56b01ccf46ec29f20ccdf2ce1f6a920f413b6e5dc07aba1c7d9bd6"
+    "digest": "825d774f2dca02b2314a3fa1453932a12b1d1a9baddfac6ba906f18cd3653131"
   },
   "anchor:dummyOff": {
-    "dps": 80270.37,
-    "totalDamage": 4624911.31,
+    "dps": 80765.83,
+    "totalDamage": 4653458.08,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -446,7 +446,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2301009.62,
+        "expectedDamage": 2329556.38,
         "castCount": 0
       },
       {
@@ -564,14 +564,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "584a7e9aa6ece91fa020f9e505f431948ec4b9fa4f45314a263de4791a991723"
+    "digest": "1be1548cde75ee666aece757463509fd221bd2e91e2cd1a2d3598480ec92cec6"
   },
   "anchor:noQiBreak": {
-    "dps": 68185.21,
-    "totalDamage": 3928604.41,
+    "dps": 68653.49,
+    "totalDamage": 3955585.31,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -636,7 +636,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2148995.3,
+        "expectedDamage": 2175976.2,
         "castCount": 0
       },
       {
@@ -754,14 +754,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "5387f71c673f402c451b07a30c5640eced890dc0e0e1ee08b85efccacedf0a39"
+    "digest": "9705880bb1d4c92e9484dbcb21beb13c50c39fc5a9496a46d99c19c63ad51166"
   },
   "anchor:healerBuff": {
-    "dps": 82400.85,
-    "totalDamage": 4747662.2,
+    "dps": 82905.37,
+    "totalDamage": 4776730.91,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -826,7 +826,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2353205.61,
+        "expectedDamage": 2382274.33,
         "castCount": 0
       },
       {
@@ -944,14 +944,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "883363efe7a53da875c7b35fbfb017da0e2464ef5ea9255f582eac5534b6d64a"
+    "digest": "5fed13f72d52ca1ccfdb6963bcdc48def4dca079bd8558f9736026751e3d3410"
   },
   "anchor:revelryScript": {
-    "dps": 85460.91,
-    "totalDamage": 4923972.6,
+    "dps": 85983.54,
+    "totalDamage": 4954085.22,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -1016,7 +1016,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2443876.61,
+        "expectedDamage": 2473989.23,
         "castCount": 0
       },
       {
@@ -1134,14 +1134,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "9ea50f291891f4cd1ee249dec28aeb603f5c782ff6e4dc8b4dcfffb55d63a3f9"
+    "digest": "b7f2ba03591d458cf03789db7a4a2c14c35cd3ab64fab94a5b561f1954738b2e"
   },
   "anchor:breakExtension": {
-    "dps": 76193.37,
-    "totalDamage": 4390008.28,
+    "dps": 76661.66,
+    "totalDamage": 4416989.19,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -1206,7 +1206,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2197929.4,
+        "expectedDamage": 2224910.3,
         "castCount": 0
       },
       {
@@ -1324,14 +1324,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "5d7305833403dbc76efd4666ee16916b9438304a7fb97201b613d332ce4f2713"
+    "digest": "7520c44b53f6609facb6c79152a453433cdbecbabf285b24df74574114e06e3f"
   },
   "anchor:swordHorizonT1": {
-    "dps": 52729.07,
-    "totalDamage": 3038073.46,
+    "dps": 55292.87,
+    "totalDamage": 3185790.62,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -1396,7 +1396,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 20,
-        "expectedDamage": 1276828.26,
+        "expectedDamage": 1299892.31,
         "castCount": 0
       },
       {
@@ -1499,8 +1499,8 @@
         "name": "Smolder (DoT)",
         "breakdownName": "Smolder",
         "type": "sustain",
-        "count": 23,
-        "expectedDamage": 78033.46,
+        "count": 57,
+        "expectedDamage": 202686.56,
         "castCount": 0
       },
       {
@@ -1513,11 +1513,11 @@
       }
     ],
     "counts": {
-      "timeline": 238,
-      "buffWindows": 126,
+      "timeline": 272,
+      "buffWindows": 127,
       "casts": 69
     },
-    "digest": "f9cd29b14c733046f8ecbfdf9e448e250ed324d62341aba237a3e4a6a9ad77da"
+    "digest": "0e3a998c1908345eb1bd41cc54dd0a9f5aa5fe252af4a6afa344a617b231e7b7"
   },
   "anchor:noSwordHorizon": {
     "dps": 45927.04,
@@ -1704,14 +1704,14 @@
     ],
     "counts": {
       "timeline": 238,
-      "buffWindows": 122,
+      "buffWindows": 123,
       "casts": 69
     },
-    "digest": "18ba7053a8dca625fa43f9e7bc0a333cf807aaa464c7d00f61049659f2fb1ea2"
+    "digest": "4d5a9315cc4d1fa6119aaabe17fb6befb681b5bd67e5730ce779f7e8ba0d6d37"
   },
   "anchor:noInsightfulStrike": {
-    "dps": 64204.82,
-    "totalDamage": 3699267.43,
+    "dps": 64617.8,
+    "totalDamage": 3723062.34,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -1776,7 +1776,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 1779347.79,
+        "expectedDamage": 1803142.71,
         "castCount": 0
       },
       {
@@ -1894,14 +1894,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "2cf3b9cc03f7bab41b7a06a636d4787c18ca2112519af40bcfadd6940784c36a"
+    "digest": "5e3c66211d9ed968dcb2d75d8c7aaf0781ca4db1f8c681c3c53a1dd030c361ca"
   },
   "anchor:noMoraleChant": {
-    "dps": 68758.1,
-    "totalDamage": 3961612.32,
+    "dps": 69218.42,
+    "totalDamage": 3988134.87,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -1966,7 +1966,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2014001.63,
+        "expectedDamage": 2040524.18,
         "castCount": 0
       },
       {
@@ -2076,14 +2076,14 @@
     ],
     "counts": {
       "timeline": 350,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "198f061502ab71988c1ce306cd4fc6d9c0b3a7f4c7939bde8e14c36d84228c29"
+    "digest": "6ea859db0a7a7013714fc3d3e33351e0b92b59e9c26b16210287e03e3bc7c6fd"
   },
   "anchor:spearHeavyNoWolfchasersArt": {
-    "dps": 43616.94,
-    "totalDamage": 2649729.12,
+    "dps": 43921.99,
+    "totalDamage": 2668260.61,
     "rotationDuration": 60.75,
     "warnings": [],
     "perSkill": [
@@ -2156,7 +2156,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 36,
-        "expectedDamage": 1493368.1,
+        "expectedDamage": 1511899.59,
         "castCount": 0
       },
       {
@@ -2274,14 +2274,14 @@
     ],
     "counts": {
       "timeline": 383,
-      "buffWindows": 145,
+      "buffWindows": 146,
       "casts": 80
     },
-    "digest": "351ebead616b9bf08a013affaab19c6947ac543e5097c7db91bc53854bd61e49"
+    "digest": "147cc87ff95a10d65654c2d9647d1e1061dd41a33a04f4b3b98d2319b93681c9"
   },
   "anchor:bitterSeasonT6": {
-    "dps": 54566.25,
-    "totalDamage": 3143925.37,
+    "dps": 54905.94,
+    "totalDamage": 3163497.41,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -2346,7 +2346,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 1382925.72,
+        "expectedDamage": 1400919.51,
         "castCount": 0
       },
       {
@@ -2458,7 +2458,7 @@
         "breakdownName": "Bitter Season Tick",
         "type": "sustain",
         "count": 57,
-        "expectedDamage": 68144.97,
+        "expectedDamage": 69723.22,
         "castCount": 0
       },
       {
@@ -2472,14 +2472,14 @@
     ],
     "counts": {
       "timeline": 412,
-      "buffWindows": 130,
+      "buffWindows": 131,
       "casts": 69
     },
-    "digest": "a6124aab6f0e78a12405a39a564fe071ac65a44c5951dba5510057e46e24ddde"
+    "digest": "b0f7b253bbaba55cb9af9bb06701d7541cf8b060fb8421c36f3b15b9a58fa697"
   },
   "anchor:bitterSeasonT4": {
-    "dps": 53545.89,
-    "totalDamage": 3085135.66,
+    "dps": 53879.15,
+    "totalDamage": 3104336.99,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -2544,7 +2544,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 1358072.01,
+        "expectedDamage": 1375727.29,
         "castCount": 0
       },
       {
@@ -2656,7 +2656,7 @@
         "breakdownName": "Bitter Season Tick",
         "type": "sustain",
         "count": 57,
-        "expectedDamage": 66755.72,
+        "expectedDamage": 68301.77,
         "castCount": 0
       },
       {
@@ -2670,14 +2670,14 @@
     ],
     "counts": {
       "timeline": 412,
-      "buffWindows": 130,
+      "buffWindows": 131,
       "casts": 69
     },
-    "digest": "3e7f3e67fb1b9a3aca27664262ef4d3501aa8d223fc03dae578ea68121bd48af"
+    "digest": "d17626750cf8f7ff062aebc1add9569bb6904ddf567a67b807fce9b31224855d"
   },
   "anchor:bitterSeasonT1": {
-    "dps": 53089.6,
-    "totalDamage": 3058845.81,
+    "dps": 53453.52,
+    "totalDamage": 3079813.9,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -2742,7 +2742,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 1347263.15,
+        "expectedDamage": 1365252.85,
         "castCount": 0
       },
       {
@@ -2854,7 +2854,7 @@
         "breakdownName": "Bitter Season Tick",
         "type": "sustain",
         "count": 57,
-        "expectedDamage": 62806.39,
+        "expectedDamage": 65784.79,
         "castCount": 0
       },
       {
@@ -2868,14 +2868,14 @@
     ],
     "counts": {
       "timeline": 412,
-      "buffWindows": 130,
+      "buffWindows": 131,
       "casts": 69
     },
-    "digest": "899657b405a4dff83ee8c93e470028b3d433cb72d8ed63a0a2a1e79724f21e2f"
+    "digest": "ed85a464f84c1433902ee91861779ebfee12adeee8aa50f2b351892df57364aa"
   },
   "anchor:noSet": {
-    "dps": 68638.26,
-    "totalDamage": 3954707.93,
+    "dps": 69090.17,
+    "totalDamage": 3980745.05,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -2940,7 +2940,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 1969596.23,
+        "expectedDamage": 1995633.35,
         "castCount": 0
       },
       {
@@ -3058,14 +3058,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "28be95bd7c6a4771d3d1afee226bd59e515146ccc530c5e0a6a29aeb6cd01ebf"
+    "digest": "a2c300445edc190c15a1268f2418d6ed5f4c13f149d70f234360fd865265f13a"
   },
   "anchor:set-Jadeware": {
-    "dps": 70926.29,
-    "totalDamage": 4086536.48,
+    "dps": 71387.38,
+    "totalDamage": 4113103,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -3130,7 +3130,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2043806.1,
+        "expectedDamage": 2070372.61,
         "castCount": 0
       },
       {
@@ -3248,14 +3248,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "c449f03c9e4867b4c1d9315df5771f4e5d564ad1c1088c8d8dffae717d9d3019"
+    "digest": "60ceeb69014e0e5a9c5283f97c11d0de9030729de1243ea5eb6626dfc351bb80"
   },
   "anchor:set-Mistwillow": {
-    "dps": 69245.95,
-    "totalDamage": 3989720.74,
+    "dps": 69687.54,
+    "totalDamage": 4015163.61,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -3320,7 +3320,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 1987666.81,
+        "expectedDamage": 2013109.68,
         "castCount": 0
       },
       {
@@ -3438,14 +3438,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "eb88ef7e1fe246ee07accec4c79a4d7c0a871cdea1236c59e9b946b5a91cfc92"
+    "digest": "c426047ab7915b53dc32fb02e0f59ac6917cb96ae59650305337ee8499620b58"
   },
   "anchor:set-Rainwhisper": {
-    "dps": 70235.63,
-    "totalDamage": 4046742.95,
+    "dps": 70664.21,
+    "totalDamage": 4071436.09,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -3510,7 +3510,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2010836.56,
+        "expectedDamage": 2035529.7,
         "castCount": 0
       },
       {
@@ -3628,14 +3628,14 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "5818d9158aa8946cda69221f4459bfa4cb0e64b8ecd7bc52f52dbbda13388eb4"
+    "digest": "3de9b597be010fa918e24497f3496231371c44d03692f000a85ab923c648281b"
   },
   "anchor:set-Cleftpeak": {
-    "dps": 70581.5,
-    "totalDamage": 4066670.91,
+    "dps": 71037.27,
+    "totalDamage": 4092930.71,
     "rotationDuration": 57.62,
     "warnings": [],
     "perSkill": [
@@ -3700,7 +3700,7 @@
         "breakdownName": "Blood Burst",
         "type": "sustain",
         "count": 33,
-        "expectedDamage": 2021699.32,
+        "expectedDamage": 2047959.13,
         "castCount": 0
       },
       {
@@ -3818,10 +3818,10 @@
     ],
     "counts": {
       "timeline": 355,
-      "buffWindows": 129,
+      "buffWindows": 130,
       "casts": 69
     },
-    "digest": "0b65d996364198b64f54ccddf3f31c8bcc51590b39eaae80f9d364dadd72436f"
+    "digest": "5834548a80b2b4b82c2c9043abaaa591943fb615c4cad8b527aa698969a53f12"
   },
   "defaults:umbra": {
     "dps": 11256.79,
@@ -4000,9 +4000,9 @@
     ],
     "counts": {
       "timeline": 260,
-      "buffWindows": 137,
+      "buffWindows": 138,
       "casts": 79
     },
-    "digest": "ae492d011e79702fafd3d848e64ad7fc6a9283f8df68f8f6d35b5cebf91f914d"
+    "digest": "09f5a8ceb75ece741ccf529902ada3a253dd34ebb9cd1bf464929b0d87dc0d84"
   }
 }

--- a/tests/engine/engineBaseline.test.ts
+++ b/tests/engine/engineBaseline.test.ts
@@ -284,8 +284,8 @@ describe("engine baseline — profile-v7 anchor", () => {
     round(result.perSkill.find((row) => row.name === name)?.expectedDamage ?? NaN, 2)
 
   it("still reports the user-verified rotation figures", () => {
-    expect(round(result.dps, 2)).toBe(75079.84)
-    expect(round(result.totalDamage, 2)).toBe(4325850.03)
+    expect(round(result.dps, 2)).toBe(75548.12)
+    expect(round(result.totalDamage, 2)).toBe(4352830.94)
     expect(round(result.rotationDuration, 4)).toBe(57.6167)
     expect(result.warnings).toEqual([])
   })
@@ -293,7 +293,7 @@ describe("engine baseline — profile-v7 anchor", () => {
   // The two `attune:bleed` entities — the only rows P1 may touch, and it must
   // move neither.
   it("still reports the bleed rows P1 relocates the attunement for", () => {
-    expect(damageOf("Blood Burst")).toBe(2158142.62)
+    expect(damageOf("Blood Burst")).toBe(2185123.53)
     expect(damageOf("Bleeding (DoT)")).toBe(278117.22)
   })
 

--- a/tests/engine/rotation.test.ts
+++ b/tests/engine/rotation.test.ts
@@ -40,6 +40,17 @@ describe("isRotation — validation", () => {
     const r = makeRotation(CLASS, { permanentBuffIds: [1 as unknown as string] })
     expect(isRotation(r)).toBe(false)
   })
+
+  it("accepts a rotation carrying no openingStacks at all", () => {
+    expect(isRotation(makeRotation(CLASS))).toBe(true)
+  })
+
+  it("rejects openingStacks holding a negative or non-numeric count", () => {
+    expect(isRotation(makeRotation(CLASS, { openingStacks: { "buff-a": -1 } }))).toBe(false)
+    expect(
+      isRotation(makeRotation(CLASS, { openingStacks: { "buff-a": "3" as unknown as number } })),
+    ).toBe(false)
+  })
 })
 
 describe("resolveRotation — binding + diagnostics", () => {
@@ -118,6 +129,34 @@ describe("storage round-trip", () => {
     saveCustomRotation(stale)
     const loaded = loadCustomRotations().find((x) => x.id === stale.id)!
     expect("prePullHitsCount" in loaded).toBe(false)
+  })
+
+  it("save → load preserves openingStacks", () => {
+    const r = makeRotation(CLASS, { name: "Opener", openingStacks: { "buff-a": 3 } })
+    saveCustomRotation(r)
+    const loaded = loadCustomRotations().find((x) => x.id === r.id)!
+    expect(loaded.openingStacks).toEqual({ "buff-a": 3 })
+  })
+
+  it("heals an unreadable openingStacks entry instead of dropping the rotation", () => {
+    const corrupt = {
+      ...makeRotation(CLASS, { name: "Corrupt" }),
+      openingStacks: { "buff-a": "3", "buff-b": 2, "buff-c": -4 },
+    }
+    saveCustomRotation(corrupt as never)
+    const loaded = loadCustomRotations().find((x) => x.id === corrupt.id)!
+    expect(loaded.openingStacks).toEqual({ "buff-b": 2 })
+  })
+
+  it("export → import carries openingStacks across", () => {
+    const r = makeRotation(CLASS, { name: "x", openingStacks: { "buff-a": 4 } })
+    expect(importCustomRotation(exportCustomRotation(r)).openingStacks).toEqual({ "buff-a": 4 })
+  })
+
+  it("imports a rotation exported before openingStacks existed", () => {
+    const legacy = makeRotation(CLASS, { name: "legacy" }) as unknown as Record<string, unknown>
+    delete legacy.openingStacks
+    expect(importCustomRotation(JSON.stringify(legacy)).openingStacks).toEqual({})
   })
 
   it("export → import regenerates rotation + step ids", () => {

--- a/tests/engine/swordMorphExhausted.test.ts
+++ b/tests/engine/swordMorphExhausted.test.ts
@@ -21,6 +21,7 @@ const buildAt = (tier: number | null): BuildView => ({
   innerWayTier: (name) => (name === swordMorph.id ? tier : null),
   classSpecificAttunement: () => 0,
   grantsMinPhysCritBoost: () => false,
+  openingStacks: () => 0,
 })
 
 const hitInput = (skill: Skill, index: number): HitInput =>


### PR DESCRIPTION
Adds a per-rotation opening count for a stacking gate buff, and points it at Sword Horizon's Zenith bar. A pull that starts on banked charges was previously not expressible — every simulation began from an empty bar.

## What it does

`Rotation.openingStacks` holds the count, keyed by buff id, so it travels through save, export and import. An inner way opts a gate buff in through `openingStackBuffIds`. That allowlist is **authored, never derived from `maxStacks`** — a counter is only pre-settable once something actually seeds a simulation from it. Sword Horizon lists the Zenith bar; nothing else lists anything.

It sets the **starting value only**. `onDetonation` is untouched, so the rotation still builds, spends and resets the counter exactly as before.

The editor renders it as a row at the head of the step list, deliberately **outside `steps.map`**. It is not a `RotationStep` and no move / remove / add-after / index operation may treat it as one. On a built-in rotation the row shows but is not editable, matching every other field there.

## Two things worth a reviewer's attention

**Seeding the tracker was not enough.** `CrosswindTracker` decides damage; the status ledger is what the timeline chips and every stack-reading trigger condition see. Seeded alone, the bar kept reading its baseline on every cast until the first detonation and the setting looked ignored. The count is written into the ledger too, at `spanStart`, which also covers the pre-pull window.

**The chip fallback was drawing empty counters as charged.** A status with an open window but no stack history was reported as holding one stack — right for a buff that is merely on, wrong for a counter. Since the ledger handed to a cast is owner-filtered, every cast before the first recorded stack hit that path. The fallback is now restricted to statuses that do not count, with both directions pinned directly against `collectCastBuffs`.

## The re-baseline

All seven `bellstrikeUmbra` built-in rotations open on five charges. Only that class can slot Sword Horizon, so the field would be dead data elsewhere.

This moves output, so the re-baseline is in the same commit as its cause. The generated baseline is regenerated; the two hand-written blocks it keeps outside itself did **not** come along and were raised by hand:

| | before | after |
| --- | --- | --- |
| Verified DPS | 75,079.84 | 75,548.12 |
| Verified total | 4,325,850.03 | 4,352,830.94 |
| Blood Burst | 2,158,142.62 | 2,185,123.53 |

Only those rows move — Bleeding, Smolder, Flute Ripple and Yi River are unchanged to the last decimal. That is the expected shape: the bar's bonus lands on detonations and nowhere else.

Parity bands are **re-centered at their existing widths, not widened**. The engine now sits ~1.9 % above the reference site's cached run rather than ~1.2 %, and the detonation row ~2.7 %, because that cached run scores its detonations from an empty bar.

## Storage

Additive and optional, so no version bump. A stored rotation passes through a hydrate pass ahead of the validation filter, so one unreadable entry heals rather than dropping the whole rotation. `permanentBuffIds` is untouched — rewriting it would have been the incompatible branch for a version-counter store, discarding every saved rotation.

## Checks

`pnpm test` 1939 passing across 174 files, plus typecheck, lint, `format:check` and the English-only grep guard.

The wiki pages for adding an inner way and adding a rotation are updated in the wiki clone, held back until this merges.
