### PR TITLE
Release v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-winds-meet-dps",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "engines": {
     "node": ">=26"

--- a/src/changelog/entries/v0-5-0.ts
+++ b/src/changelog/entries/v0-5-0.ts
@@ -1,0 +1,73 @@
+import type { ChangelogEntryDetails } from "../types"
+
+export const details: ChangelogEntryDetails = {
+  sections: [
+    {
+      label: "Added",
+      items: [
+        {
+          text: "Rotations can open on a partly built Zenith bar, and every built-in Bellstrike Umbra rotation starts on a full one.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The app asks for fresh inner-way screenshots whenever a new breakthrough supersedes the data an inner way was read at.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Changed",
+      items: [
+        {
+          text: "The Qi break window belongs to the rotation and is edited there; the encounter setting is an override, off by default.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The default breakthrough advances by itself when a new one goes live, leaving a breakthrough you picked yourself alone.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Bellstrike Umbra offers four built-in rotations, with 38 BB's as the class default.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "36 BB's is rebuilt around the six-hit Spear Q, a single-hit Smolder opener and reordered mid-rotation blocks.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Nox - 1m DH follows its latest export, dropping the Spear Q cancel and a Sword Charge stage for Delay and Ghostly Steps.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The rotation list sits in its own card beside the subtabs, so it stays reachable from the editor, graph and timeline.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Buff chips on the rotation editor's cast rows show initials with their stack count; the tooltip keeps the full name.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "The Hawkwing cast tag no longer names a piece count.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+    {
+      label: "Fixed",
+      items: [
+        {
+          text: "A buff that counts stacks shows zero before its first stack lands instead of reading as one.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "River Flow is one buff in the Skill Editor instead of two, and no longer applies without Wolfchaser's Art slotted.",
+          authors: ["M1zuke"],
+        },
+        {
+          text: "Class damage figures come down slightly: an unsourced flat bonus to attribute attack no longer applies.",
+          authors: ["M1zuke"],
+        },
+      ],
+    },
+  ],
+}

--- a/src/changelog/registry.ts
+++ b/src/changelog/registry.ts
@@ -2,6 +2,12 @@ import type { ChangelogEntry } from "./types"
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: "0.5.0",
+    date: "2026-09-02",
+    headline: "Rotations carry their Qi break and Zenith opener",
+    loadDetails: () => import("./entries/v0-5-0").then((module) => module.details),
+  },
+  {
     version: "0.4.2",
     date: "2026-08-29",
     headline: "Truer Full Potential figures on gear tiles",


### PR DESCRIPTION
Bumps the app version to 0.5.0 and adds the in-app changelog entry for everything since v0.4.2 (`e11014d`, 2026-08-29).

Minor bump: new selectable and editable things appeared — a per-rotation Qi break window, opening Zenith charges, and the breakthrough data request dialog.

Headline: **Rotations carry their Qi break and Zenith opener**

### Added
- Rotations can open on a partly built Zenith bar, and every built-in Bellstrike Umbra rotation starts on a full one.
- The app asks for fresh inner-way screenshots whenever a new breakthrough supersedes the data an inner way was read at.

### Changed
- The Qi break window belongs to the rotation and is edited there; the encounter setting is an override, off by default.
- The default breakthrough advances by itself when a new one goes live, leaving a breakthrough you picked yourself alone.
- Bellstrike Umbra offers four built-in rotations, with 38 BB's as the class default.
- 36 BB's is rebuilt around the six-hit Spear Q, a single-hit Smolder opener and reordered mid-rotation blocks.
- Nox - 1m DH follows its latest export, dropping the Spear Q cancel and a Sword Charge stage for Delay and Ghostly Steps.
- The rotation list sits in its own card beside the subtabs, so it stays reachable from the editor, graph and timeline.
- Buff chips on the rotation editor's cast rows show initials with their stack count; the tooltip keeps the full name.
- The Hawkwing cast tag no longer names a piece count.

### Fixed
- A buff that counts stacks shows zero before its first stack lands instead of reading as one.
- River Flow is one buff in the Skill Editor instead of two, and no longer applies without Wolfchaser's Art slotted.
- Class damage figures come down slightly: an unsourced flat bonus to attribute attack no longer applies.

Three files touched, and only these: the `version` field in `package.json`, a new `src/changelog/entries/v0-5-0.ts`, and the prepended registry row with a dynamic `import()`.

no migration needed: the changelog is display-only and no stored shape changed. Every commit in the range that did change a stored shape shipped its own hop (V18, V19, V20, plus the additive `followedBreakthroughRelease` field).