### PR TITLE
Keep the profile values a build cannot resolve

### DIFF
--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -130,6 +130,11 @@ still drop on version mismatch.
 - **Tested** — TESTING.md § "Migration tests".
 - **Conservative about deleting** — clear the one field that is now illegal; do not
   discard neighbouring user data to be safe.
+- **Silent about what it cannot resolve** — a stored value this build does not
+  recognise is kept exactly as written, and scores nothing. Repair renames and
+  clamps; it never empties a field to make an unknown value go away. A profile
+  written by a newer build and opened by an older one is the ordinary case, and
+  there every unrecognised value is one the user still owns.
 - **Checked against the default build** — the hydrator runs on the default profile,
   so a too-aggressive migration can silently change the app's default build.
 

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -134,7 +134,10 @@ still drop on version mismatch.
   recognise is kept exactly as written, and scores nothing. Repair renames and
   clamps; it never empties a field to make an unknown value go away. A profile
   written by a newer build and opened by an older one is the ordinary case, and
-  there every unrecognised value is one the user still owns.
+  there every unrecognised value is one the user still owns. The one thing that
+  is still cleared is a value this build **does** define but the current
+  selection forbids: that one would be scored, and a build the selection cannot
+  hold is the invisible wrong number an allowlist exists to stop.
 - **Checked against the default build** — the hydrator runs on the default profile,
   so a too-aggressive migration can silently change the app's default build.
 

--- a/src/data/stats/statLines.ts
+++ b/src/data/stats/statLines.ts
@@ -438,6 +438,12 @@ export function isGearWordId(value: unknown): value is GearWordId {
   return typeof value === "string" && GEAR_WORD_ID_SET.has(value)
 }
 
+// A word a profile holds that this build has no line for — a roll another build
+// wrote and this one must keep without showing or scoring it.
+export function isUnknownGearWord(value: unknown): boolean {
+  return typeof value === "string" && value !== "" && !GEAR_WORD_ID_SET.has(value)
+}
+
 export const GEAR_WORD_MAX_ROLL: Readonly<Record<GearWordId, number>> = Object.fromEntries(
   GEAR_WORD_LINES.map((line) => [line.id, line.maxRoll]),
 ) as Record<GearWordId, number>

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -192,14 +192,16 @@ function sanitizeOpeningStacks(stored: unknown): Record<string, number> {
   return healed
 }
 
-// A word outside the catalogue already scores nothing, so clearing the row costs
-// the user no contribution.
+// A word this build cannot resolve is kept exactly as stored, roll included. It
+// scores nothing — every consumer skips a word with no spec — and clearing it
+// would destroy a roll the build that wrote it understood, which is what a
+// profile saved by a newer build and opened by an older one looks like.
 function repairGearWord(entry: unknown): unknown {
   if (!entry || typeof entry !== "object") return entry
   const stored = (entry as { word?: unknown }).word
   if (typeof stored !== "string") return entry
   const renamed = migrateFormlessWordId(migrateCurrentGearWordLabel(migrateGearWordId(stored)))
-  return isGearWordId(renamed) ? { ...entry, word: renamed } : { ...entry, word: "", value: 0 }
+  return isGearWordId(renamed) ? { ...entry, word: renamed } : { ...entry, word: stored }
 }
 
 // The live registry is the allowlist, never `migrateSetId`'s table: that table
