### PR TITLE
Rotation Editor as its own tab

### DIFF
--- a/src/app/App.module.scss
+++ b/src/app/App.module.scss
@@ -152,6 +152,16 @@
   margin-left: auto;
 }
 
+.tabGapBefore {
+  margin-left: 20px;
+}
+
+@include breakpoints.below(breakpoints.$bp-980) {
+  .tabGapBefore {
+    margin-left: 0;
+  }
+}
+
 @include breakpoints.below(breakpoints.$bp-700) {
   .tab {
     display: flex;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,6 +19,7 @@ import { GithubLink } from "../ui/layout/github-link/GithubLink"
 import { ChangelogButton } from "../ui/layout/changelog-button/ChangelogButton"
 import { LanguageSelect } from "../ui/layout/language-select/LanguageSelect"
 import { RotationTab } from "../ui/features/rotation/rotation-tab/RotationTab"
+import { RotationEditorPanel } from "../ui/features/rotation/rotation-editor-panel/RotationEditorPanel"
 import { SimulationTab } from "../ui/features/simulation/simulation-tab/SimulationTab"
 import { ProfilePanel } from "../ui/features/profile/profile-panel/ProfilePanel"
 import { GearTab } from "../ui/features/gear/gear-tab/GearTab"
@@ -279,14 +280,15 @@ function AppInner() {
     tabRefs.current[pathname]?.scrollIntoView({ block: "nearest", inline: "nearest" })
   }, [pathname])
 
-  const TABS: { path: string; label: string; align?: "right" }[] = [
+  const TABS: { path: string; label: string; align?: "right"; gapBefore?: true }[] = [
     { path: "/overview", label: t("common.overview") },
     { path: "/gear", label: t("app.gear") },
     { path: "/rotation", label: t("common.rotation") },
+    { path: "/rotation-editor", label: t("rotation.rotationEditor") },
     { path: "/simulation", label: t("app.simulation") },
     { path: "/skills", label: t("app.skillEditor") },
-    { path: "/talents", label: t("common.enhancementOdditiesTalents") },
-    { path: "/profile", label: t("common.profiles"), align: "right" },
+    { path: "/talents", label: t("common.enhancementOdditiesTalents"), align: "right" },
+    { path: "/profile", label: t("common.profiles"), gapBefore: true },
   ]
 
   const saveLabel =
@@ -382,7 +384,8 @@ function AppInner() {
               className={({ isActive }) =>
                 styles.tab +
                 (isActive ? ` ${styles.active}` : "") +
-                (tab.align === "right" ? ` ${styles.tabRight}` : "")
+                (tab.align === "right" ? ` ${styles.tabRight}` : "") +
+                (tab.gapBefore ? ` ${styles.tabGapBefore}` : "")
               }
             >
               {tab.label}
@@ -427,6 +430,10 @@ function AppInner() {
                   result={result}
                 />
               }
+            />
+            <Route
+              path="/rotation-editor"
+              element={<RotationEditorPanel inputs={inputs} onChange={setInputs} result={result} />}
             />
             <Route
               path="/simulation"

--- a/src/ui/features/rotation/rotation-editor-panel/RotationEditorPanel.tsx
+++ b/src/ui/features/rotation/rotation-editor-panel/RotationEditorPanel.tsx
@@ -403,7 +403,7 @@ export function RotationEditorPanel({ inputs, onChange, result }: Props) {
   const steps = activeRotation?.steps ?? []
 
   return (
-    <div className={styles.customRotationPanel}>
+    <div className={`panel ${styles.customRotationPanel}`}>
       <div className="toolbar">
         <span className="toolbar-label">{t("rotation.editor.rotationEditor")}</span>
         <Select

--- a/src/ui/features/rotation/rotation-tab/RotationTab.module.scss
+++ b/src/ui/features/rotation/rotation-tab/RotationTab.module.scss
@@ -15,12 +15,9 @@
   overscroll-behavior: contain;
 }
 
-.mainColumn {
+.outputGrid {
   flex: 1;
   min-width: 0;
-}
-
-.outputGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;

--- a/src/ui/features/rotation/rotation-tab/RotationTab.tsx
+++ b/src/ui/features/rotation/rotation-tab/RotationTab.tsx
@@ -1,9 +1,5 @@
-import { useState } from "react"
 import { useI18n } from "../../../../i18n/i18nContext"
 import type { Inputs, Result } from "../../../../engine/types"
-import { SubTabs } from "../../../components/sub-tabs/SubTabs"
-import { SubTabPanel } from "../../../components/sub-tabs/SubTabPanel"
-import { RotationEditorPanel } from "../rotation-editor-panel/RotationEditorPanel"
 import { RotationOptionsPanel } from "../rotation-options-panel/RotationOptionsPanel"
 import { RotationBreakdownPanel } from "../rotation-breakdown-panel/RotationBreakdownPanel"
 import { RotationDpsGraphPanel } from "../rotation-dps-graph-panel/RotationDpsGraphPanel"
@@ -22,7 +18,6 @@ export function RotationTab({
   result: Result
 }) {
   const { t } = useI18n()
-  const [sub, setSub] = useState<"overview" | "editor">("overview")
   return (
     <div className={styles.rotationLayout}>
       <div className={`panel ${styles.optionsPanel}`}>
@@ -34,36 +29,19 @@ export function RotationTab({
           currentDps={result.dps}
         />
       </div>
-      <div className={styles.mainColumn}>
-        <SubTabs
-          active={sub}
-          onSelect={setSub}
-          tabs={[
-            { key: "overview", label: t("common.overview") },
-            { key: "editor", label: t("rotation.rotationEditor") },
-          ]}
-        />
-        <SubTabPanel>
-          {sub === "overview" && (
-            <div className={styles.outputGrid}>
-              <div className="panel">
-                <h2>{t("rotation.dpsBreakdown")}</h2>
-                <RotationBreakdownPanel result={result} />
-              </div>
-              <div className="panel">
-                <h2>{t("rotation.dpsGraph")}</h2>
-                <RotationDpsGraphPanel result={result} />
-              </div>
-              <div className={`panel ${styles.spanColumns}`}>
-                <h2>{t("rotation.castTimeline")}</h2>
-                <RotationTimelinePanel result={result} />
-              </div>
-            </div>
-          )}
-          {sub === "editor" && (
-            <RotationEditorPanel inputs={inputs} onChange={onChange} result={result} />
-          )}
-        </SubTabPanel>
+      <div className={styles.outputGrid}>
+        <div className="panel">
+          <h2>{t("rotation.dpsBreakdown")}</h2>
+          <RotationBreakdownPanel result={result} />
+        </div>
+        <div className="panel">
+          <h2>{t("rotation.dpsGraph")}</h2>
+          <RotationDpsGraphPanel result={result} />
+        </div>
+        <div className={`panel ${styles.spanColumns}`}>
+          <h2>{t("rotation.castTimeline")}</h2>
+          <RotationTimelinePanel result={result} />
+        </div>
       </div>
     </div>
   )

--- a/tests/ui/rotationTab.test.tsx
+++ b/tests/ui/rotationTab.test.tsx
@@ -31,35 +31,22 @@ function optionButtons(): HTMLElement[] {
   return screen.getAllByRole("button").filter((button) => button.hasAttribute("aria-current"))
 }
 
-describe("RotationTab subtabs", () => {
-  it("opens on the rotation's output, not on the editor", () => {
+describe("RotationTab", () => {
+  it("shows the rotation output beside the list, with no subtab to choose", () => {
     renderTab()
 
     expect(screen.getByText("Rotations")).toBeInTheDocument()
     expect(screen.getByText("DPS Breakdown")).toBeInTheDocument()
     expect(screen.getByText("DPS Graph")).toBeInTheDocument()
     expect(screen.getByText("Cast Timeline")).toBeInTheDocument()
+    expect(screen.queryAllByRole("tab")).toHaveLength(0)
+  })
+
+  it("leaves the editor to its own tab", () => {
+    renderTab()
+
     expect(screen.queryByRole("button", { name: "+ Add skill" })).not.toBeInTheDocument()
-  })
-
-  it("shows the editor once its subtab is selected", () => {
-    renderTab()
-
-    fireEvent.click(screen.getByRole("tab", { name: "Rotation Editor" }))
-
-    expect(screen.getByRole("button", { name: "+ New" })).toBeInTheDocument()
-    expect(screen.queryByText("DPS Breakdown")).not.toBeInTheDocument()
-    expect(screen.queryByText("Cast Timeline")).not.toBeInTheDocument()
-  })
-
-  it("keeps the rotation list beside both subtabs", () => {
-    renderTab()
-    const listedOnOverview = optionButtons().length
-
-    fireEvent.click(screen.getByRole("tab", { name: "Rotation Editor" }))
-
-    expect(screen.getByText("Rotations")).toBeInTheDocument()
-    expect(optionButtons()).toHaveLength(listedOnOverview)
+    expect(screen.queryByRole("button", { name: "+ New" })).not.toBeInTheDocument()
   })
 
   it("lists every rotation the class offers and nothing else", () => {


### PR DESCRIPTION
## What

- **Rotation Editor is a top-level tab** at `/rotation-editor`, directly right of **Rotation**. The Rotation tab's subtabs are gone.
- **Rotation tab** now shows the DPS breakdown, DPS graph and cast timeline as plain cards beside the rotation list — no subtab bar, no extra wrapper.
- **Enhancement & Oddities & Talents** moved to the right end of the tab bar, with a 20px gap to **Profiles**. The gap drops below 980px, where the tab bar scrolls anyway.

## Notes

- `RotationEditorPanel` carries the `panel` surface itself now that no `SubTabPanel` sits under it.
- `tests/ui/rotationTabSubTabs.test.tsx` → `tests/ui/rotationTab.test.tsx`; the two subtab-switching cases are replaced by "shows the output without subtabs" and "leaves the editor to its own tab".
- The wiki's `How to Add a Rotation` is updated in the same piece of work (wiki commit `701a012`).
- No migration needed: no saved-profile shape, stored value or id changes — tab paths are not persisted.