@@ -442,9 +444,14 @@ export function loadProfiles(): ProfilesState & { firstRun: boolean } {
             ? migrated.activeId
             : profiles[0].id
           // Persist the upgraded blob so the chain is walked once, not per load.
+          // Never for a blob a newer build wrote: the walk left it alone, and
+          // writing it back would stamp it at this build's version and hand it
+          // whatever this build made of the fields it does not know.
+          const storedByNewerBuild = typeof migrated.v === "number" && migrated.v > PROFILES_VERSION
           if (
-            releaseFollowed ||
-            (result && (result.applied.length > 0 || migrated.v !== PROFILES_VERSION))
+            !storedByNewerBuild &&
+            (releaseFollowed ||
+              (result && (result.applied.length > 0 || migrated.v !== PROFILES_VERSION)))
           ) {
             saveProfiles({ profiles, activeId })
           }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -210,11 +210,15 @@ function repairGearWord(entry: unknown): unknown {
 // selection on every load. It survives here only as the pre-V11 display-name
 // hop for the two paths that never walk the chain — a bare imported profile
 // and the legacy `wwm.inputs` blob.
+//
+// A set id neither table nor registry knows is one this build has no option
+// for, and is handed back as stored rather than cleared.
 function selectableSetId(stored: string | null): string | null {
   const renamed = migrateCleftpeakSetId(stored)
   if (typeof renamed === "string" && SET_BY_ID[renamed] !== undefined) return renamed
   const migrated = migrateCleftpeakSetId(migrateSetId(stored))
-  return typeof migrated === "string" && SET_BY_ID[migrated] !== undefined ? migrated : null
+  if (typeof migrated === "string" && SET_BY_ID[migrated] !== undefined) return migrated
+  return typeof stored === "string" && stored !== "" ? stored : null
 }
 
 // additive — see CLAUDE.md → "localStorage migrations"
@@ -266,16 +270,13 @@ function hydrateInputs(inputs: Inputs): Inputs {
   }
   if (typeof next.selectedBuiltinRotationId !== "string") next.selectedBuiltinRotationId = null
   delete (next as unknown as Record<string, unknown>).calcMode
-  if (next.bowSet !== "affinity" && next.bowSet !== "crit" && next.bowSet !== "precision") {
-    next.bowSet = null
-  }
-  if (
-    next.arsenal !== "general" &&
-    next.arsenal !== "bellstrike" &&
-    next.arsenal !== "stonesplit" &&
-    next.arsenal !== "silkbind" &&
-    next.arsenal !== "bamboocut"
-  ) {
+  // A selection this build has no option for is another build's, kept as
+  // stored: it matches no bonus here, and the panel that offers the choices
+  // shows none of them selected. Only a missing or non-string value falls back.
+  const storedBowSet = (next as unknown as Record<string, unknown>).bowSet
+  if (typeof storedBowSet !== "string" || storedBowSet === "") next.bowSet = null
+  const storedArsenal = (next as unknown as Record<string, unknown>).arsenal
+  if (typeof storedArsenal !== "string" || storedArsenal === "") {
     next.arsenal = defaultArsenalForClass(next.classId)
   }
   if (!Array.isArray(next.inventory)) next.inventory = []
@@ -310,9 +311,13 @@ function hydrateInputs(inputs: Inputs): Inputs {
   // additive value-level repair — see CLAUDE.md → "localStorage migrations"
   //
   // A slot used to be identified by its display name. It now carries a stable
-  // `id`, healed here from whatever the profile stored. A slot naming an inner
-  // way that no longer exists resolves to nothing the class allows and is
-  // cleared, which is the same path an already-disallowed slot takes.
+  // `id`, healed here from whatever the profile stored.
+  //
+  // A slot naming an inner way this build has no definition for is kept as
+  // stored — it resolves to no definition, so it reaches no panel stat and no
+  // mechanic. A slot naming one this build knows but the class may not hold is
+  // cleared instead: that one would be scored, and scoring a build the class
+  // cannot have is the invisible wrong number the allowlist exists to stop.
   if (Array.isArray(next.mindMethods)) {
     const allowed = new Set(allowedInnerWaysForClass(next.classId))
     const seen = new Set<string>()
@@ -323,7 +328,8 @@ function hydrateInputs(inputs: Inputs): Inputs {
       const disallowed = !!innerWayId && allowed.size > 0 && !allowed.has(innerWayId)
       const duplicate = !!innerWayId && seen.has(innerWayId)
       if (!innerWayId) return { ...slot, id: undefined, name: "", stacks: "" }
-      if (!known || disallowed || duplicate) return { id: undefined, name: "", stacks: "" }
+      if (!known) return { ...slot, id: innerWayId, stacks: slot.stacks || "tier 6" }
+      if (disallowed || duplicate) return { id: undefined, name: "", stacks: "" }
       seen.add(innerWayId)
       return {
         ...slot,

--- a/src/ui/features/gear/gear-piece-form/GearPieceForm.tsx
+++ b/src/ui/features/gear/gear-piece-form/GearPieceForm.tsx
@@ -7,7 +7,7 @@ import type {
   GearWordEntry,
 } from "../../../../engine/types"
 import { GEAR_SLOTS, isWeaponSlot } from "../../../../engine/types"
-import { isGearWordId } from "../../../../data/stats/statLines"
+import { isGearWordId, isUnknownGearWord } from "../../../../data/stats/statLines"
 import { getWordSpecs } from "../../../../engine/itemRanking"
 import { relayedCapValue } from "../../../../engine/gearStats"
 import { gearBaseStatsFor } from "../../../../data/stats/gearBaseStats"
@@ -156,9 +156,16 @@ export function GearPieceForm({
     const cap = relayed ? relayedCapValue(spec.amount, spec.unit) : spec.amount
     return roundToShownPrecision(Math.min(Math.max(value, 0), cap), spec.unit === "percent")
   }
+  // A row the form shows as empty is empty as far as an edit is concerned: the
+  // word the profile is holding for another build goes only when the user
+  // writes over the row it sits on.
   function patchWord(idx: number, patchedFields: Partial<GearWordEntry>): void {
     const next = [...piece.words] as GearPiece["words"]
-    const merged = { ...next[idx], ...patchedFields }
+    const current = next[idx]
+    const base = isUnknownGearWord(current.word)
+      ? { ...current, word: "" as const, value: 0 }
+      : current
+    const merged = { ...base, ...patchedFields }
     merged.value = clampAndRound(merged.value, merged.word, piece.relayed)
     next[idx] = merged
     onChange({ ...piece, words: next })
@@ -256,7 +263,10 @@ export function GearPieceForm({
               </span>
             </>
           )}
-          {piece.words.map((word, idx) => {
+          {piece.words.map((stored, idx) => {
+            const word = isUnknownGearWord(stored.word)
+              ? { ...stored, word: "" as const, value: 0 }
+              : stored
             const spec = wordSpecs.find((candidate) => candidate.word === word.word)
             const isPercent = spec?.unit === "percent"
             const ValueInput = isPercent ? PercentInput : NumInput

--- a/tests/migrations/migrationRunner.test.ts
+++ b/tests/migrations/migrationRunner.test.ts
@@ -118,6 +118,38 @@ describe("runProfileMigrations — never deletes", () => {
     expect(result.notes.join(" ")).toMatch(/newer than/)
   })
 
+  // The shape of a downgrade: a build that shipped a later step wrote ids this
+  // build has no line for. The runner leaves such a blob alone, and nothing
+  // after it — hydration included — may undo that.
+  function futureBlobHoldingWordsThisBuildLacks(): RawProfilesBlob {
+    const blob = blobAt(LATEST_PROFILES_VERSION + 1)
+    const profile = blob.profiles[0] as { inputs: { inventory: unknown[] } }
+    const piece = profile.inputs.inventory[0] as {
+      words: { word: string; value: number; retuned: boolean }[]
+    }
+    piece.words[0] = { word: "maxWordFromALaterBuild", value: 41.3, retuned: false }
+    piece.words[1] = { word: "maxWordFromALaterBuild", value: 39.2, retuned: false }
+    return blob
+  }
+
+  it("loads a FUTURE-version blob without dropping the words it cannot resolve", () => {
+    localStorage.setItem(PROFILES_KEY, JSON.stringify(futureBlobHoldingWordsThisBuildLacks()))
+
+    const piece = loadProfiles().profiles[0].inputs.inventory[0]
+
+    expect(piece.words[0]).toEqual({ word: "maxWordFromALaterBuild", value: 41.3, retuned: false })
+    expect(piece.words[1]).toEqual({ word: "maxWordFromALaterBuild", value: 39.2, retuned: false })
+  })
+
+  it("does not write a FUTURE-version blob back at this build's version", () => {
+    const future = futureBlobHoldingWordsThisBuildLacks()
+    localStorage.setItem(PROFILES_KEY, JSON.stringify(future))
+
+    loadProfiles()
+
+    expect(JSON.parse(localStorage.getItem(PROFILES_KEY)!)).toEqual(future)
+  })
+
   it("survives a step that throws — the pre-step blob carries forward", () => {
     const exploding: Migration = {
       to: LATEST_PROFILES_VERSION,

--- a/tests/migrations/migrationRunner.test.ts
+++ b/tests/migrations/migrationRunner.test.ts
@@ -132,6 +132,29 @@ describe("runProfileMigrations — never deletes", () => {
     return blob
   }
 
+  it("loads a FUTURE-version blob without dropping the selections it cannot resolve", () => {
+    const blob = futureBlobHoldingWordsThisBuildLacks()
+    const profile = blob.profiles[0] as { inputs: Record<string, unknown> }
+    profile.inputs.set = "setFromALaterBuild"
+    profile.inputs.arsenal = "arsenalFromALaterBuild"
+    profile.inputs.bowSet = "bowSetFromALaterBuild"
+    profile.inputs.mindMethods = [
+      { id: "innerWayFromALaterBuild", name: "Inner Way From A Later Build", stacks: "tier 6" },
+      { name: "", stacks: "" },
+      { name: "", stacks: "" },
+      { name: "", stacks: "" },
+    ]
+    localStorage.setItem(PROFILES_KEY, JSON.stringify(blob))
+
+    const loaded = loadProfiles().profiles[0].inputs
+
+    expect(loaded.set).toBe("setFromALaterBuild")
+    expect(loaded.arsenal).toBe("arsenalFromALaterBuild")
+    expect(loaded.bowSet).toBe("bowSetFromALaterBuild")
+    expect(loaded.mindMethods[0].id).toBe("innerWayFromALaterBuild")
+    expect(loaded.mindMethods[0].stacks).toBe("tier 6")
+  })
+
   it("loads a FUTURE-version blob without dropping the words it cannot resolve", () => {
     localStorage.setItem(PROFILES_KEY, JSON.stringify(futureBlobHoldingWordsThisBuildLacks()))
 

--- a/tests/migrations/profileV14DropUnimplementedArmorSets.test.ts
+++ b/tests/migrations/profileV14DropUnimplementedArmorSets.test.ts
@@ -105,13 +105,13 @@ describe("V14__dropUnimplementedArmorSets — registered in the chain", () => {
 
 // The chain never runs on a bare imported profile, so only the live-registry
 // check in `hydrateInputs` stands between it and an illegal stored set.
-describe("hydrateInputs backstop — a retired set on a bare import", () => {
+describe("hydrateInputs — a retired set on a bare import", () => {
   beforeEach(() => localStorage.clear())
 
   for (const retired of RETIRED_SET_IDS) {
-    it(`clears ${retired}`, () => {
+    it(`keeps ${retired} stored, for the step to drop when the profile walks the chain`, () => {
       const bare = withSet(clone(LEGACY.profile), retired)
-      expect(importProfile(JSON.stringify(bare)).inputs.set).toBeNull()
+      expect(importProfile(JSON.stringify(bare)).inputs.set).toBe(retired)
     })
   }
 

--- a/tests/migrations/profileV15DropSwallowcallSet.test.ts
+++ b/tests/migrations/profileV15DropSwallowcallSet.test.ts
@@ -98,12 +98,12 @@ describe("V15__dropSwallowcallSet — registered in the chain", () => {
   })
 })
 
-describe("hydrateInputs backstop — swallowcall on a bare import, never walking the chain", () => {
+describe("hydrateInputs — swallowcall on a bare import, never walking the chain", () => {
   beforeEach(() => localStorage.clear())
 
-  it("clears it", () => {
+  it("keeps it stored, for the step to drop when the profile walks the chain", () => {
     const bare = withSet(clone(LEGACY.profile), RETIRED_SET_ID)
-    expect(importProfile(JSON.stringify(bare)).inputs.set).toBeNull()
+    expect(importProfile(JSON.stringify(bare)).inputs.set).toBe(RETIRED_SET_ID)
   })
 
   it("keeps a set that is still offered", () => {

--- a/tests/migrations/profileV8DropRemovedArmorSets.test.ts
+++ b/tests/migrations/profileV8DropRemovedArmorSets.test.ts
@@ -108,14 +108,15 @@ describe("V8__dropRemovedArmorSets — registered in the chain", () => {
   })
 })
 
-// The chain never runs on these two, so only the `hydrateInputs` allowlist pass
-// stands between them and an illegal stored set.
-describe("hydrateInputs backstop — the paths that bypass the chain", () => {
+// The chain never runs on these two, so a removed set reaches `hydrateInputs`
+// with no step having seen it. It is kept rather than cleared — it matches no
+// option, so it scores nothing while it sits there.
+describe("hydrateInputs — the paths that bypass the chain", () => {
   beforeEach(() => localStorage.clear())
 
-  it("clears a removed set on a bare imported profile", () => {
+  it("keeps a removed set on a bare imported profile", () => {
     const bare = withSet(clone(LEGACY.profile), "Ivorybloom")
-    expect(importProfile(JSON.stringify(bare)).inputs.set).toBeNull()
+    expect(importProfile(JSON.stringify(bare)).inputs.set).toBe("Ivorybloom")
   })
 
   it("keeps a surviving set on a bare imported profile, healed to its id", () => {
@@ -123,11 +124,11 @@ describe("hydrateInputs backstop — the paths that bypass the chain", () => {
     expect(importProfile(JSON.stringify(bare)).inputs.set).toBe("jadeware")
   })
 
-  it("clears a removed set on the legacy wwm.inputs blob rolled into a profile", () => {
+  it("keeps a removed set on the legacy wwm.inputs blob rolled into a profile", () => {
     localStorage.setItem(
       "wwm.inputs",
       JSON.stringify({ v: 5, inputs: withSet(clone(LEGACY.profile), "Rainwhisper").inputs }),
     )
-    expect(loadOne().inputs.set).toBeNull()
+    expect(loadOne().inputs.set).toBe("Rainwhisper")
   })
 })

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -486,7 +486,7 @@ describe("mystic-boost merges (field/gear-word/buff-stat-key, no version bump)",
     }
   })
 
-  it("clears a stored word the catalogue no longer offers and leaves its neighbours alone", () => {
+  it("keeps a stored word the catalogue no longer offers, roll and all", () => {
     const strandedPiece: StoredGearPiece = {
       id: "test-stranded-piece",
       slot: "helm",
@@ -519,8 +519,98 @@ describe("mystic-boost merges (field/gear-word/buff-stat-key, no version bump)",
 
     const { profiles } = loadProfiles()
     const piece = profiles[0].inputs.inventory[0]
-    expect(piece.words[0]).toEqual({ word: "", value: 0, retuned: false })
+    expect(piece.words[0]).toEqual({ word: "Retired Word", value: 0.09, retuned: false })
     expect(piece.words[1]).toEqual({ word: "crit", value: 0.09, retuned: true })
+  })
+
+  it("scores nothing for a word the catalogue no longer offers", () => {
+    const strandedPiece: StoredGearPiece = {
+      id: "test-stranded-scoring",
+      slot: "helm",
+      level: 91,
+      rarity: "legendary",
+      minPhys: 0,
+      maxPhys: 0,
+      hp: 0,
+      physDef: 0,
+      words: [
+        { word: "Retired Word", value: 0.09, retuned: false },
+        { word: "", value: 0, retuned: false },
+        { word: "", value: 0, retuned: false },
+        { word: "", value: 0, retuned: false },
+        { word: "", value: 0, retuned: false },
+      ],
+      attunement: "",
+      attunementValue: 0,
+      relayed: false,
+    }
+    kvStore.set(
+      PROFILES_KEY,
+      JSON.stringify({
+        v: PROFILES_VERSION,
+        profiles: [
+          {
+            id: "p1",
+            name: "Legacy",
+            inputs: { ...defaultInputs, inventory: [strandedPiece] },
+          },
+        ],
+        activeId: "p1",
+      }),
+    )
+
+    const { profiles } = loadProfiles()
+    const hydratedInputs = profiles[0].inputs
+    const contribution = computeGearContribution(hydratedInputs.inventory[0], hydratedInputs)
+    const fromWords = contribution.filter((row) => row.path !== "hp" && row.path !== "physDef")
+    expect(fromWords).toEqual([])
+  })
+
+  it("hands a profile saved by a newer build its unknown words back unchanged", () => {
+    const fromNewerBuild: StoredGearPiece = {
+      id: "test-newer-build-piece",
+      slot: "leftWeapon",
+      level: 91,
+      rarity: "legendary",
+      minPhys: 0,
+      maxPhys: 0,
+      hp: 0,
+      physDef: 0,
+      words: [
+        { word: "maxWordThisBuildHasNeverHeardOf", value: 41.3, retuned: false },
+        { word: "maxWordThisBuildHasNeverHeardOf", value: 39.2, retuned: false },
+        { word: "maxPhys", value: 73.1, retuned: false },
+        { word: "", value: 0, retuned: false },
+        { word: "", value: 0, retuned: false },
+      ],
+      attunement: "",
+      attunementValue: 0,
+      relayed: false,
+    }
+    kvStore.set(
+      PROFILES_KEY,
+      JSON.stringify({
+        v: PROFILES_VERSION + 1,
+        profiles: [
+          {
+            id: "p1",
+            name: "From tomorrow",
+            inputs: { ...defaultInputs, inventory: [fromNewerBuild] },
+          },
+        ],
+        activeId: "p1",
+      }),
+    )
+
+    const piece = loadProfiles().profiles[0].inputs.inventory[0]
+    expect(piece.words.map((entry) => entry.word)).toEqual([
+      "maxWordThisBuildHasNeverHeardOf",
+      "maxWordThisBuildHasNeverHeardOf",
+      "maxPhys",
+      "",
+      "",
+    ])
+    expect(piece.words.map((entry) => entry.value)).toEqual([41.3, 39.2, 73.1, 0, 0])
   })
 
   it("renames a legacy word rather than clearing it as unknown", () => {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -38,9 +38,9 @@ import { kvStore } from "../src/kvStore"
 import { EMPTY_EQUIPPED } from "../src/engine/types"
 import type { GearPiece, Inputs, StoredProfile } from "../src/engine/types"
 import { CLASS_IDS } from "../src/definitions/classes/registry"
-import { getDefaultTalentsForClass } from "../src/definitions/baseStats"
+import { getDefaultTalentsForClass, getMindMethodContributions } from "../src/definitions/baseStats"
 import { runEngine } from "../src/engine/dps"
-import { applyArmorSet, applyBowSet } from "../src/engine/panel"
+import { allowedInnerWaysForClass, applyArmorSet, applyBowSet } from "../src/engine/panel"
 
 type StoredGearPiece = Omit<GearPiece, "words"> & {
   words: readonly { word: string; value: number; retuned: boolean }[]
@@ -1234,10 +1234,12 @@ describe("armor-set display name heal (wwm.inputs blob, no version bump)", () =>
     expect(profiles[0].inputs.set).toBe("hawking")
   })
 
-  it("degrades an unrecognised legacy set to no set instead of leaving it dangling", () => {
-    saveInputs({ ...defaultInputs, set: "A Removed Set" })
+  it("keeps an unrecognised set stored and grants nothing for it", () => {
+    saveInputs({ ...defaultInputs, set: "A Set From Another Build" })
     const { profiles } = loadProfiles()
-    expect(profiles[0].inputs.set).toBeNull()
+    const stored = profiles[0].inputs
+    expect(stored.set).toBe("A Set From Another Build")
+    expect(applyArmorSet(stored)).toEqual(stored)
   })
 
   it("round-trips an already-migrated id unchanged", () => {
@@ -1326,6 +1328,73 @@ describe("class id degrade (an unrecognised classId falls back to the default bu
     kvStore.remove(PROFILES_KEY)
     writeProfileWithClassId("mingJinHong")
     expect(loadProfiles().profiles[0].inputs.classId).toBe(defaultInputs.classId)
+  })
+
+  it("keeps a slotted inner way this build has no definition for", () => {
+    kvStore.set(
+      PROFILES_KEY,
+      JSON.stringify({
+        v: LATEST_PROFILES_VERSION,
+        profiles: [
+          {
+            id: "p1",
+            name: "From another build",
+            inputs: {
+              ...defaultInputs,
+              mindMethods: [
+                { id: "innerWayFromAnotherBuild", name: "From Another Build", stacks: "tier 6" },
+                { name: "", stacks: "" },
+                { name: "", stacks: "" },
+                { name: "", stacks: "" },
+              ],
+            },
+          },
+        ],
+        activeId: "p1",
+      }),
+    )
+
+    const loaded = loadProfiles().profiles[0].inputs
+    expect(loaded.mindMethods[0].id).toBe("innerWayFromAnotherBuild")
+    expect(getMindMethodContributions(loaded)).toEqual({})
+  })
+
+  // The one thing hydration still takes off a profile, and why: this build has a
+  // definition for it, so leaving it slotted would score a build the class
+  // cannot hold.
+  it("clears a slotted inner way the class may not hold", () => {
+    const notForThisClass = allowedInnerWaysForClass("stonesplitStrength").find(
+      (innerWayId) => !allowedInnerWaysForClass("bellstrikeUmbra").includes(innerWayId),
+    )!
+    kvStore.set(
+      PROFILES_KEY,
+      JSON.stringify({
+        v: LATEST_PROFILES_VERSION,
+        profiles: [
+          {
+            id: "p1",
+            name: "Wrong class",
+            inputs: {
+              ...defaultInputs,
+              classId: "bellstrikeUmbra",
+              mindMethods: [
+                { id: notForThisClass, name: "", stacks: "tier 6" },
+                { name: "", stacks: "" },
+                { name: "", stacks: "" },
+                { name: "", stacks: "" },
+              ],
+            },
+          },
+        ],
+        activeId: "p1",
+      }),
+    )
+
+    expect(loadProfiles().profiles[0].inputs.mindMethods[0]).toEqual({
+      id: undefined,
+      name: "",
+      stacks: "",
+    })
   })
 
   it("the default build's own class id is a member of CLASS_IDS, so the degrade is a no-op on it", () => {


### PR DESCRIPTION
Opening a profile written by a newer build destroys what that build knew. Reported after a branch switch: two Max Formless Attack rolls on a left weapon, gone and not recoverable.

## What happened

The profile was saved at v21 with `maxFormless`. On a build that stopped at v20:

1. `runProfileMigrations` did the right thing — `v21 > 20`, blob returned untouched, note "newer than we know", no step run.
2. `hydrateInputs` ran anyway. `repairGearWord` cleared every word outside *that* build's catalogue, which is exactly the set the newer build had written.
3. `loadProfiles` then re-saved, because `migrated.v !== PROFILES_VERSION` — writing the emptied words over the original and stamping the blob at v20.

Step 1 is the guard that says a downgrade must not shred data. Steps 2 and 3 walked through it.

## The fix

Nothing in the load path deletes profile content for being unrecognised. A value this build has no definition for is handed back exactly as stored:

- **Gear words** keep their roll. They score nothing — `computeGearContribution`, `maxRelayedClone` and the ranking sweep all skip a word with no spec.
- **Armour set, bow set and arsenal** keep their stored id. The set and bow lookups miss, the arsenal maps to no block, so none of them grants anything.
- **A slotted inner way** with no definition here keeps its id and tier, and reaches no panel stat or mechanic.
- **A blob a newer build wrote is never written back.** Nothing needs persisting when the walk did nothing, and the write-back is what made the loss permanent.

Only a missing or non-string value still falls back to a default. In the UI every one of these reads as nothing selected, and the gear form treats such a row as empty on edit, so a hidden roll cannot jump onto whatever word the user picks next. It disappears from view; it stays in the profile.

**One thing is still cleared**, deliberately: a slotted inner way this build *does* define but the class may not hold. That one would be scored, and a build the class cannot hold is the invisible wrong number the allowlist exists to stop. There is a test for it beside the test that says an unknown slot is kept.

The set steps (V8, V14, V15) still drop the ids they froze, so a profile walking the chain loses a retired set exactly as before. What changed is the standing "must be selectable" pass beneath them, which used to clear on the two paths that never walk the chain — a bare import and the legacy inputs blob. `docs/MIGRATIONS.md` carries the rule and its exception.

## The test gap this came through

`migrationRunner.test.ts` asserted the untouched-blob rule against `runProfileMigrations` in isolation — never through `loadProfiles`, which is where the data actually died. It now loads a future-version blob end to end and asserts the words, set, arsenal, bow set and inner-way slot all survive, and that the blob is not written back at this build's version. Reverting either half of the fix fails those tests.

Users reach this without switching branches: a deploy rollback moves every profile from a newer version to an older build, and a tab left open across a deploy keeps saving from the old bundle.

Full suite green at 2093 tests, with `typecheck`, `lint` and `format:check` clean.
